### PR TITLE
ci: bump Go version to 1.23.2

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -2,7 +2,7 @@ pvc-autoscaler:
   base_definition:
     steps:
       verify:
-        image: 'golang:1.22.2'
+        image: 'golang:1.23.2'
     traits:
       version:
         preprocess: 'inject-commit-hash'


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps the image used by the CI/CD pipeline to Go 1.23.2

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
None
```
