### PR TITLE
Bugfix: Skip expansion if Prometheus metrics are out-of date.

### DIFF
--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -13,5 +13,5 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
-        - "--interval=150s"
+        - "--interval=60s"
         - "--prometheus-address=http://prometheus-k8s.monitoring.svc.cluster.local:9090"

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -262,7 +262,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        - --interval=150s
+        - --interval=60s
         - --prometheus-address=http://prometheus-k8s.monitoring.svc.cluster.local:9090
         command:
         - /manager

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/pvc-autoscaler
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.20.2

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -37,4 +37,8 @@ const (
 	// DefaultIncreaseByValue is the default increase-by value, if not
 	// specified for a PVC object.
 	DefaultIncreaseByValue = "10%"
+
+	// ScalingResolutionBytes is the smallest possible step. Any storage request set by the autoscaler is guaranteed
+	// to be divisible by that value. ScalingResolutionBytes is guaranteed to be an even number.
+	ScalingResolutionBytes = 1024 * 1024 * 1024
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
`pvc-autoscaler` is driven by volume utilisation data from Prometheus. However, shortly after a volume was extended, it is possible for Prometheus data to be still reflecting the state before expansion, thus still suggesting that space is exhausted, and triggering another, unnecessary, expansion.

This change compares the volume capacity reported by Prometheus with the capacity in the PVC object. If a discrepancy is detected, it is taken as indication that Prometheus data is stale, and expansion is postponed.

**Release note**:
```bugfix operator
A bug, where a PVC could be subjected to excessive expansion while prometheus data lags behind actual PVC state, was fixed. 
```