### PR TITLE
Enable Static Application Security Testing (SAST)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,3 +38,4 @@ linters:
     - unconvert
     - unparam
     - unused
+    - gosec


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables Static Application Security Testing (SAST) linter via golangci-lint.

**Which issue(s) this PR fixes**:
Fixes #14 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Enable Static Application Security Testing (SAST) linter
```
