### PR TITLE
Enhancement: Add support for threshold lower bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,33 @@ Note, that specifying a max capacity is required.
 The following annotations can be configured by an operator in order to control
 the behaviour of `pvc-autoscaler`.
 
-| Annotation                                    | Description                                          | Default |
-|:----------------------------------------------|:-----------------------------------------------------|:-------:|
-| `pvc.autoscaling.gardener.cloud/is-enabled`   | Enable autoscaling when set to `true`                | N/A     |
-| `pvc.autoscaling.gardener.cloud/increase-by`  | Specifies how much to increase the PVC in percentage | `10%`   |
-| `pvc.autoscaling.gardener.cloud/threshold`    | Specify the threshold in percentage                  | `10%`   |
-| `pvc.autoscaling.gardener.cloud/max-capacity` | Max capacity up to which a PVC can be resized        | N/A     |
+| Annotation                                       | Description                                            | Default |
+|:-------------------------------------------------|:-------------------------------------------------------|:-------:|
+| `pvc.autoscaling.gardener.cloud/is-enabled`      | Enable autoscaling when set to `true`                  |   N/A   |
+| `pvc.autoscaling.gardener.cloud/increase-by`     | Specifies how much to increase the PVC in percentage   |  `10%`  |
+| `pvc.autoscaling.gardener.cloud/threshold`       | Specify the threshold in percentage                    |  `10%`  |
+| `pvc.autoscaling.gardener.cloud/min-threshold`   | Specify the minimum threshold in bytes <sup>[1]</sup>  |   N/A   |
+| `pvc.autoscaling.gardener.cloud/max-capacity`    | Max capacity up to which a PVC can be resized          |   N/A   |
+
+**Notes:**
+
+[1]:
+If both `threshold` and `min-threshold` are specified, a resize is
+initiated if any of the thresholds is reached.
+  
+When scaling is initiated based on `min-threshold`, the increment
+(see `increase-by`) is calculated by a different formula:
+```
+Increment = (IncreaseBy / Threshold) * MinThreshold
+```
+With this formula, a scaling event based on `min-threshold` actually
+results in the same increment, as would be suggested by the pair of
+relative `threshold` and `increase-by` parameters, at the capacity point
+where the absolute value derived from `threshold` would equal
+`min-threshold`.
+  
+In contrast to `threshold`, `min-threshold` only applies to free
+space, not to inodes.
 
 The following additional annotations are populated by the controller, which
 provide information about the latest observed state for a PVC.

--- a/internal/annotation/annotation.go
+++ b/internal/annotation/annotation.go
@@ -22,7 +22,35 @@ const (
 	// capacity (free space) for the PVC reaches or drops below the
 	// specified threshold this will trigger a resize operation by the
 	// controller.
+	//
+	// If Threshold and MinThreshold are both specified, a resize is
+	// initiated when any of the thresholds is reached.
 	Threshold = Prefix + "threshold"
+
+	// MinThreshold is an annotation which is applied to a PVC, and
+	// specifies the scaling trigger threshold for the PVC's free space in
+	// absolute terms (e.g. 1Gi, 600Mi, etc.).
+	// Once the available capacity (free space) for the PVC drops below the
+	// level specified by the annotation, the controller will respond by
+	// resizing the PVC.
+	//
+	// If both Threshold and MinThreshold are specified, a resize is
+	// initiated if any of the thresholds is reached.
+	//
+	// When scaling is initiated based on MinThreshold, the increment
+	// (see IncreaseBy) is calculated by a different formula:
+	//
+	// Increment = (IncreaseBy / Threshold) * MinThreshold
+	//
+	// With this formula, a scaling event based on MinThreshold actually
+	// results in the same increment, as would be suggested by the pair of
+	// relative Threshold and IncreaseBy parameters, at the capacity point
+	// where the absolute value derived from Threshold would equal
+	// MinThreshold.
+	//
+	// Note: In contrast to Threshold, MinThreshold only applies to free
+	// space, not to inodes.
+	MinThreshold = Prefix + "min-threshold"
 
 	// MaxCapacity is an annotation which specifies the maximum capacity up
 	// to which a PVC is allowed to be extended. The max capacity is

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package controller_test
+package controller
 
 import (
 	"context"


### PR DESCRIPTION
**What this PR does / why we need it**:
Threshold scales proportionally to PVC capacity. With small volumes, a reasonable threshold percentage can turn into an absolute value too small to accommodate the workload's occasional storage allocation bursts.  This enhancement adds support for a new, optional parameter (PVC anotation) - an absolute lower bound for threshold.  

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Support was added for a new scaling parameter (PVC annotation): `pvc.autoscaling.gardener.cloud/min-threshold`.
```
