### PR TITLE
Add kind local setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,14 +101,14 @@ kind-up:
 kind-down: 
 	kind delete cluster --name pvc-autoscaler
 
-.PHONY: pvc-autoscaler-up
-pvc-autoscaler-up:
+.PHONY: kind-pvc-autoscaler-up
+kind-pvc-autoscaler-up:
 	./hack/pvc-autoscaler-up.sh \
 	--with-lpp-resize-support $(DEV_SETUP_WITH_LPP_RESIZE_SUPPORT)
 	skaffold run 
 
-.PHONY: pvc-autoscaler-dev
-pvc-autoscaler-dev:
+.PHONY: kind-pvc-autoscaler-dev
+kind-pvc-autoscaler-dev:
 	./hack/pvc-autoscaler-up.sh \
 	--with-lpp-resize-support $(DEV_SETUP_WITH_LPP_RESIZE_SUPPORT) 
 	skaffold dev

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,14 @@ lint: golangci-lint  ## Run golangci-lint linter & yamllint
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(GOLANGCI_LINT) run --fix
 
+.PHONY: kind-up
+kind-up: 
+	kind create cluster --name pvc-autoscaler
+
+.PHONY: kind-down
+kind-down: 
+	kind delete cluster --name pvc-autoscaler
+
 .PHONY: minikube-start
 minikube-start: minikube yq  ## Start a local dev environment
 	env MINIKUBE_PROFILE=$(MINIKUBE_PROFILE) ./hack/minikube-start.sh

--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ $(KIND): $(call gen-tool-version,$(KIND),$(KIND_VERSION))
 	$(call download-tool,kind,https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-$(GOOS)-$(GOARCH))
 
 .PHONY: skaffold
-skaffold: $(SKAFFOLD) | $(LOCALBIN)  ## Download kind locally if necessary.
+skaffold: $(SKAFFOLD) | $(LOCALBIN)  ## Download skaffold locally if necessary.
 $(SKAFFOLD): $(call gen-tool-version,$(SKAFFOLD),$(SKAFFOLD_VERSION))
 		$(call download-tool,skaffold,https://storage.googleapis.com/skaffold/releases/$(SKAFFOLD_VERSION)/skaffold-$(GOOS)-$(GOARCH))
 

--- a/Makefile
+++ b/Makefile
@@ -99,20 +99,20 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(GOLANGCI_LINT) run --fix
 
 .PHONY: kind-up
-kind-up: kind skaffold kustomize kubectl
+kind-up: kind kustomize kubectl
 	./hack/kind-up.sh \
 	--with-lpp-resize-support $(DEV_SETUP_WITH_LPP_RESIZE_SUPPORT) \
 
 .PHONY: kind-down
-kind-down: kind skaffold kustomize kubectl
+kind-down: kind
 	$(KIND) delete cluster --name pvc-autoscaler
 
 .PHONY: pvc-autoscaler-up
-pvc-autoscaler-up: kind skaffold kustomize kubectl
+pvc-autoscaler-up: skaffold kustomize kubectl
 	$(SKAFFOLD) run 
 
 .PHONY: pvc-autoscaler-dev
-pvc-autoscaler-dev: kind skaffold kustomize kubectl
+pvc-autoscaler-dev: skaffold kustomize kubectl
 	$(SKAFFOLD) dev
 
 .PHONY: minikube-start

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ CONTAINER_TOOL ?= docker
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-DEV_SETUP_WITH_LPP_RESIZE_SUPPORT ?= false
+DEV_SETUP_WITH_LPP_RESIZE_SUPPORT ?= true
 
 .PHONY: all
 all: build

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ CONTAINER_TOOL ?= docker
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+DEV_SETUP_WITH_LPP_RESIZE_SUPPORT ?= false
+
 .PHONY: all
 all: build
 
@@ -98,6 +100,18 @@ kind-up:
 .PHONY: kind-down
 kind-down: 
 	kind delete cluster --name pvc-autoscaler
+
+.PHONY: pvc-autoscaler-up
+pvc-autoscaler-up:
+	./hack/pvc-autoscaler-up.sh \
+	--with-lpp-resize-support $(DEV_SETUP_WITH_LPP_RESIZE_SUPPORT)
+	skaffold run 
+
+.PHONY: pvc-autoscaler-dev
+pvc-autoscaler-dev:
+	./hack/pvc-autoscaler-up.sh \
+	--with-lpp-resize-support $(DEV_SETUP_WITH_LPP_RESIZE_SUPPORT) 
+	skaffold dev
 
 .PHONY: minikube-start
 minikube-start: minikube yq  ## Start a local dev environment

--- a/README.md
+++ b/README.md
@@ -171,13 +171,13 @@ make kind-up
 You can also deploy the `pvc-autoscaler` in the kind cluster via this command.
 
 ```shell
-make kind-pvc-autoscaler-up
+make pvc-autoscaler-up
 ```
 
 If you want automatic deploy on change in code, you can use this command.
 
 ```shell
-make kind-pvc-autoscaler-dev
+make pvc-autoscaler-dev
 ```
 
 When you're done with development, you can safely run the following command.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,30 @@ executing this command.
 make help
 ```
 
+The local setup also supports Kind Kubernetes clusters. For convenience you can create a dev Kind cluster by using the following command.
+
+```shell
+make kind-up
+```
+
+You can also deploy the `pvc-autoscaler` in the kind cluster via this command.
+
+```shell
+make kind-pvc-autoscaler-up
+```
+
+If you want automatic deploy on change in code, you can use this command.
+
+```shell
+make kind-pvc-autoscaler-dev
+```
+
+When you're done with development, you can safely run the following command.
+
+```shell
+make kind-down
+```
+
 # Tests
 
 Run the unit tests.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patches:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -14,4 +14,4 @@ spec:
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
         - "--interval=30s"
-        - "--prometheus-address=http://prometheus-k8s.monitoring.svc.cluster.local:9090"
+        - "--prometheus-address=http://kind-prometheus-kube-prome-prometheus.monitoring.svc.cluster.local:9090"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,7 +1,9 @@
-resources:
-- manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+resources:
+- manager.yaml
+
 images:
 - name: controller
   newName: pvc-autoscaler-local

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: pvc-autoscaler-local
+  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -66,9 +66,7 @@ spec:
         # seccompProfile:
         #   type: RuntimeDefault
       containers:
-      - command:
-        - /manager
-        args:
+      - args:
         - --leader-elect
         image: controller:latest
         name: manager

--- a/example/kind/local/.gitignore
+++ b/example/kind/local/.gitignore
@@ -1,0 +1,1 @@
+kubeconfig

--- a/hack/pvc-autoscaler-up.sh
+++ b/hack/pvc-autoscaler-up.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+WITH_LPP_RESIZE_SUPPORT=${WITH_LPP_RESIZE_SUPPORT:-false}
+
+# if [ ! -d "kube-prometheus" ]; then 
+#     echo "Cloning kube-prometheus..."; 
+#     git clone --depth 1 https://github.com/prometheus-operator/kube-prometheus.git;
+# else 
+#     echo "kube-prometheus already exists";
+# fi
+
+
+parse_flags() {
+  while test $# -gt 0; do
+    case "$1" in
+    --with-lpp-resize-support)
+      shift
+      WITH_LPP_RESIZE_SUPPORT="${1}"
+      ;;
+    esac
+
+    shift
+  done
+}
+
+kubectl patch storageclass standard -p '{"allowVolumeExpansion": true}'
+
+nodes=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}')
+
+# setup_containerd_registry_mirrors sets up all containerd registry mirrors.
+# Resources:
+# - https://github.com/containerd/containerd/blob/main/docs/hosts.md
+# - https://kind.sigs.k8s.io/docs/user/local-registry/
+setup_containerd_registry_mirrors() {
+  NODES=("$@")
+  REGISTRY_HOSTNAME="garden.local.gardener.cloud"
+
+  for NODE in "${NODES[@]}"; do
+    setup_containerd_registry_mirror $NODE "gcr.io" "https://gcr.io" "http://${REGISTRY_HOSTNAME}:5003"
+    setup_containerd_registry_mirror $NODE "registry.k8s.io" "https://registry.k8s.io" "http://${REGISTRY_HOSTNAME}:5006"
+    setup_containerd_registry_mirror $NODE "quay.io" "https://quay.io" "http://${REGISTRY_HOSTNAME}:5007"
+    setup_containerd_registry_mirror $NODE "europe-docker.pkg.dev" "https://europe-docker.pkg.dev" "http://${REGISTRY_HOSTNAME}:5008"
+    setup_containerd_registry_mirror $NODE "garden.local.gardener.cloud:5001" "http://garden.local.gardener.cloud:5001" "http://${REGISTRY_HOSTNAME}:5001"
+  done
+}
+
+# setup_containerd_registry_mirror sets up a given contained registry mirror.
+setup_containerd_registry_mirror() {
+  NODE=$1
+  UPSTREAM_HOST=$2
+  UPSTREAM_SERVER=$3
+  MIRROR_HOST=$4
+
+  echo "[${NODE}] Setting up containerd registry mirror for host ${UPSTREAM_HOST}.";
+  REGISTRY_DIR="/etc/containerd/certs.d/${UPSTREAM_HOST}"
+  docker exec "${NODE}" mkdir -p "${REGISTRY_DIR}"
+  cat <<EOF | docker exec -i "${NODE}" cp /dev/stdin "${REGISTRY_DIR}/hosts.toml"
+server = "${UPSTREAM_SERVER}"
+
+[host."${MIRROR_HOST}"]
+  capabilities = ["pull", "resolve"]
+EOF
+}
+
+setup_containerd_registry_mirrors $nodes
+
+# The default StorageClass which comes with `kind' is configured to use
+# rancher.io/local-path (see [1]) provisioner, which defaults to `hostPath'
+# volume (see [2]).  However, `hostPath' does not expose any metrics via
+# kubelet, while `local' (see [3]) does. On the other hand `kind' does not
+# expose any mechanism for configuring the StorageClass it comes with (see [4]).
+#
+# This function annotates the default StorageClass with `defaultVolumeType: local',
+# so that we can later scrape the various `kubelet_volume_stats_*' metrics
+# exposed by kubelet (see [5]).
+#
+# References:
+#
+# [1]: https://github.com/rancher/local-path-provisioner
+# [2]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+# [3]: https://kubernetes.io/docs/concepts/storage/volumes/#local
+# [4]: https://github.com/kubernetes-sigs/kind/blob/main/pkg/cluster/internal/create/actions/installstorage/storage.go
+# [5]: https://kubernetes.io/docs/reference/instrumentation/metrics/
+setup_kind_sc_default_volume_type() {
+  echo "Configuring default StorageClass for kind cluster ..."
+  kubectl annotate storageclass standard defaultVolumeType=local
+}
+
+# The rancher.io/local-path provisioner at the moment does not support volume
+# resizing (see [1]). There is an open PR, which is scheduled for the next
+# release around May, 2024 (see [2]). Until [2] is merged we will use a custom
+# local-path provisioner with support for volume resizing.
+#
+# This function should be called after setting up the containerd registries on
+# the kind nodes.
+#
+# References:
+#
+# [1]: https://github.com/rancher/local-path-provisioner
+# [2]: https://github.com/rancher/local-path-provisioner/pull/350
+#
+# TODO(dnaeon): remove this once we have [2] merged into upstream
+setup_kind_with_lpp_resize_support() {
+  if [ "${WITH_LPP_RESIZE_SUPPORT}" != "true" ]; then
+    return
+  fi
+
+  echo "Configuring kind local-path provisioner with volume resize support ..."
+
+  # First configure allowVolumeExpansion on the default StorageClass
+  kubectl patch storageclass standard --patch '{"allowVolumeExpansion": true}'
+
+  # Apply the latest manifests and use our own image
+  local _image="ghcr.io/ialidzhikov/local-path-provisioner:feature-external-resizer-c0c1c13"
+  local _lpp_repo="https://github.com/marjus45/local-path-provisioner"
+  local _lpp_branch="feature-external-resizer"
+  local _timeout="90"
+
+  kustomize build "${_lpp_repo}/deploy/?ref=${_lpp_branch}&timeout=${_timeout}" | \
+    sed -e "s|image: rancher/local-path-provisioner:master-head|image: ${_image}|g" | \
+    kubectl apply -f -
+
+  # The default manifests from rancher/local-path come with another
+  # StorageClass, which we don't need, so make sure to remove it.
+  kubectl delete --ignore-not-found=true storageclass local-path
+}
+
+setup_kind_sc_default_volume_type
+setup_kind_with_lpp_resize_support

--- a/hack/pvc-autoscaler-up.sh
+++ b/hack/pvc-autoscaler-up.sh
@@ -10,14 +10,6 @@ set -o pipefail
 
 WITH_LPP_RESIZE_SUPPORT=${WITH_LPP_RESIZE_SUPPORT:-false}
 
-# if [ ! -d "kube-prometheus" ]; then 
-#     echo "Cloning kube-prometheus..."; 
-#     git clone --depth 1 https://github.com/prometheus-operator/kube-prometheus.git;
-# else 
-#     echo "kube-prometheus already exists";
-# fi
-
-
 parse_flags() {
   while test $# -gt 0; do
     case "$1" in

--- a/hack/pvc-autoscaler-up.sh
+++ b/hack/pvc-autoscaler-up.sh
@@ -8,7 +8,7 @@ set -o nounset
 set -o pipefail
 
 
-WITH_LPP_RESIZE_SUPPORT=${WITH_LPP_RESIZE_SUPPORT:-false}
+WITH_LPP_RESIZE_SUPPORT=${WITH_LPP_RESIZE_SUPPORT:-true}
 
 parse_flags() {
   while test $# -gt 0; do
@@ -99,7 +99,7 @@ setup_kind_sc_default_volume_type() {
 # [1]: https://github.com/rancher/local-path-provisioner
 # [2]: https://github.com/rancher/local-path-provisioner/pull/350
 #
-# TODO(dnaeon): remove this once we have [2] merged into upstream
+# TODO(RadaBDimitrova): remove this once we have [2] merged into upstream
 setup_kind_with_lpp_resize_support() {
   if [ "${WITH_LPP_RESIZE_SUPPORT}" != "true" ]; then
     return

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -2,7 +2,6 @@ apiVersion: skaffold/v4beta12
 kind: Config
 metadata:
   name: pvc-autoscaler
-
 build:
   artifacts:
     - image: pvc-autoscaler-local
@@ -14,12 +13,10 @@ build:
             - go.sum              # Go module checksums
             - config/**           # Kustomize configurations
         main: ./cmd
-
 manifests:
   kustomize:
     paths: 
       - config/default
-
 deploy:
   helm:
     releases:
@@ -36,7 +33,6 @@ deploy:
         remoteChart: kube-prometheus-stack
         namespace: monitoring
         createNamespace: true
-
   kubectl:
     flags:
       apply:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -36,15 +36,6 @@ deploy:
         remoteChart: kube-prometheus-stack
         namespace: monitoring
         createNamespace: true
-        setValues:
-          prometheus.service.nodePort: "30000"
-          prometheus.service.type: "NodePort"
-          grafana.service.nodePort: "31000"
-          grafana.service.type: "NodePort"
-          alertmanager.service.nodePort: "32000"
-          alertmanager.service.type: "NodePort"
-          prometheus-node-exporter.service.nodePort: "32001"
-          prometheus-node-exporter.service.type: "NodePort"
 
   kubectl:
     flags:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,77 @@
+apiVersion: skaffold/v4beta12
+kind: Config
+metadata:
+  name: pvc-autoscaler
+
+build:
+  artifacts:
+    - image: pvc-autoscaler-local
+      ko:
+        dependencies:
+          paths:
+            - cmd
+            - dist
+            - config
+            - config/webhook
+            - config/rbac
+            - config/network-policy
+            - config/crd
+            - config/crd/patches
+            - config/crd/bases
+            - config/default
+            - config/samples
+            - config/manager
+            - config/certmanager
+            - config/prometheus
+            - internal
+            - internal/metrics
+            - internal/metrics/source
+            - internal/metrics/source/prometheus
+            - internal/metrics/source/fake
+            - internal/periodic
+            - internal/utils
+            - internal/controller
+            - internal/controller/autoscaling
+            - internal/common
+            - hack
+            - api
+            - api/autoscaling
+            - api/autoscaling/v1alpha1
+        main: ./cmd
+
+manifests:
+  kustomize:
+    paths: 
+      - config/default
+
+deploy:
+  helm:
+    releases:
+      - name: cert-manager
+        repo: https://charts.jetstack.io
+        remoteChart: cert-manager
+        version: v1.16.1
+        namespace: cert-manager
+        createNamespace: true
+        setValues:
+          crds.enabled: "true"
+      - name: kind-prometheus
+        repo: https://prometheus-community.github.io/helm-charts
+        remoteChart: kube-prometheus-stack
+        namespace: monitoring
+        createNamespace: true
+        setValues:
+          prometheus.service.nodePort: "30000"
+          prometheus.service.type: "NodePort"
+          grafana.service.nodePort: "31000"
+          grafana.service.type: "NodePort"
+          alertmanager.service.nodePort: "32000"
+          alertmanager.service.type: "NodePort"
+          prometheus-node-exporter.service.nodePort: "32001"
+          prometheus-node-exporter.service.type: "NodePort"
+
+  kubectl:
+    flags:
+      apply:
+        - --server-side
+        - --force-conflicts

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -9,34 +9,10 @@ build:
       ko:
         dependencies:
           paths:
-            - cmd
-            - dist
-            - config
-            - config/webhook
-            - config/rbac
-            - config/network-policy
-            - config/crd
-            - config/crd/patches
-            - config/crd/bases
-            - config/default
-            - config/samples
-            - config/manager
-            - config/certmanager
-            - config/prometheus
-            - internal
-            - internal/metrics
-            - internal/metrics/source
-            - internal/metrics/source/prometheus
-            - internal/metrics/source/fake
-            - internal/periodic
-            - internal/utils
-            - internal/controller
-            - internal/controller/autoscaling
-            - internal/common
-            - hack
-            - api
-            - api/autoscaling
-            - api/autoscaling/v1alpha1
+            - "**/*.go"           # All Go source files
+            - go.mod              # Go module definition
+            - go.sum              # Go module checksums
+            - config/**           # Kustomize configurations
         main: ./cmd
 
 manifests:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the option to run a kind setup for local development via skaffold and kustomize.
It adds the targets `make kind-{up,down}` which create/tear down a kind cluster. It also adds `make pvc-autoscaler-up` for a one time deploy of the pvc-autoscaler and other needed components, such as prometheus and cert manager, in the cluster and `make pvc-autoscaler-dev` for a trigger-based redeploy by skaffold on change.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This PR will be followed by a PR to introduce fake metrics for better local development.
Additional note: maybe the make targets could use variables for calling binaries.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
New make targets `make kind-{up,down}` to create/tear down cluster and `make pvc-autoscaler-{up,dev}` deploy pvc-autoscaler and relevant components.
```
