### PR TITLE
Add fake metrics server

### DIFF
--- a/config/prometheus/fake.yaml
+++ b/config/prometheus/fake.yaml
@@ -1,0 +1,106 @@
+# Minimal nginx-based fake metrics server for testing PVC autoscaler
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minimal-fake-metrics-server
+  namespace: monitoring
+  labels:
+    app: minimal-fake-metrics-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minimal-fake-metrics-server
+  template:
+    metadata:
+      labels:
+        app: minimal-fake-metrics-server
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        ports:
+        - containerPort: 8080
+          name: metrics
+        volumeMounts:
+        - name: config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+        - name: config
+          mountPath: /etc/nginx/metrics.txt
+          subPath: metrics.txt
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+            cpu: "50m"
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+      volumes:
+      - name: config
+        configMap:
+          name: minimal-fake-metrics-config
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minimal-fake-metrics-server
+  namespace: monitoring
+  annotations:
+    networking.resources.monitoringer.cloud/from-all-seed-scrape-targets-allowed-ports: '[{"protocol":"TCP","port":8080}]'
+  labels:
+    app: minimal-fake-metrics-server
+spec:
+  selector:
+    app: minimal-fake-metrics-server
+  ports:
+  - port: 8080
+    targetPort: 8080
+    name: metrics
+  type: ClusterIP
+
+---
+# ServiceMonitor for minimal fake nginx metrics server
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: minimal-fake-metrics-server
+  namespace: monitoring
+  labels:
+    release: kind-prometheus
+    app: minimal-fake-metrics-server
+spec:
+  selector:
+    matchLabels:
+      app: minimal-fake-metrics-server
+  endpoints:
+  - port: metrics
+    path: /metrics
+    interval: 30s
+    scrapeTimeout: 30s
+    honorLabels: false
+    metricRelabelings:
+    - sourceLabels: [__name__]
+      regex: kubelet_volume_stats_.*
+      action: keep
+    - sourceLabels: [type]
+      regex: fake
+      action: keep
+    relabelings:
+    - targetLabel: instance
+      replacement: fake-metrics-server
+    - targetLabel: job
+      replacement: fake-kubelet-metrics

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,9 @@
+configMapGenerator:
+- name: minimal-fake-metrics-config
+  files:
+  - nginx.conf
+  - metrics.txt
+
 resources:
+- fake.yaml
 - monitor.yaml

--- a/config/prometheus/metrics.txt
+++ b/config/prometheus/metrics.txt
@@ -1,0 +1,23 @@
+# HELP kubelet_volume_stats_available_bytes Fake available bytes in volumes
+# TYPE kubelet_volume_stats_available_bytes gauge
+kubelet_volume_stats_available_bytes{namespace="monitoring",persistentvolumeclaim="vali-vali-0",type="fake"} 1073741824
+kubelet_volume_stats_available_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="vali-vali-0-test-sts-0",type="fake"} 1073741824
+kubelet_volume_stats_available_bytes{namespace="default",persistentvolumeclaim="test-pvc-2",type="fake"} 4294967296
+
+# HELP kubelet_volume_stats_capacity_bytes Fake capacity bytes of volumes
+# TYPE kubelet_volume_stats_capacity_bytes gauge
+kubelet_volume_stats_capacity_bytes{namespace="monitoring",persistentvolumeclaim="vali-vali-0",type="fake"} 107374182400
+kubelet_volume_stats_capacity_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="vali-vali-0-test-sts-0",type="fake"} 107374182400
+kubelet_volume_stats_capacity_bytes{namespace="default",persistentvolumeclaim="test-pvc-2",type="fake"} 53687091200
+
+# HELP kubelet_volume_stats_inodes_free Fake free inodes in volumes
+# TYPE kubelet_volume_stats_inodes_free gauge
+kubelet_volume_stats_inodes_free{namespace="monitoring",persistentvolumeclaim="vali-vali-0",type="fake"} 65536
+kubelet_volume_stats_inodes_free{namespace="pvc-autoscaler-system",persistentvolumeclaim="vali-vali-0-test-sts-0",type="fake"} 65536
+kubelet_volume_stats_inodes_free{namespace="default",persistentvolumeclaim="test-pvc-2",type="fake"} 262144
+
+# HELP kubelet_volume_stats_inodes Fake total inodes in volumes
+# TYPE kubelet_volume_stats_inodes gauge
+kubelet_volume_stats_inodes{namespace="monitoring",persistentvolumeclaim="vali-vali-0",type="fake"} 655360
+kubelet_volume_stats_inodes{namespace="pvc-autoscaler-system",persistentvolumeclaim="vali-vali-0-test-sts-0",type="fake"} 655360
+kubelet_volume_stats_inodes{namespace="default",persistentvolumeclaim="test-pvc-2",type="fake"} 327680

--- a/config/prometheus/nginx.conf
+++ b/config/prometheus/nginx.conf
@@ -1,0 +1,21 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen 8080;
+        
+        # Serve static fake Prometheus metrics from file
+        location /metrics {
+            add_header Content-Type text/plain;
+            alias /etc/nginx/metrics.txt;
+        }
+        
+        # Health check endpoint
+        location /health {
+            add_header Content-Type text/plain;
+            return 200 'OK';
+        }
+    }
+}

--- a/example/kind/example-pod-with-pvc.yaml
+++ b/example/kind/example-pod-with-pvc.yaml
@@ -1,0 +1,63 @@
+---
+# Example PersistentVolumeClaim
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vali-vali-0
+  namespace: pvc-autoscaler-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 100Gi
+
+---
+# Example Pod that uses the PVC
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy-pod
+  namespace: pvc-autoscaler-system
+  labels:
+    app: dummy-app
+spec:
+  containers:
+  - name: dummy-container
+    image: busybox:1.35
+    command:
+    - sleep
+    - "3600"
+    volumeMounts:
+    - name: data-volume
+      mountPath: /data
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+  volumes:
+  - name: data-volume
+    persistentVolumeClaim:
+      claimName: vali-vali-0
+  restartPolicy: Always
+
+---
+# Example PersistentVolumeClaimAutoscaler for the PVC
+apiVersion: autoscaling.gardener.cloud/v1alpha1
+kind: PersistentVolumeClaimAutoscaler
+metadata:
+  name: dummy-storage-pvca
+  namespace: pvc-autoscaler-system
+  labels:
+    app: dummy-app
+    pvc: dummy-storage
+spec:
+  scaleTargetRef:
+    name: vali-vali-0
+  threshold: "20%"      # Trigger scaling when free space < 20%
+  increaseBy: "10%"     # Increase capacity by 10%
+  maxCapacity: 200Gi      # Maximum allowed size


### PR DESCRIPTION
**What this PR does / why we need it**:
In a `kind` setup with local-path-provisioner, the metrics `kubelet_volume_stats_*` don't show the correct usage - they [return the same numbers for every volume when they are on the same filesystem](https://github.com/rancher/local-path-provisioner/issues/44#issuecomment-991156130).

This PR adds a minimal fake metrics server that can be used in local development. While using `pvc-autoscaler-dev`, if needed, you can modify `config/prometheus/metrics.txt` and that will update the metrics served by the nginx fake metrics server.

The PR also introduces an example pod + PVC + PVCA setup that can be used with the default fake metrics for testing purposes during development.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
> [!NOTE] 
> While testing, we realized that K8s v1.34 introduced a regression that made [kubelet_volume_stats_* metrics unavailable](https://github.com/kubernetes/kubernetes/issues/133847). This will be tackled in a follow-up PR.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
There are now fake `kubelet_volume_stats_*` metrics available for use in local development. They can be modified via `config/prometheus/metrics.txt` during the run of `pvc-autoscaler-dev`.
```
