### PR TITLE
Use common `make generate` targets and drop `make vet` and `make fmt`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ ci-e2e-kind:
 	./hack/ci-e2e-kind.sh
 
 .PHONY: test-cov
-test-cov: manifests generate fmt vet envtest
+test-cov: generate envtest
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 		./hack/test-cover.sh ./cmd/... ./internal/... ./api/...
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
This PR changes the make targets. The goal is for the make targets to be like the other gardener repos

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
