### PR TITLE
[Flake] Increase fake metrics instance timeout

### DIFF
--- a/internal/metrics/source/fake/fake_test.go
+++ b/internal/metrics/source/fake/fake_test.go
@@ -97,6 +97,8 @@ var _ = Describe("Fake", func() {
 			// Start the fake source and give it some time to
 			// consume it all
 			go func() {
+				// Every 10 milliseconds 1 percent is consumed and we expect after 1 second 100 percent to be consumed.
+				// But there might be some delays so we might need a bit more time.
 				ch := time.After(2 * time.Second)
 				<-ch
 				cancelFunc()


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area testing
/kind flake

**What this PR does / why we need it**:
As every 10 milliseconds 1 percentage is consumed we expect 100 percents to be consumed after 1 sec. The issue is caused by a small lag in consumption. So small that only 1 percent remain not consumed. Therefore increasing timeout from 1 to 2 sec should be enough to cover this failed 1 percentage

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/pvc-autoscaler/issues/112

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
