### PR TITLE
Use debian 13 (trixie) distroless image as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static-debian13:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/area quality

 **What this PR does / why we need it**:
 There is a [debian 13 distroless](https://github.com/GoogleContainerTools/distroless#debian-13) image available. This update has been done to other repos, such as [gardener-extension-registry-cache](https://github.com/gardener/gardener-extension-registry-cache/pull/505) and [gardener-extension-shoot-rsyslog-relp](https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/354), as well as [gardener/gardener](https://github.com/gardener/gardener/pull/13660). Keeping up with the versions is a step towards unification of work in this and other repos in the organization.
 
 **Which issue(s) this PR fixes**: 
N/A
 
 **Special notes for your reviewer**: 
N/A 

 **Release note**:
 ```other developer
 The base image of pvc-autoscaler components is updated to `gcr.io/distroless/static-debian13:nonroot`.
 ```