### PR TITLE
[FLAKE] Fix e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,15 +121,15 @@ kind-down: kind
 	$(KIND) delete cluster --name pvc-autoscaler
 
 .PHONY: pvc-autoscaler-up
-pvc-autoscaler-up: skaffold kustomize kubectl
+pvc-autoscaler-up: skaffold kustomize kubectl helm
 	$(SKAFFOLD) run 
 
 .PHONY: pvc-autoscaler-dev
-pvc-autoscaler-dev: skaffold kustomize kubectl
+pvc-autoscaler-dev: skaffold kustomize kubectl helm
 	$(SKAFFOLD) dev
 
 .PHONY: pvc-autoscaler-down
-pvc-autoscaler-down: skaffold kustomize kubectl
+pvc-autoscaler-down: skaffold kustomize kubectl helm
 	$(SKAFFOLD) delete
 
 .PHONY: minikube-start

--- a/Makefile
+++ b/Makefile
@@ -121,15 +121,15 @@ kind-down: kind
 	$(KIND) delete cluster --name pvc-autoscaler
 
 .PHONY: pvc-autoscaler-up
-pvc-autoscaler-up: skaffold kustomize kubectl helm
+pvc-autoscaler-up: skaffold kustomize kubectl helm yq
 	$(SKAFFOLD) run 
 
 .PHONY: pvc-autoscaler-dev
-pvc-autoscaler-dev: skaffold kustomize kubectl helm
+pvc-autoscaler-dev: skaffold kustomize kubectl helm yq
 	$(SKAFFOLD) dev
 
 .PHONY: pvc-autoscaler-down
-pvc-autoscaler-down: skaffold kustomize kubectl helm
+pvc-autoscaler-down: skaffold kustomize kubectl helm yq
 	$(SKAFFOLD) delete
 
 .PHONY: minikube-start

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ KINDEST_NODE_IAMGE_TAG		      ?= v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a
 
 ## Rules
 kind-up kind-down pvc-autoscaler-up pvc-autoscaler-dev test-e2e-local ci-e2e-kind: export KUBECONFIG = $(KIND_KUBECONFIG)
-ci-e2e-kind: export ARTIFACTS=/tmp/artifacts
+ci-e2e-kind: export ARTIFACTS ?= /tmp/artifacts
 
 .PHONY: all
 all: build

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -55,7 +55,7 @@ patches:
     group: apps
     version: v1
     kind: Deployment
-    name: pvc-autoscaler-controller-manager
+    name: controller-manager
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -176,7 +176,7 @@ export_artifacts() {
   echo "> Exporting events of kind cluster '$cluster_name' > '$ARTIFACTS/$cluster_name'"
   export_events_for_cluster "$ARTIFACTS/$cluster_name"
 
-  export_resource_yamls_for pvcas
+  export_resource_yamls_for pods pvcas
 }
 
 export_resource_yamls_for() {

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -88,6 +88,8 @@ setup_kind_with_lpp_resize_support() {
   kubectl delete --ignore-not-found=true storageclass local-path
 }
 
+parse_flags "$@"
+
 kind create cluster --name pvc-autoscaler --image "kindest/node:${KINDEST_NODE_IMAGE_TAG}"
 setup_kind_sc_default_volume_type
 setup_kind_with_lpp_resize_support


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area testing
/kind flake

**What this PR does / why we need it**:
After [enabling of e2e tests on PR level](https://github.com/gardener/ci-infra/pull/5040), on [another PR](https://github.com/gardener/pvc-autoscaler/pull/134) I saw that some binary dependencies weren't specified in every target that used the binary, so I fixed those. 

Also, @Kostov6 and I noticed a flake where sometimes the wrong metrics would be scraped, instead of the ones with the label `type="fake"`. It's now fixed by removing an unnecessary prefix.

In the process of debugging the flake we also found out that there were some missing artifacts in the prow build, so this is also fixed similarly to the solution in [`gardener-extension-rsyslog-relp`](https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/blob/4cd37bc13c9c0b72e35db5d0067af69898bc4d5d/Makefile#L31-L33). I also added the export of resource yamls for pods, since that was of great help during debugging and I think it may be useful in the future.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @Kostov6 @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
NONE
```
