### PR TITLE
Add `RecommendationAvailable` and `Resizing` status conditions

### DIFF
--- a/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
+++ b/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
@@ -137,6 +137,19 @@ type ScalingRules struct {
 	CooldownDuration *metav1.Duration `json:"cooldownDuration,omitempty"`
 }
 
+// PVCAutoscalerConditionType are the valid conditions of
+// a PersistentVolumeClaimAutoscaler.
+type PersistentVolumeClaimAutoscalerConditionType string
+
+const (
+	// ConditionTypeRecommendationAvailable represents the type of condition
+	// indicating whether metrics have been successfully fetched and computed.
+	ConditionTypeRecommendationAvailable PersistentVolumeClaimAutoscalerConditionType = "RecommendationAvailable"
+	// ConditionTypeResizing represents the type of condition indicating the
+	// status of the resize operation.
+	ConditionTypeResizing PersistentVolumeClaimAutoscalerConditionType = "Resizing"
+)
+
 // SetCondition sets the given [metav1.Condition] for the object.
 func (obj *PersistentVolumeClaimAutoscaler) SetCondition(ctx context.Context, klient client.Client, condition metav1.Condition) error {
 	patch := client.MergeFrom(obj.DeepCopy())

--- a/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
+++ b/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
@@ -162,3 +162,13 @@ func (obj *PersistentVolumeClaimAutoscaler) SetCondition(ctx context.Context, kl
 
 	return klient.Status().Patch(ctx, obj, patch)
 }
+
+// RemoveCondition removes the condition with the given type from the object.
+func (obj *PersistentVolumeClaimAutoscaler) RemoveCondition(ctx context.Context, klient client.Client, conditionType string) error {
+	patch := client.MergeFrom(obj.DeepCopy())
+	conditions := obj.Status.Conditions
+	meta.RemoveStatusCondition(&conditions, conditionType)
+	obj.Status.Conditions = conditions
+
+	return klient.Status().Patch(ctx, obj, patch)
+}

--- a/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
+++ b/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
@@ -137,7 +137,7 @@ type ScalingRules struct {
 	CooldownDuration *metav1.Duration `json:"cooldownDuration,omitempty"`
 }
 
-// PVCAutoscalerConditionType are the valid conditions of
+// PersistentVolumeClaimAutoscalerConditionType are the valid conditions of
 // a PersistentVolumeClaimAutoscaler.
 type PersistentVolumeClaimAutoscalerConditionType string
 

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -42,7 +42,7 @@ function _test_consume_space_and_resize() {
   ${_SCRIPT_DIR}/set-volume-metrics-stage.sh pod_bytes_low_1Gi
   _msg_info "waiting for PVC Autoscaler resource to become healthy ..."
   kubectl wait "pvca/${_pvca_name}" \
-          --for condition= RecommendationAvailable \
+          --for condition=RecommendationAvailable \
           --namespace "${_namespace}" \
           --timeout 10m
 
@@ -65,7 +65,7 @@ function _test_consume_space_and_resize() {
 
   _msg_info "waiting for PVC Autoscaler resource to become healthy ..."
   kubectl wait "pvca/${_pvca_name}" \
-          --for condition= RecommendationAvailable \
+          --for condition=RecommendationAvailable \
           --namespace "${_namespace}" \
           --timeout 10m
 
@@ -126,7 +126,7 @@ function _test_consume_inodes_and_resize() {
   ${_SCRIPT_DIR}/set-volume-metrics-stage.sh pod_inode_low_1Gi
   _msg_info "waiting for PVC Autoscaler resource to become healthy ..."
   kubectl wait "pvca/${_pvca_name}" \
-          --for condition= RecommendationAvailable \
+          --for condition=RecommendationAvailable \
           --namespace "${_namespace}" \
           --timeout 10m
 
@@ -150,7 +150,7 @@ function _test_consume_inodes_and_resize() {
 
   _msg_info "waiting for PVC Autoscaler resource to become healthy ..."
   kubectl wait "pvca/${_pvca_name}" \
-          --for condition= RecommendationAvailable \
+          --for condition=RecommendationAvailable \
           --namespace "${_namespace}" \
           --timeout 10m
 

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -42,7 +42,7 @@ function _test_consume_space_and_resize() {
   ${_SCRIPT_DIR}/set-volume-metrics-stage.sh pod_bytes_low_1Gi
   _msg_info "waiting for PVC Autoscaler resource to become healthy ..."
   kubectl wait "pvca/${_pvca_name}" \
-          --for condition=Healthy \
+          --for condition= RecommendationAvailable \
           --namespace "${_namespace}" \
           --timeout 10m
 
@@ -65,7 +65,7 @@ function _test_consume_space_and_resize() {
 
   _msg_info "waiting for PVC Autoscaler resource to become healthy ..."
   kubectl wait "pvca/${_pvca_name}" \
-          --for condition=Healthy \
+          --for condition= RecommendationAvailable \
           --namespace "${_namespace}" \
           --timeout 10m
 
@@ -92,7 +92,7 @@ function _test_consume_space_and_resize() {
 
   _msg_info "waiting for PVC Autoscaler resource to become unhealthy ..."
   kubectl wait "pvca/${_pvca_name}" \
-          --for condition=Healthy=false \
+          --for condition=Resizing=false \
           --namespace "${_namespace}" \
           --timeout 10m
 
@@ -126,7 +126,7 @@ function _test_consume_inodes_and_resize() {
   ${_SCRIPT_DIR}/set-volume-metrics-stage.sh pod_inode_low_1Gi
   _msg_info "waiting for PVC Autoscaler resource to become healthy ..."
   kubectl wait "pvca/${_pvca_name}" \
-          --for condition=Healthy \
+          --for condition= RecommendationAvailable \
           --namespace "${_namespace}" \
           --timeout 10m
 
@@ -150,7 +150,7 @@ function _test_consume_inodes_and_resize() {
 
   _msg_info "waiting for PVC Autoscaler resource to become healthy ..."
   kubectl wait "pvca/${_pvca_name}" \
-          --for condition=Healthy \
+          --for condition= RecommendationAvailable \
           --namespace "${_namespace}" \
           --timeout 10m
 
@@ -178,7 +178,7 @@ function _test_consume_inodes_and_resize() {
 
   _msg_info "waiting for PVC Autoscaler resource to become unhealthy ..."
   kubectl wait "pvca/${_pvca_name}" \
-          --for condition=Healthy=false \
+          --for condition=Resizing=false \
           --namespace "${_namespace}" \
           --timeout 10m
 

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -40,7 +40,7 @@ function _test_consume_space_and_resize() {
           --timeout 10m
 
   ${_SCRIPT_DIR}/set-volume-metrics-stage.sh pod_bytes_low_1Gi
-  _msg_info "waiting for PVC Autoscaler resource to become healthy ..."
+  _msg_info "waiting for PVC Autoscaler resource to have RecommendationAvailable condition ..."
   kubectl wait "pvca/${_pvca_name}" \
           --for condition=RecommendationAvailable \
           --namespace "${_namespace}" \
@@ -63,7 +63,7 @@ function _test_consume_space_and_resize() {
   _ensure_pvc_capacity "${_pvc_name}" "${_namespace}" 2Gi
   ${_SCRIPT_DIR}/set-volume-metrics-stage.sh pod_bytes_low_2Gi
 
-  _msg_info "waiting for PVC Autoscaler resource to become healthy ..."
+  _msg_info "waiting for PVC Autoscaler resource to have RecommendationAvailable condition ..."
   kubectl wait "pvca/${_pvca_name}" \
           --for condition=RecommendationAvailable \
           --namespace "${_namespace}" \
@@ -90,7 +90,7 @@ function _test_consume_space_and_resize() {
   # We should remain at 3Gi
   _ensure_pvc_capacity "${_pvc_name}" "${_namespace}" 3Gi
 
-  _msg_info "waiting for PVC Autoscaler resource to become unhealthy ..."
+  _msg_info "waiting for PVC Autoscaler resource to have false Resizing condition ..."
   kubectl wait "pvca/${_pvca_name}" \
           --for condition=Resizing=false \
           --namespace "${_namespace}" \
@@ -124,7 +124,7 @@ function _test_consume_inodes_and_resize() {
           --timeout 10m
 
   ${_SCRIPT_DIR}/set-volume-metrics-stage.sh pod_inode_low_1Gi
-  _msg_info "waiting for PVC Autoscaler resource to become healthy ..."
+  _msg_info "waiting for PVC Autoscaler resource to have RecommendationAvailable condition ..."
   kubectl wait "pvca/${_pvca_name}" \
           --for condition=RecommendationAvailable \
           --namespace "${_namespace}" \
@@ -148,7 +148,7 @@ function _test_consume_inodes_and_resize() {
   _ensure_pvc_capacity "${_pvc_name}" "${_namespace}" 2Gi
   ${_SCRIPT_DIR}/set-volume-metrics-stage.sh pod_inode_low_2Gi
 
-  _msg_info "waiting for PVC Autoscaler resource to become healthy ..."
+  _msg_info "waiting for PVC Autoscaler resource to have RecommendationAvailable condition ..."
   kubectl wait "pvca/${_pvca_name}" \
           --for condition=RecommendationAvailable \
           --namespace "${_namespace}" \
@@ -176,7 +176,7 @@ function _test_consume_inodes_and_resize() {
   # We should remain at 3Gi
   _ensure_pvc_capacity "${_pvc_name}" "${_namespace}" 3Gi
 
-  _msg_info "waiting for PVC Autoscaler resource to become unhealthy ..."
+  _msg_info "waiting for PVC Autoscaler resource to have false Resizing condition ..."
   kubectl wait "pvca/${_pvca_name}" \
           --for condition=Resizing=false \
           --namespace "${_namespace}" \

--- a/internal/controller/autoscaling/persistentvolumeclaimautoscaler_controller.go
+++ b/internal/controller/autoscaling/persistentvolumeclaimautoscaler_controller.go
@@ -38,7 +38,7 @@ var ErrNoStorageRequests = errors.New("no .spec.resources.requests.storage field
 // the .status.capacity.storage field.
 var ErrNoStorageStatus = errors.New("no .status.capacity.storage field")
 
-// Condition reason for the Resizing condition.
+// ReasonReconcile condition reason for the Resizing condition.
 const ReasonReconcile = "Reconcile"
 
 // PersistentVolumeClaimAutoscalerReconciler reconciles a
@@ -178,6 +178,7 @@ func (r *PersistentVolumeClaimAutoscalerReconciler) Reconcile(ctx context.Contex
 			if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
 				return ctrl.Result{}, err
 			}
+
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 
@@ -193,6 +194,7 @@ func (r *PersistentVolumeClaimAutoscalerReconciler) Reconcile(ctx context.Contex
 			if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
 				return ctrl.Result{}, err
 			}
+
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 
@@ -208,6 +210,7 @@ func (r *PersistentVolumeClaimAutoscalerReconciler) Reconcile(ctx context.Contex
 			if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
 				return ctrl.Result{}, err
 			}
+
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 
@@ -225,6 +228,7 @@ func (r *PersistentVolumeClaimAutoscalerReconciler) Reconcile(ctx context.Contex
 			if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
 				return ctrl.Result{}, err
 			}
+
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 

--- a/internal/controller/autoscaling/persistentvolumeclaimautoscaler_controller.go
+++ b/internal/controller/autoscaling/persistentvolumeclaimautoscaler_controller.go
@@ -186,7 +186,7 @@ func (r *PersistentVolumeClaimAutoscalerReconciler) Reconcile(ctx context.Contex
 
 	// If previously recorded size is equal to the current status it means
 	// we are still waiting for the resize to complete
-	if !pvca.Status.PrevSize.IsZero() && pvca.Status.PrevSize.Equal(*currStatusSize) {
+	if pvca.Status.PrevSize.Equal(*currStatusSize) {
 		logger.Info("persistent volume claim is still being resized")
 		condition := metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeResizing),
@@ -273,11 +273,7 @@ func (r *PersistentVolumeClaimAutoscalerReconciler) Reconcile(ctx context.Contex
 		Message: fmt.Sprintf("- %s: resizing from %s to %s due to %s", pvcObj.Name, currSpecSize.String(), newSize.String(), scalingReason),
 	}
 
-	if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, pvca.SetCondition(ctx, r.client, condition)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/autoscaling/persistentvolumeclaimautoscaler_controller_test.go
+++ b/internal/controller/autoscaling/persistentvolumeclaimautoscaler_controller_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"io"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -172,7 +171,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Controller", func() {
 			newCtx := log.IntoContext(ctx, logger)
 
 			result, err := reconciler.Reconcile(newCtx, req)
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 30 * time.Second}))
+			Expect(result).To(Equal(ctrl.Result{}))
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(buf.String()).To(ContainSubstring("resize has been started"))
@@ -250,7 +249,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Controller", func() {
 			newCtx := log.IntoContext(ctx, logger)
 
 			result, err := reconciler.Reconcile(newCtx, req)
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 30 * time.Second}))
+			Expect(result).To(Equal(ctrl.Result{}))
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(buf.String()).To(ContainSubstring("filesystem resize is pending"))
@@ -328,7 +327,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Controller", func() {
 			newCtx := log.IntoContext(ctx, logger)
 
 			result, err := reconciler.Reconcile(newCtx, req)
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 30 * time.Second}))
+			Expect(result).To(Equal(ctrl.Result{}))
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(buf.String()).To(ContainSubstring("volume is being modified"))
@@ -398,7 +397,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Controller", func() {
 			newCtx := log.IntoContext(ctx, logger)
 
 			result, err := reconciler.Reconcile(newCtx, req)
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 30 * time.Second}))
+			Expect(result).To(Equal(ctrl.Result{}))
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(buf.String()).To(ContainSubstring("persistent volume claim is still being resized"))
@@ -461,7 +460,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Controller", func() {
 			newCtx := log.IntoContext(ctx, logger)
 
 			result, err := reconciler.Reconcile(newCtx, req)
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 30 * time.Second}))
+			Expect(result).To(Equal(ctrl.Result{}))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(buf.String()).To(ContainSubstring("resizing persistent volume claim"))
 
@@ -529,7 +528,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Controller", func() {
 
 			// First resize
 			result, err := reconciler.Reconcile(newCtx, req)
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 30 * time.Second}))
+			Expect(result).To(Equal(ctrl.Result{}))
 			Expect(err).NotTo(HaveOccurred())
 
 			wantLog := `"resizing persistent volume claim","pvc":"pvc-max-capacity-reached","from":"1Gi","to":"2Gi"}`
@@ -549,7 +548,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Controller", func() {
 
 			// Reconcile for the second time
 			result, err = reconciler.Reconcile(newCtx, req)
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: 30 * time.Second}))
+			Expect(result).To(Equal(ctrl.Result{}))
 			Expect(err).NotTo(HaveOccurred())
 
 			wantLog = `"resizing persistent volume claim","pvc":"pvc-max-capacity-reached","from":"2Gi","to":"3Gi"}`

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -210,6 +210,7 @@ func (r *Runner) enqueueObjects(ctx context.Context) error {
 			if err := item.SetCondition(ctx, r.client, condition); err != nil {
 				logger.Info("failed to update status condition", "reason", err.Error())
 			}
+
 			continue
 		}
 

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gardener/pvc-autoscaler/internal/common"
 	"github.com/gardener/pvc-autoscaler/internal/metrics"
 	metricssource "github.com/gardener/pvc-autoscaler/internal/metrics/source"
-	"github.com/gardener/pvc-autoscaler/internal/utils"
 )
 
 // UnknownUtilizationValue is the value which will be used when the free
@@ -51,6 +50,14 @@ var ErrStorageClassDoesNotSupportExpansion = errors.New("storage class does not 
 // ErrNoClient is an error which is returned when the periodic [Runner] was
 // configured configured without a Kubernetes API client.
 var ErrNoClient = errors.New("no client provided")
+
+// Condition reasons for the RecommendationAvailable condition
+const (
+	// ReasonMetricsFetched indicates that metrics were successfully fetched and computed.
+	ReasonMetricsFetched = "MetricsFetched"
+	// ReasonMetricsFetchError indicates an error occurred while fetching metrics.
+	ReasonMetricsFetchError = "MetricsFetchError"
+)
 
 // Runner is a [sigs.k8s.io/controller-runtime/pkg/manager.Runnable], which
 // enqueues [v1alpha1.PersistentVolumeClaimAutoscaler] items for reconciling on
@@ -195,30 +202,29 @@ func (r *Runner) enqueueObjects(ctx context.Context) error {
 			logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
 			metrics.SkippedTotal.WithLabelValues(item.Namespace, item.Name, err.Error()).Inc()
 			condition := metav1.Condition{
-				Type:    utils.ConditionTypeHealthy,
-				Status:  metav1.ConditionUnknown,
-				Reason:  "Reconciling",
-				Message: err.Error(),
+				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+				Status:  metav1.ConditionFalse,
+				Reason:  ReasonMetricsFetchError,
+				Message: fmt.Sprintf(" - %s: %s", pvcObjKey.Name, err.Error()),
 			}
 			if err := item.SetCondition(ctx, r.client, condition); err != nil {
 				logger.Info("failed to update status condition", "reason", err.Error())
 			}
-
 			continue
 		}
 
 		if ok {
 			toReconcile = append(toReconcile, item)
-		} else {
-			condition := metav1.Condition{
-				Type:    utils.ConditionTypeHealthy,
-				Status:  metav1.ConditionTrue,
-				Reason:  "Reconciling",
-				Message: "Successfully reconciled",
-			}
-			if err := item.SetCondition(ctx, r.client, condition); err != nil {
-				logger.Info("failed to update status condition", "reason", err.Error())
-			}
+		}
+
+		condition := metav1.Condition{
+			Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+			Status:  metav1.ConditionTrue,
+			Reason:  ReasonMetricsFetched,
+			Message: fmt.Sprintf(" - %s: metrics fetched", pvcObjKey.Name),
+		}
+		if err := item.SetCondition(ctx, r.client, condition); err != nil {
+			logger.Info("failed to update status condition", "reason", err.Error())
 		}
 	}
 

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -216,6 +216,10 @@ func (r *Runner) enqueueObjects(ctx context.Context) error {
 
 		if ok {
 			toReconcile = append(toReconcile, item)
+		} else {
+			if err := item.RemoveCondition(ctx, r.client, string(v1alpha1.ConditionTypeResizing)); err != nil {
+				logger.Info("failed to remove status condition", "reason", err.Error())
+			}
 		}
 
 		condition := metav1.Condition{

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -885,6 +885,7 @@ var _ = Describe("Periodic Runner", func() {
 			for i := range updatedPVCA.Status.Conditions {
 				if updatedPVCA.Status.Conditions[i].Type == string(v1alpha1.ConditionTypeRecommendationAvailable) {
 					foundCondition = &updatedPVCA.Status.Conditions[i]
+
 					break
 				}
 			}
@@ -998,6 +999,7 @@ var _ = Describe("Periodic Runner", func() {
 			for i := range updatedPVCA.Status.Conditions {
 				if updatedPVCA.Status.Conditions[i].Type == string(v1alpha1.ConditionTypeRecommendationAvailable) {
 					foundCondition = &updatedPVCA.Status.Conditions[i]
+
 					break
 				}
 			}
@@ -1092,6 +1094,7 @@ var _ = Describe("Periodic Runner", func() {
 			for i := range updatedPVCA.Status.Conditions {
 				if updatedPVCA.Status.Conditions[i].Type == string(v1alpha1.ConditionTypeRecommendationAvailable) {
 					foundCondition = &updatedPVCA.Status.Conditions[i]
+
 					break
 				}
 			}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -12,10 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// ConditionTypeHealthy represents the type of the condition to represent
-// healthy state for the PVC Autoscaler.
-const ConditionTypeHealthy = "Healthy"
-
 // ErrBadPercentageValue is an error which is returned when attempting to parse
 // a bad percentage value.
 var ErrBadPercentageValue = errors.New("bad percentage value")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area usability
/kind api-change

**What this PR does / why we need it**:
This PR adds new more detailed condition types to the API and replaces the `Healthy` condition with the new conditions based on whether it's related to the "recommendation via metrics" or "update" part of the reconciliation flow. The new conditions are accordingly `RecommendationAvailable` and `Resizing`.

`RecommendationAvailable` indicates whether volume metrics have been successfully fetched and computed.
`Resizing` indicates the current state of PVC resize operations.
The `Resizing` condition is automatically cleared once the PVC resize operation completes, providing clear visibility into the resize lifecycle.

**Which issue(s) this PR fixes**:
Fixes #146

**Special notes for your reviewer**:
/cc @plkokanov @Kostov6 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added `RecommendationAvailable` and `Resizing` status conditions to PersistentVolumeClaimAutoscaler resources.
```
