### PR TITLE
Add `selectorfetcher.Fetcher` and `pvcfetcher.Fetcher` interfaces and corresponding implementations

### DIFF
--- a/internal/target/pvcfetcher/pvcfetcher.go
+++ b/internal/target/pvcfetcher/pvcfetcher.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pvcfetcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
+	"github.com/gardener/pvc-autoscaler/internal/target/selectorfetcher"
+)
+
+var (
+	// ErrNoClient is returned when the [Fetcher] is configured without a Kubernetes client.
+	ErrNoClient = errors.New("no client provided")
+
+	// ErrNoSelectorFetcher is returned when the [Fetcher] is configured without a selector fetcher.
+	ErrNoSelectorFetcher = errors.New("no selector fetcher provided")
+)
+
+// Fetcher is an interface that can be used to fetch all PersistentVolumeClaims
+// that are managed by a PersistentVolumeClaimAutoscaler's targetRef.
+type Fetcher interface {
+	// Fetch returns all PersistentVolumeClaims that are managed by the given PersistentVolumeClaimAutoscaler's targetRef.
+	Fetch(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler) ([]*corev1.PersistentVolumeClaim, error)
+}
+
+type pvcFetcher struct {
+	client          client.Client
+	selectorFetcher selectorfetcher.Fetcher
+}
+
+// Option is a function which configures the [Fetcher].
+type Option func(*pvcFetcher)
+
+// New creates a new PVC [Fetcher] with the given options.
+func New(opts ...Option) (Fetcher, error) {
+	f := &pvcFetcher{}
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	if f.client == nil {
+		return nil, ErrNoClient
+	}
+
+	if f.selectorFetcher == nil {
+		return nil, ErrNoSelectorFetcher
+	}
+
+	return f, nil
+}
+
+// WithClient configures the [Fetcher] with the given Kubernetes client.
+func WithClient(c client.Client) Option {
+	return func(f *pvcFetcher) {
+		f.client = c
+	}
+}
+
+// WithSelectorFetcher configures the [Fetcher] with the given fetcher.
+func WithSelectorFetcher(sf selectorfetcher.Fetcher) Option {
+	return func(f *pvcFetcher) {
+		f.selectorFetcher = sf
+	}
+}
+
+func (f *pvcFetcher) Fetch(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler) ([]*corev1.PersistentVolumeClaim, error) {
+	// For backwards compatibility handle the case where the PVCA target ref points directly to a PVC.
+	if pvca.Spec.TargetRef.Kind == "PersistentVolumeClaim" {
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvca.Spec.TargetRef.Name,
+				Namespace: pvca.Namespace,
+			},
+		}
+
+		if err := f.client.Get(ctx, client.ObjectKeyFromObject(pvc), pvc); err != nil {
+			return nil, fmt.Errorf("failed to get PersistentVolumeClaim %s under PersistentVolumeClaimAutoscaler %s: %w", client.ObjectKeyFromObject(pvc), client.ObjectKeyFromObject(pvca), err)
+		}
+
+		return []*corev1.PersistentVolumeClaim{pvc}, nil
+	}
+
+	selector, err := f.selectorFetcher.Fetch(ctx, pvca.Namespace, pvca.Spec.TargetRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch selector for target %s: %w", pvca.Spec.TargetRef.String(), err)
+	}
+
+	podList := &corev1.PodList{}
+	if err := f.client.List(ctx, podList, &client.ListOptions{LabelSelector: selector, Namespace: pvca.Namespace}); err != nil {
+		return nil, fmt.Errorf("failed to list Pods for PersistentVolumeClaimAutoscaler %s: %w", client.ObjectKeyFromObject(pvca), err)
+	}
+
+	return f.getPVCsFromPods(ctx, podList.Items, pvca)
+}
+
+func (f *pvcFetcher) getPVCsFromPods(ctx context.Context, pods []corev1.Pod, pvca *v1alpha1.PersistentVolumeClaimAutoscaler) ([]*corev1.PersistentVolumeClaim, error) {
+	// Use a map to deduplicate PVCs (multiple pods might reference the same PVC)
+	pvcMap := make(map[string]*corev1.PersistentVolumeClaim)
+
+	for _, pod := range pods {
+		for _, volume := range pod.Spec.Volumes {
+			if volume.PersistentVolumeClaim == nil {
+				continue
+			}
+
+			pvcKey := client.ObjectKey{
+				Namespace: pod.Namespace,
+				Name:      volume.PersistentVolumeClaim.ClaimName,
+			}
+
+			if _, exists := pvcMap[pvcKey.String()]; exists {
+				continue
+			}
+
+			pvc := &corev1.PersistentVolumeClaim{}
+			if err := f.client.Get(ctx, pvcKey, pvc); err != nil {
+				return nil, fmt.Errorf("failed to get PersistentVolumeClaim %s referenced by Pod %s under PersistentVolumeClaimAutoscaler %s: %w", pvcKey, client.ObjectKeyFromObject(&pod), client.ObjectKeyFromObject(pvca), err)
+			}
+
+			pvcMap[pvcKey.String()] = pvc
+		}
+	}
+
+	pvcs := make([]*corev1.PersistentVolumeClaim, 0, len(pvcMap))
+	for _, pvc := range pvcMap {
+		pvcs = append(pvcs, pvc)
+	}
+
+	return pvcs, nil
+}

--- a/internal/target/pvcfetcher/pvcfetcher.go
+++ b/internal/target/pvcfetcher/pvcfetcher.go
@@ -73,7 +73,6 @@ func WithSelectorFetcher(sf selectorfetcher.Fetcher) Option {
 }
 
 func (f *pvcFetcher) Fetch(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler) ([]*corev1.PersistentVolumeClaim, error) {
-	// For backwards compatibility handle the case where the PVCA target ref points directly to a PVC.
 	if pvca.Spec.TargetRef.Kind == "PersistentVolumeClaim" {
 		pvc := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/target/pvcfetcher/pvcfetcher_suite_test.go
+++ b/internal/target/pvcfetcher/pvcfetcher_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pvcfetcher_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPVCFetcher(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PVCFetcher Suite")
+}

--- a/internal/target/pvcfetcher/pvcfetcher_test.go
+++ b/internal/target/pvcfetcher/pvcfetcher_test.go
@@ -1,0 +1,418 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pvcfetcher_test
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
+	"github.com/gardener/pvc-autoscaler/internal/target/pvcfetcher"
+)
+
+var _ = Describe("PVCFetcher", func() {
+	var (
+		ctx context.Context
+
+		fakeClient      client.Client
+		selectorFetcher *fakeSelectorFetcher
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		scheme := runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+		selectorFetcher = &fakeSelectorFetcher{}
+	})
+
+	Describe("New", func() {
+		It("should return an error when no client is provided", func() {
+			_, err := pvcfetcher.New(
+				pvcfetcher.WithSelectorFetcher(selectorFetcher),
+			)
+			Expect(err).To(Equal(pvcfetcher.ErrNoClient))
+		})
+
+		It("should return an error when no selector fetcher is provided", func() {
+			_, err := pvcfetcher.New(
+				pvcfetcher.WithClient(fakeClient),
+			)
+			Expect(err).To(Equal(pvcfetcher.ErrNoSelectorFetcher))
+		})
+
+		It("should create a fetcher when all required options are provided", func() {
+			fetcher, err := pvcfetcher.New(
+				pvcfetcher.WithClient(fakeClient),
+				pvcfetcher.WithSelectorFetcher(selectorFetcher),
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fetcher).ToNot(BeNil())
+		})
+	})
+
+	Describe("Fetch", func() {
+		var (
+			fetcher pvcfetcher.Fetcher
+
+			pvca *v1alpha1.PersistentVolumeClaimAutoscaler
+		)
+
+		BeforeEach(func() {
+			selector, err := labels.Parse("app=test")
+			Expect(err).NotTo(HaveOccurred())
+
+			selectorFetcher.selector = selector
+
+			fetcher, err = pvcfetcher.New(
+				pvcfetcher.WithClient(fakeClient),
+				pvcfetcher.WithSelectorFetcher(selectorFetcher),
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			pvca = &v1alpha1.PersistentVolumeClaimAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pvca",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.PersistentVolumeClaimAutoscalerSpec{
+					TargetRef: autoscalingv1.CrossVersionObjectReference{
+						Kind:       "StatefulSet",
+						Name:       "test-sts",
+						APIVersion: "apps/v1",
+					},
+				},
+			}
+		})
+
+		It("should return an error when selector fetcher fails", func() {
+			selectorFetcher.err = errors.New("scale not found")
+
+			_, err := fetcher.Fetch(ctx, pvca)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to fetch selector"))
+		})
+
+		It("should return empty list when no pods match the selector", func() {
+			selectorFetcher.selector, _ = labels.Parse("app=test")
+
+			pvcs, err := fetcher.Fetch(ctx, pvca)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvcs).To(BeEmpty())
+		})
+
+		It("should return empty list when pods have no PVC volumes", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test", Image: "test"},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "test-config",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, pod)).To(Succeed())
+
+			pvcs, err := fetcher.Fetch(ctx, pvca)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvcs).To(BeEmpty())
+		})
+
+		It("should return PVCs from pods with PVC volumes", func() {
+			pod1 := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-0",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test", Image: "test"},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "data-test-pod-0",
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, pod1)).To(Succeed())
+
+			pod2 := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test", Image: "test"},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "data-test-pod-1",
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, pod2)).To(Succeed())
+
+			pvc1 := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "data-test-pod-0",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, pvc1)).To(Succeed())
+
+			pvc2 := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "data-test-pod-1",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, pvc2)).To(Succeed())
+
+			pvcs, err := fetcher.Fetch(ctx, pvca)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvcs).To(HaveLen(2))
+			Expect(pvcs).To(ConsistOf(HaveField("Name", "data-test-pod-0"), HaveField("Name", "data-test-pod-1")))
+		})
+
+		It("should deduplicate PVCs when multiple pods reference the same PVC", func() {
+			sharedPVC := "shared-data"
+
+			pod1 := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-0",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test", Image: "test"},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: sharedPVC,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, pod1)).To(Succeed())
+
+			pod2 := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test", Image: "test"},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: sharedPVC,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, pod2)).To(Succeed())
+
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sharedPVC,
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, pvc)).To(Succeed())
+
+			pvcs, err := fetcher.Fetch(ctx, pvca)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvcs).To(HaveLen(1))
+			Expect(pvcs[0].Name).To(Equal(sharedPVC))
+		})
+
+		It("should return an error when a referenced PVC does not exist", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test", Image: "test"},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "missing-pvc",
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, pod)).To(Succeed())
+
+			_, err := fetcher.Fetch(ctx, pvca)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get PersistentVolumeClaim"))
+		})
+
+		It("should only return PVCs from pods in the same namespace as the PVCA", func() {
+			podInNamespace := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-ns1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test", Image: "test"},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "pvc-in-default",
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, podInNamespace)).To(Succeed())
+
+			podInOtherNamespace := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-ns2",
+					Namespace: "other",
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test", Image: "test"},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "pvc-in-other",
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, podInOtherNamespace)).To(Succeed())
+
+			pvcInDefault := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pvc-in-default",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, pvcInDefault)).To(Succeed())
+
+			pvcInOther := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pvc-in-other",
+					Namespace: "other",
+				},
+			}
+			Expect(fakeClient.Create(ctx, pvcInOther)).To(Succeed())
+
+			pvcs, err := fetcher.Fetch(ctx, pvca)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvcs).To(HaveLen(1))
+			Expect(pvcs[0].Name).To(Equal("pvc-in-default"))
+			Expect(pvcs[0].Namespace).To(Equal("default"))
+		})
+	})
+})
+
+type fakeSelectorFetcher struct {
+	selector labels.Selector
+	err      error
+}
+
+func (s *fakeSelectorFetcher) Fetch(ctx context.Context, namespace string, targetRef autoscalingv1.CrossVersionObjectReference) (labels.Selector, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	return s.selector, nil
+}

--- a/internal/target/selectorfetcher/selectorfetcher.go
+++ b/internal/target/selectorfetcher/selectorfetcher.go
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package selectorfetcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	scaleclient "k8s.io/client-go/scale"
+)
+
+var (
+	// ErrNoScaleClient is returned when the [Fetcher] is configured without a scale client.
+	ErrNoScaleClient = errors.New("no scale client provided")
+
+	// ErrNoRESTMapper is returned when the [Fetcher] is configured without a REST mapper.
+	ErrNoRESTMapper = errors.New("no REST mapper provided")
+)
+
+// Fetcher is an interface that can be used to fetch the label selector from
+// the scale subresource of an autoscalingv1.CrossVersionObjectReference.
+type Fetcher interface {
+	// Fetch returns the label selector from the scale subresource of the provided
+	// autoscalingv1.CrossVersionObjectReference in the provided namespace.
+	// If the provided autoscalingv1.CrossVersionObjectReference does not support
+	// a scale subresource, an error is returned.
+	Fetch(ctx context.Context, namespace string, targetRef autoscalingv1.CrossVersionObjectReference) (labels.Selector, error)
+}
+
+type selectorFetcher struct {
+	scaleClient scaleclient.ScalesGetter
+	restMapper  apimeta.RESTMapper
+}
+
+// Option is a function which configures the [Fetcher].
+type Option func(*selectorFetcher)
+
+// New creates a new selector [Fetcher] with the given options.
+func New(opts ...Option) (Fetcher, error) {
+	f := &selectorFetcher{}
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	if f.scaleClient == nil {
+		return nil, ErrNoScaleClient
+	}
+
+	if f.restMapper == nil {
+		return nil, ErrNoRESTMapper
+	}
+
+	return f, nil
+}
+
+// WithScaleClient configures the [Fetcher] with the given scale client.
+func WithScaleClient(sc scaleclient.ScalesGetter) Option {
+	return func(f *selectorFetcher) {
+		f.scaleClient = sc
+	}
+}
+
+// WithRESTMapper configures the [Fetcher] with the given REST mapper.
+func WithRESTMapper(rm apimeta.RESTMapper) Option {
+	return func(f *selectorFetcher) {
+		f.restMapper = rm
+	}
+}
+
+func (f *selectorFetcher) Fetch(ctx context.Context, namespace string, targetRef autoscalingv1.CrossVersionObjectReference) (labels.Selector, error) {
+	targetGV, err := schema.ParseGroupVersion(targetRef.APIVersion)
+	if err != nil {
+		return nil, fmt.Errorf("invalid API version in target reference: %w", err)
+	}
+
+	targetGK := schema.GroupKind{
+		Group: targetGV.Group,
+		Kind:  targetRef.Kind,
+	}
+
+	mappings, err := f.restMapper.RESTMappings(targetGK)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine resource for scale target reference: %w", err)
+	}
+
+	scale, _, err := f.scaleForResourceMappings(ctx, namespace, targetRef.Name, mappings)
+	if err != nil {
+		return nil, fmt.Errorf("could not get scale subresource for target %s: %w", targetRef.String(), err)
+	}
+
+	labelSelector, err := labels.Parse(scale.Status.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse label selector for target %s: %w", targetRef.String(), err)
+	}
+
+	return labelSelector, nil
+}
+
+func (f *selectorFetcher) scaleForResourceMappings(ctx context.Context, namespace, name string, mappings []*apimeta.RESTMapping) (*autoscalingv1.Scale, schema.GroupResource, error) {
+	// make sure we handle an empty set of mappings
+	if len(mappings) == 0 {
+		return nil, schema.GroupResource{}, errors.New("unrecognized resource")
+	}
+
+	errs := []error{}
+	for _, mapping := range mappings {
+		targetGR := mapping.Resource.GroupResource()
+		scale, err := f.scaleClient.Scales(namespace).Get(ctx, targetGR, name, metav1.GetOptions{})
+		if err == nil {
+			return scale, targetGR, nil
+		}
+
+		errs = append(errs, err)
+	}
+
+	return nil, schema.GroupResource{}, errors.Join(errs...)
+}

--- a/internal/target/selectorfetcher/selectorfetcher.go
+++ b/internal/target/selectorfetcher/selectorfetcher.go
@@ -91,7 +91,7 @@ func (f *selectorFetcher) Fetch(ctx context.Context, namespace string, targetRef
 		return nil, fmt.Errorf("unable to determine resource for scale target reference: %w", err)
 	}
 
-	scale, _, err := f.scaleForResourceMappings(ctx, namespace, targetRef.Name, mappings)
+	scale, err := f.scaleForResourceMappings(ctx, namespace, targetRef.Name, mappings)
 	if err != nil {
 		return nil, fmt.Errorf("could not get scale subresource for target %s: %w", targetRef.String(), err)
 	}
@@ -104,10 +104,10 @@ func (f *selectorFetcher) Fetch(ctx context.Context, namespace string, targetRef
 	return labelSelector, nil
 }
 
-func (f *selectorFetcher) scaleForResourceMappings(ctx context.Context, namespace, name string, mappings []*apimeta.RESTMapping) (*autoscalingv1.Scale, schema.GroupResource, error) {
+func (f *selectorFetcher) scaleForResourceMappings(ctx context.Context, namespace, name string, mappings []*apimeta.RESTMapping) (*autoscalingv1.Scale, error) {
 	// make sure we handle an empty set of mappings
 	if len(mappings) == 0 {
-		return nil, schema.GroupResource{}, errors.New("unrecognized resource")
+		return nil, errors.New("unrecognized resource")
 	}
 
 	errs := []error{}
@@ -115,11 +115,11 @@ func (f *selectorFetcher) scaleForResourceMappings(ctx context.Context, namespac
 		targetGR := mapping.Resource.GroupResource()
 		scale, err := f.scaleClient.Scales(namespace).Get(ctx, targetGR, name, metav1.GetOptions{})
 		if err == nil {
-			return scale, targetGR, nil
+			return scale, nil
 		}
 
 		errs = append(errs, err)
 	}
 
-	return nil, schema.GroupResource{}, errors.Join(errs...)
+	return nil, errors.Join(errs...)
 }

--- a/internal/target/selectorfetcher/selectorfetcher_suite_test.go
+++ b/internal/target/selectorfetcher/selectorfetcher_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package selectorfetcher_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSelectorFetcher(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SelectorFetcher Suite")
+}

--- a/internal/target/selectorfetcher/selectorfetcher_test.go
+++ b/internal/target/selectorfetcher/selectorfetcher_test.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package selectorfetcher_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	scalefake "k8s.io/client-go/scale/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/gardener/pvc-autoscaler/internal/target/selectorfetcher"
+)
+
+var _ = Describe("SelectorFetcher", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	Describe("New", func() {
+		It("should return an error when no scale client is provided", func() {
+			mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{})
+			_, err := selectorfetcher.New(
+				selectorfetcher.WithRESTMapper(mapper),
+			)
+			Expect(err).To(Equal(selectorfetcher.ErrNoScaleClient))
+		})
+
+		It("should return an error when no REST mapper is provided", func() {
+			scaleClient := &scalefake.FakeScaleClient{}
+			_, err := selectorfetcher.New(
+				selectorfetcher.WithScaleClient(scaleClient),
+			)
+			Expect(err).To(Equal(selectorfetcher.ErrNoRESTMapper))
+		})
+
+		It("should create a fetcher when all required options are provided", func() {
+			scaleClient := &scalefake.FakeScaleClient{}
+			mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{})
+			fetcher, err := selectorfetcher.New(
+				selectorfetcher.WithScaleClient(scaleClient),
+				selectorfetcher.WithRESTMapper(mapper),
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fetcher).ToNot(BeNil())
+		})
+	})
+
+	Describe("Fetch", func() {
+		var (
+			scaleClient     *scalefake.FakeScaleClient
+			mapper          *meta.DefaultRESTMapper
+			selectorFetcher selectorfetcher.Fetcher
+
+			targetRef autoscalingv1.CrossVersionObjectReference
+		)
+
+		BeforeEach(func() {
+			scaleClient = &scalefake.FakeScaleClient{}
+
+			mapper = meta.NewDefaultRESTMapper([]schema.GroupVersion{appsv1.SchemeGroupVersion})
+			mapper.Add(appsv1.SchemeGroupVersion.WithKind("StatefulSet"), meta.RESTScopeNamespace)
+
+			targetRef = autoscalingv1.CrossVersionObjectReference{
+				Kind:       "StatefulSet",
+				Name:       "test-sts",
+				APIVersion: "apps/v1",
+			}
+		})
+
+		JustBeforeEach(func() {
+			var err error
+			selectorFetcher, err = selectorfetcher.New(
+				selectorfetcher.WithScaleClient(scaleClient),
+				selectorfetcher.WithRESTMapper(mapper),
+			)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		When("REST mapper is empty", func() {
+			BeforeEach(func() {
+				mapper = meta.NewDefaultRESTMapper([]schema.GroupVersion{}) // Empty mapper
+			})
+
+			It("should return an error because REST mapper cannot find resource mappings", func() {
+				_, err := selectorFetcher.Fetch(ctx, "default", targetRef)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unable to determine resource"))
+			})
+		})
+
+		When("REST mapper is not empty", func() {
+			It("should return an error because REST mapper does not have mapping for Deployment", func() {
+				targetRef = autoscalingv1.CrossVersionObjectReference{
+					Kind:       "Deployment",
+					Name:       "test-sts",
+					APIVersion: "apps/v1",
+				}
+
+				_, err := selectorFetcher.Fetch(ctx, "default", targetRef)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unable to determine resource"))
+			})
+
+			It("should return a label selector when scale subresource is found", func() {
+				scale := &autoscalingv1.Scale{
+					Status: autoscalingv1.ScaleStatus{
+						Selector: "app=test,version=v1",
+					},
+				}
+
+				scaleClient.AddReactor("get", "statefulsets/scale", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					return true, scale, nil
+				})
+
+				selector, err := selectorFetcher.Fetch(ctx, "default", targetRef)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(selector).ToNot(BeNil())
+				Expect(selector.Matches(labels.Set{
+					"app":     "test",
+					"version": "v1",
+				})).To(BeTrue())
+			})
+
+			It("should return an error when scale selector is invalid", func() {
+				scale := &autoscalingv1.Scale{
+					Status: autoscalingv1.ScaleStatus{
+						Selector: "!@#$invalid",
+					},
+				}
+
+				scaleClient.AddReactor("get", "statefulsets/scale", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					return true, scale, nil
+				})
+
+				_, err := selectorFetcher.Fetch(ctx, "default", targetRef)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("could not parse label selector"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR adds interfaces for a label selector and pvc selector that can be used to find the PVCs that are targeted by a particular PVCA.

Subsequent PRs will add checks whether there is collision leading to multiple PVCAs targeting the same PVCs (using the same label selector), event recordings and updates to the status of the PVCA.

An example usage in the periodic controller could look like this: https://github.com/plkokanov/pvc-autoscaler/compare/enh/pvc-selector...plkokanov:pvc-autoscaler:enh/init-pvc-selector

**Which issue(s) this PR fixes**:
Part of #147 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Added `selectorfetcher.Fetcher` interface that can be used to fetch the label selector of the workload controller targeted by a `PersistentVolumeClaimAutoscaler`.
```
```feature developer
Added `pvcfetcher.Fetcher` interface that can be used to fetch the PVCs that should be managed by a `PersistentVolumeClaimAutoscaler` by using a label selector fetcher.
```