### PR TITLE
fix: correct main.go filepaths in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,11 +173,11 @@ minikube-load-image: minikube docker-build  ## Load the operator image into the 
 
 .PHONY: build
 build: generate ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+	go build -o bin/manager cmd/pvc-autoscaler/main.go
 
 .PHONY: run
 run: generate ## Run a controller from your host.
-	go run ./cmd/main.go
+	go run ./cmd/pvc-autoscaler/main.go
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.


### PR DESCRIPTION
Updated the Makefile targets build and run to use the correct path of cmd/pvc-autoscaler/main.go instead of cmd/main.go

**How to categorize this PR?**
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Housekeeping for developer productivity.

Use the correct path for main.go which is `cmd/pvc-autoscaler/main.go`

**Which issue(s) this PR fixes**:
Fixes #157

**Special notes for your reviewer**:

Minor housekeeping fix for developer convenience.

Executing `make build` and `make run` are now functional.

**Release note**:

```other operator
NONE
```
