### PR TITLE
Improve renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,7 @@
   "labels": ["kind/enhancement"],
   "postUpdateOptions": ["gomodTidy"],
   "automergeStrategy": "squash",
+  "separateMinorPatch": true,
   // Add PR footer with empty release note by default.
   "prFooter": "**Release note**:\n```other dependency\nNONE\n```",
   "packageRules": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,8 @@
   "labels": ["kind/enhancement"],
   "postUpdateOptions": ["gomodTidy"],
   "separateMinorPatch": true,
+  // Only rebase when there are conflicts. Prow tests against the latest state of master branch anyway before merging the PR.
+  "rebaseWhen": "conflicted",
   // Add PR footer with empty release note by default.
   "prFooter": "**Release note**:\n```other dependency\nNONE\n```",
   customManagers: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,8 @@
     "config:recommended",
     ":semanticCommitsDisabled",
     "regexManagers:githubActionsVersions",
-    "group:monorepos"
+    "group:monorepos",
+    'github>gardener/ci-infra//config/renovate/makefile-versions.json5'
   ],
   "labels": ["kind/enhancement"],
   "postUpdateOptions": ["gomodTidy"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,8 @@
     ":semanticCommitsDisabled",
     "regexManagers:githubActionsVersions",
     "group:monorepos",
-    'github>gardener/ci-infra//config/renovate/makefile-versions.json5'
+    'github>gardener/ci-infra//config/renovate/makefile-versions.json5',
+    'github>gardener/ci-infra//config/renovate/group-go-updates.json5'
   ],
   "labels": ["kind/enhancement"],
   "postUpdateOptions": ["gomodTidy"],
@@ -39,12 +40,6 @@
     },
   ],
   "packageRules": [
-    {
-      // Group golang updates in one PR.
-      "groupName": "golang",
-      "matchDatasources": ["docker", "go", "golang-version"],
-      "matchPackageNames": ["go", "golang"],
-    },
     {
       // Update only patchlevels of major dependencies like kubernetes and controller-runtime.
       // Minor and major upgrades most likely require manual adaptations of the code.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,8 @@
   "labels": ["kind/enhancement"],
   "postUpdateOptions": ["gomodTidy"],
   "automergeStrategy": "squash",
+  // Add PR footer with empty release note by default.
+  "prFooter": "**Release note**:\n```other dependency\nNONE\n```",
   "packageRules": [
     {
       // Group golang updates in one PR.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,6 +33,16 @@
       "datasourceTemplate": "docker",
     },
     {
+      // Detection for kindest/node image tag in Makefile.
+      "customType": "regex",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        'KINDEST_NODE_IMAGE_TAG\\s*\\?=\\s*(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)',
+      ],
+      "depNameTemplate": "kindest/node",
+      "datasourceTemplate": "docker",
+    },
+    {
       "customType": "regex",
       "fileMatch": ["^skaffold\\.yaml$"],
       "matchStrings": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,21 +73,6 @@
       "enabled": false
     },
     {
-      // Ignore dependency updates from k8s.io/kube-openapi because it depends on k8s.io/apiserver.
-      "matchDatasources": ["go"],
-      "matchPackagePatterns": ["k8s\\.io\/kube-openapi"],
-      "enabled": false
-    },
-    {
-      // Disable major updates of jsonpatch/v2.
-      // The major version of this dependency should be kept in sync with controller-runtime:
-      // https://github.com/kubernetes-sigs/controller-runtime/blob/main/go.mod
-      "matchDatasources": ["go"],
-      "matchPackageNames": ["gomodules.xyz/jsonpatch/v2"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false,
-    },
-    {
       // Ask for manual approval to create PRs for minor and major updates of dependencies which most likely
       // require manual adaptations of the code.
       "matchDatasources": ["go"],
@@ -96,8 +81,6 @@
       "matchPackageNames": [
         "/k8s\\.io/.+/",
         "/sigs\\.k8s\\.io/controller-runtime/",
-        "/istio\\.io/.+/",
-        "/github\\.com/fluent/.+/",
       ],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -77,6 +77,15 @@
       "enabled": false
     },
     {
+      // Disable major updates of jsonpatch/v2.
+      // The major version of this dependency should be kept in sync with controller-runtime:
+      // https://github.com/kubernetes-sigs/controller-runtime/blob/main/go.mod
+      "matchDatasources": ["go"],
+      "matchPackageNames": ["gomodules.xyz/jsonpatch/v2"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false,
+    },
+    {
       // Group github-actions minor updates in one PR
       "matchManagers": ["github-actions"],
       "groupName": "github-actions"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,31 @@
   "separateMinorPatch": true,
   // Add PR footer with empty release note by default.
   "prFooter": "**Release note**:\n```other dependency\nNONE\n```",
+  customManagers: [
+    {
+      // Generic detection for pod-like image specifications.
+      "customType": "regex",
+      managerFilePatterns: [
+        "/^.github/workflows/.+\\.yaml$/",
+        "/^example/.+\\.yaml$/",
+        "/^config/.+\\.yaml$/",
+        "/^hack/.+\\.yaml$/",
+        "/^test/manifests/.+\\.yaml$/",
+      ],
+      "matchStrings": [
+        '["|\']?image["|\']?: ["|\']?(?<depName>.*?):(?<currentValue>.*?)["|\']?\\s',
+      ],
+      "datasourceTemplate": "docker",
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^skaffold\\.yaml$"],
+      "matchStrings": [
+        "repo: (?<registryUrl>https?://[^\\s]+)\\s+remoteChart: (?<depName>[^\\s]+)\\s+version: (?<currentValue>[^\\s]+)",
+      ],
+      "datasourceTemplate": "helm",
+    },
+  ],
   "packageRules": [
     {
       // Group golang updates in one PR.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -86,6 +86,27 @@
       "enabled": false,
     },
     {
+      // Ask for manual approval to create PRs for minor and major updates of dependencies which most likely
+      // require manual adaptations of the code.
+      "matchDatasources": ["go"],
+      "matchUpdateTypes": ["major","minor"],
+      "dependencyDashboardApproval": true,
+      "matchPackageNames": [
+        "/k8s\\.io/.+/",
+        "/sigs\\.k8s\\.io/controller-runtime/",
+        "/istio\\.io/.+/",
+        "/github\\.com/fluent/.+/",
+      ],
+    },
+    {
+      // Ask for manual approval to create PRs for kindest/node image. Minor and major versions are updated when new
+      // versions of Kubernetes are introduced only.
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["major","minor"],
+      "dependencyDashboardApproval": true,
+      "matchPackageNames": ["/kindest/node/"],
+    },
+    {
       // Group github-actions minor updates in one PR
       "matchManagers": ["github-actions"],
       "groupName": "github-actions"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,11 +6,11 @@
     "regexManagers:githubActionsVersions",
     "group:monorepos",
     'github>gardener/ci-infra//config/renovate/makefile-versions.json5',
-    'github>gardener/ci-infra//config/renovate/group-go-updates.json5'
+    'github>gardener/ci-infra//config/renovate/group-go-updates.json5',
+    'github>gardener/ci-infra//config/renovate/automerge-with-tide.json5',
   ],
   "labels": ["kind/enhancement"],
   "postUpdateOptions": ["gomodTidy"],
-  "automergeStrategy": "squash",
   "separateMinorPatch": true,
   // Add PR footer with empty release note by default.
   "prFooter": "**Release note**:\n```other dependency\nNONE\n```",
@@ -40,6 +40,25 @@
     },
   ],
   "packageRules": [
+    {
+      // automerge patch updates
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+    },
+    {
+      // automerge k8s.io/utils updates
+      "matchDatasources": ["go"],
+      "matchPackageNames": ["k8s.io/utils"],
+      "matchUpdateTypes": ["digest"],
+      "automerge": true,
+    },
+    {
+      // automerge non-major golang.org/x updates
+      "matchDatasources": ["go"],
+      matchPackageNames: ["golang.org/x/*"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true,
+    },
     {
       // Update only patchlevels of major dependencies like kubernetes and controller-runtime.
       // Minor and major upgrades most likely require manual adaptations of the code.

--- a/Makefile
+++ b/Makefile
@@ -264,19 +264,32 @@ GOIMPORTS ?= $(LOCALBIN)/goimports
 GOIMPORTSREVISER ?= $(LOCALBIN)/goimports-reviser
 
 ## Tool Versions
+# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize\/(?<version>.*)$
 KUSTOMIZE_VERSION ?= v5.5.0
-CONTROLLER_TOOLS_VERSION ?= v0.16.4
-ENVTEST_VERSION ?= release-0.19
+# renovate: datasource=github-releases depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.7.2
+# renovate: datasource=github-releases depName=kubernetes/minikube
 MINIKUBE_VERSION ?= v1.34.0
+# renovate: datasource=github-releases depName=mikefarah/yq
 YQ_VERSION ?= v4.44.3
+# renovate: datasource=github-releases depName=helm/helm
 HELM_VERSION ?= v3.16.2
+# renovate: datasource=github-releases depName=kubernetes-sigs/kind
 KIND_VERSION ?= v0.30.0
+# renovate: datasource=github-releases depName=GoogleContainerTools/skaffold
 SKAFFOLD_VERSION ?= v2.16.1
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
 KUBECTL_VERSION ?= v1.33.4
+# renovate: datasource=github-releases depName=securego/gosec
 GOSEC_VERSION ?= v2.22.10
-GOIMPORTS_VERSION ?= v0.38.0
+# renovate: datasource=github-releases depName=incu6us/goimports-reviser
 GOIMPORTSREVISER_VERSION ?= v3.11.0
+# renovate: datasource=github-releases depName=kubernetes-sigs/controller-tools
+CONTROLLER_TOOLS_VERSION ?= v0.16.4
+
+# tool versions from go.mod
+ENVTEST_VERSION ?= $(subst v,release-,$(call major_minor_version_gomod,sigs.k8s.io/controller-runtime))
+GOIMPORTS_VERSION ?= $(call version_gomod,golang.org/x/tools)
 
 # minikube settings
 MINIKUBE_PROFILE ?= pvc-autoscaler
@@ -291,6 +304,14 @@ $(LOCALBIN)/.version_%: | $(LOCALBIN)
 # $1 - target binary path
 # $2 - version of the tool
 gen-tool-version = $(LOCALBIN)/.version_$(subst $(LOCALBIN)/,,$(1))_$(2)
+
+# Use this function to get the version of a go module from go.mod
+# $1 - go module
+version_gomod = $(shell go list -f '{{ .Version }}' -m $(1))
+
+# Use this function to get the major and minor version of a go module from go.mod
+# $1 - go module
+major_minor_version_gomod = $(shell go list -f '{{ .Version }}' -m $(1) | awk -F. '{ printf "%s.%s", $$1, $$2 }')
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) | $(LOCALBIN)  ## Download kustomize locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ SHELL = /usr/bin/env bash -o pipefail
 REPO_ROOT                         := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 KIND_KUBECONFIG                   := $(REPO_ROOT)/example/kind/local/kubeconfig
 DEV_SETUP_WITH_LPP_RESIZE_SUPPORT ?= true
-KINDEST_NODE_IAMGE_TAG		      ?= v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
+KINDEST_NODE_IMAGE_TAG		      ?= v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
 
 ## Rules
 tools-for-generate: controller-gen golangci-lint goimports yq
@@ -137,7 +137,7 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 kind-up: kind kustomize kubectl
 	./hack/kind-up.sh \
 	--with-lpp-resize-support $(DEV_SETUP_WITH_LPP_RESIZE_SUPPORT) \
-	--kindest-node-image-tag $(KINDEST_NODE_IAMGE_TAG)
+	--kindest-node-image-tag $(KINDEST_NODE_IMAGE_TAG)
 
 .PHONY: kind-down
 kind-down: kind


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
With this PR, renovate will start tracking and opening version bump PRs for the following:
- dev tools listed in [`Makefile`](https://github.com/gardener/pvc-autoscaler/blob/0051ec27d9c6ea76944bfe95ec23fcb2e8b9dedd/Makefile#L266-L279)
- patch bumps for `k8s.io` dependencies
- versions of 3rd party images used for tests
- versions of helm charts also used for tests

The PR also adds automerging via tide and extends the renovate config with some common configurations already available in the [gardener/ci-infra repository](https://github.com/gardener/ci-infra/tree/master/config/renovate)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
