### PR TITLE
Run make generate on controller-tools updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -83,6 +83,21 @@
       "enabled": false
     },
     {
+      // Run make generate when controller-tools package has been updated as CRDs might need regeneration.
+      matchDatasources: [
+        'github-releases',
+      ],
+      postUpgradeTasks: {
+        commands: [
+          'make generate',
+        ],
+        executionMode: 'branch',
+      },
+      matchPackageNames: [
+        '/kubernetes-sigs/controller-tools',
+      ],
+    },
+    {
       // Ask for manual approval to create PRs for minor and major updates of dependencies which most likely
       // require manual adaptations of the code.
       "matchDatasources": ["go"],


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Adds a Renovate `postUpgradeTasks` rule that runs `make generate` when `kubernetes-sigs/controller-tools` is updated. Since controller-tools is used to generate CRD manifests and deep copy methods, updating it may produce changes to generated files that should be committed alongside the dependency bump.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other dependency
NONE
```
