### PR TITLE
Use a looser check and toleration for stale metrics

### DIFF
--- a/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
+++ b/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
@@ -97,7 +97,7 @@ type ScalingRules struct {
 	UtilizationThresholdPercent *int `json:"utilizationThresholdPercent,omitempty"`
 
 	// StepPercent specifies the percentage by which to change the PVC storage capacity when scaling.
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=5
 	// +kubebuilder:validation:Maximum=100
 	// +kubebuilder:default=10
 	// +optional

--- a/config/crd/bases/autoscaling.gardener.cloud_persistentvolumeclaimautoscalers.yaml
+++ b/config/crd/bases/autoscaling.gardener.cloud_persistentvolumeclaimautoscalers.yaml
@@ -118,7 +118,7 @@ spec:
                           description: StepPercent specifies the percentage by which
                             to change the PVC storage capacity when scaling.
                           maximum: 100
-                          minimum: 1
+                          minimum: 5
                           type: integer
                         utilizationThresholdPercent:
                           default: 80

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -142,7 +142,7 @@ spec:
                           description: StepPercent specifies the percentage by which
                             to change the PVC storage capacity when scaling.
                           maximum: 100
-                          minimum: 1
+                          minimum: 5
                           type: integer
                         utilizationThresholdPercent:
                           default: 80

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -47,4 +47,9 @@ const (
 	// request set by the autoscaler is guaranteed to be divisible by that
 	// value. ScalingResolutionBytes is guaranteed to be an even number.
 	ScalingResolutionBytes = 1024 * 1024 * 1024
+
+	// MaxCapacityDeviationRatio is the maximum allowed deviation ratio between the PVC size
+	// as reported by the metrics source and the PVC size as indicated by the PVC status.
+	// If the deviation is bigger than this ratio, the metrics are considered stale.
+	MaxCapacityDeviationRatio = 0.02
 )

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -404,15 +404,13 @@ func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.Persiste
 
 	// Detect whether the metrics source is reporting stale data. Stale
 	// metrics data would be when the volume info metrics reported by the
-	// metrics source are deviate from the current PVC size indicated by
+	// metrics source deviate from the current PVC size indicated by
 	// `.status.capacity.storage'
 	if statusSize, ok := currStatusSize.AsInt64(); ok {
-		delta := statusSize - int64(volInfo.CapacityBytes)
-		if delta < 0 {
-			delta = -delta
-		}
-		if delta > common.ScalingResolutionBytes/2 {
-			return false, "", fmt.Errorf("stale metrics data detected: pvc size=%d bytes, metrics size=%d bytes:%w", statusSize, volInfo.CapacityBytes, common.ErrStaleMetrics)
+		delta := math.Abs(float64(statusSize) - float64(volInfo.CapacityBytes))
+		tolerance := math.Max(common.MaxCapacityDeviationRatio*float64(statusSize), float64(common.ScalingResolutionBytes)/2)
+		if delta > tolerance {
+			return false, "", fmt.Errorf("stale metrics data detected: pvc size=%d bytes, metrics size=%d bytes: %w", statusSize, volInfo.CapacityBytes, common.ErrStaleMetrics)
 		}
 	}
 

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -233,11 +233,11 @@ var _ = Describe("Periodic Runner", func() {
 					nil,
 					common.ErrNoMetrics,
 				),
-				Entry("should return ErrStaleMetrics when metrics capacity does not match PVC",
+				Entry("should return ErrStaleMetrics when metrics capacity deviates by more than max(2%, 0.5Gi)",
 					"",
 					&metricssource.VolumeInfo{
 						AvailableBytes:  9 * 1024 * 1024,
-						CapacityBytes:   200 * 1024 * 1024,
+						CapacityBytes:   200 * 1024 * 1024, // delta ~824MiB > 0.5Gi tolerance
 						AvailableInodes: 1000,
 						CapacityInodes:  1000,
 					},

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -233,7 +233,7 @@ var _ = Describe("Periodic Runner", func() {
 					nil,
 					common.ErrNoMetrics,
 				),
-				Entry("should return ErrStaleMetrics when metrics capacity deviates by more than max(2%, 0.5Gi)",
+				Entry("should return ErrStaleMetrics when metrics capacity deviates by more than 0.5Gi (small PVC)",
 					"",
 					&metricssource.VolumeInfo{
 						AvailableBytes:  9 * 1024 * 1024,
@@ -244,6 +244,32 @@ var _ = Describe("Periodic Runner", func() {
 					common.ErrStaleMetrics,
 				),
 			)
+
+			It("should return ErrStaleMetrics when metrics capacity deviates by more than 2% (large PVC)", func() {
+				By("Patching PVC to 100Gi and PVCA maxCapacity to 200Gi")
+				specPatch := client.MergeFrom(pvc.DeepCopy())
+				pvc.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("100Gi")
+				Expect(k8sClient.Patch(parentCtx, pvc, specPatch)).To(Succeed())
+
+				statusPatch := client.MergeFrom(pvc.DeepCopy())
+				pvc.Status.Capacity[corev1.ResourceStorage] = resource.MustParse("100Gi")
+				Expect(k8sClient.Status().Patch(parentCtx, pvc, statusPatch)).To(Succeed())
+
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("200Gi")
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				By("Calling shouldReconcilePVC with metrics deviating by 3Gi")
+				volInfo := &metricssource.VolumeInfo{
+					AvailableBytes:  9 * 1024 * 1024,
+					CapacityBytes:   97 * 1024 * 1024 * 1024, // delta 3Gi > 2% tolerance
+					AvailableInodes: 1000,
+					CapacityInodes:  1000,
+				}
+				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, volInfo)
+				Expect(ok).To(BeFalse())
+				Expect(err).To(MatchError(common.ErrStaleMetrics))
+			})
 
 			It("should return ErrStorageClassNotFound", func() {
 				By("Creating a PVC without a StorageClass")

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -245,7 +245,7 @@ var _ = Describe("Periodic Runner", func() {
 				),
 			)
 
-			It("should return ErrStaleMetrics when metrics capacity deviates by more than 2% (large PVC)", func() {
+			It("should apply 2% tolerance for stale metrics detection (large PVC)", func() {
 				By("Patching PVC to 100Gi and PVCA maxCapacity to 200Gi")
 				specPatch := client.MergeFrom(pvc.DeepCopy())
 				pvc.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("100Gi")
@@ -269,6 +269,17 @@ var _ = Describe("Periodic Runner", func() {
 				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, volInfo)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(MatchError(common.ErrStaleMetrics))
+
+				By("Calling shouldReconcilePVC with metrics deviating by 1Gi")
+				volInfo = &metricssource.VolumeInfo{
+					AvailableBytes:  9 * 1024 * 1024,
+					CapacityBytes:   99 * 1024 * 1024 * 1024, // delta 1Gi < 2% tolerance
+					AvailableInodes: 1000,
+					CapacityInodes:  1000,
+				}
+				ok, _, err = runner.shouldReconcilePVC(parentCtx, pvca, volInfo)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ok).To(BeTrue())
 			})
 
 			It("should return ErrStorageClassNotFound", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
During testing, the following event was observed:
```
"namespace": "monitoring", "name": "pvca-prometheus", "pvc": "prometheus-db-prometheus-kind-prometheus-kube-prome-prometheus-0", "reason": "stale metrics data detected: pvc size=28991029248 bytes, metrics size=28440285184 bytes:stale metrics data"}
```
PVCAs were stuck with stale metrics, even though they should have been resized after getting filled. Additional tests showed that the sizes vary and providers can under-provision or over-provision with a delta bigger than the hard coded value (~1/2 GB). For example, on GCP tests with 1 Ti showed a 6-7GB difference in over-provisioning.

This PR adds a percentage based approach to the delta check for stale metrics. For small volumes (< 25Gi), the 0.5 GiB floor still applies. For larger volumes, 2% provides headroom that scales with volume size. Additionally, StepPercent minimum validation is raised from 1 to 5 to prevent unreasonably small scaling steps.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/cc @Kostov6 @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
`StepPercent` minimum is now 5.
```
