### PR TITLE
Set controller `imagePullPolicy` to `IfNotPresent`

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,6 +63,7 @@ spec:
       - args:
         - --leader-elect
         image: controller:latest
+        imagePullPolicy: IfNotPresent
         name: manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area performance
/kind enhancement

**What this PR does / why we need it**:
Previously, the controller image used the latest tag without an explicit pull policy, which caused Kubernetes to default to `Always`. With this change, the controller deployment uses `IfNotPresent` as an `imagePullPolicy` consistently across overlays, including `default` and `kind`.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/cc @Kostov6 @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The controller deployment now has imagePullPolicy set to IfNotPresent.
```
