### PR TITLE
Make it possible to target workload controllers in the PVCA API and resize multiple PVCs per one PVCA resource

### DIFF
--- a/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_webhook.go
+++ b/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_webhook.go
@@ -64,11 +64,6 @@ func validateResourceSpec(obj runtime.Object) error {
 		}
 	}
 
-	if pvca.Spec.TargetRef.Kind != "PersistentVolumeClaim" {
-		e := field.Invalid(field.NewPath("spec.targetRef.kind"), pvca.Spec.TargetRef.Kind, "only PersistentVolumeClaim kind is supported")
-		allErrs = append(allErrs, e)
-	}
-
 	if len(pvca.Spec.TargetRef.Name) == 0 {
 		allErrs = append(allErrs, field.Required(field.NewPath("spec.targetRef.name"), ""))
 	} else {
@@ -79,11 +74,6 @@ func validateResourceSpec(obj runtime.Object) error {
 
 	if len(pvca.Spec.TargetRef.APIVersion) == 0 {
 		e := field.Required(field.NewPath("spec.targetRef.apiVersion"), "")
-		allErrs = append(allErrs, e)
-	}
-
-	if pvca.Spec.TargetRef.APIVersion != "v1" {
-		e := field.Invalid(field.NewPath("spec.targetRef.apiVersion"), pvca.Spec.TargetRef.APIVersion, "only v1 apiVersion is supported")
 		allErrs = append(allErrs, e)
 	}
 

--- a/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_webhook_test.go
+++ b/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_webhook_test.go
@@ -329,7 +329,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
 		})
 
-		It("Should deny if targetRef kind is not PersistentVolumeClaim", func() {
+		It("Should admit if targetRef kind is Deployment", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-12",
@@ -337,9 +337,9 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 				},
 				Spec: PersistentVolumeClaimAutoscalerSpec{
 					TargetRef: autoscalingv1.CrossVersionObjectReference{
-						APIVersion: "v1",
-						Kind:       "StatefulSet",
-						Name:       "pvc-12",
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "deployment-12",
 					},
 					VolumePolicies: []VolumePolicy{
 						{
@@ -355,7 +355,38 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 				},
 			}
 
-			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
+			Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
+		})
+
+		It("Should admit if targetRef kind is StatefulSet", func() {
+			obj := &PersistentVolumeClaimAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pvca-12b",
+					Namespace: "default",
+				},
+				Spec: PersistentVolumeClaimAutoscalerSpec{
+					TargetRef: autoscalingv1.CrossVersionObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "StatefulSet",
+						Name:       "statefulset-12b",
+					},
+					VolumePolicies: []VolumePolicy{
+						{
+							MaxCapacity: resource.MustParse("5Gi"),
+							ScaleUp: ptr.To(ScalingRules{
+								UtilizationThresholdPercent: ptr.To(common.DefaultThresholdPercent),
+								StepPercent:                 ptr.To(common.DefaultStepPercent),
+								CooldownDuration:            ptr.To(metav1.Duration{Duration: 3600}),
+								MinStepAbsolute:             ptr.To(resource.MustParse("1Gi")),
+							}),
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
 		})
 
 		It("Should deny if targetRef name is empty", func() {
@@ -427,35 +458,6 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 						APIVersion: "",
 						Kind:       "PersistentVolumeClaim",
 						Name:       "pvc-15",
-					},
-					VolumePolicies: []VolumePolicy{
-						{
-							MaxCapacity: resource.MustParse("5Gi"),
-							ScaleUp: ptr.To(ScalingRules{
-								UtilizationThresholdPercent: ptr.To(common.DefaultThresholdPercent),
-								StepPercent:                 ptr.To(common.DefaultStepPercent),
-								CooldownDuration:            ptr.To(metav1.Duration{Duration: 3600}),
-								MinStepAbsolute:             ptr.To(resource.MustParse("1Gi")),
-							}),
-						},
-					},
-				},
-			}
-
-			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
-		})
-
-		It("Should deny if targetRef apiVersion is not v1", func() {
-			obj := &PersistentVolumeClaimAutoscaler{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pvca-16",
-					Namespace: "default",
-				},
-				Spec: PersistentVolumeClaimAutoscalerSpec{
-					TargetRef: autoscalingv1.CrossVersionObjectReference{
-						APIVersion: "v2",
-						Kind:       "PersistentVolumeClaim",
-						Name:       "pvc-16",
 					},
 					VolumePolicies: []VolumePolicy{
 						{

--- a/config/overlays/kind/fake-metrics/kustomization.yaml
+++ b/config/overlays/kind/fake-metrics/kustomization.yaml
@@ -24,6 +24,9 @@ configMapGenerator:
   - pod_cooldown_low_2Gi.txt
   - pod_cooldown_high_2Gi.txt
   - pod_cooldown_low_3Gi.txt
+  - sts_bytes_low_1Gi.txt
+  - sts_bytes_high_1Gi.txt
+  - sts_bytes_low_2Gi.txt
 
 resources:
 - metrics-test-pod-with-pvc.yaml

--- a/config/overlays/kind/fake-metrics/sts_bytes_high_1Gi.txt
+++ b/config/overlays/kind/fake-metrics/sts_bytes_high_1Gi.txt
@@ -1,0 +1,19 @@
+# HELP kubelet_volume_stats_available_bytes Number of available bytes in the volume
+# TYPE kubelet_volume_stats_available_bytes gauge
+kubelet_volume_stats_available_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-0",type="fake"} 129023424
+kubelet_volume_stats_available_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-1",type="fake"} 129023424
+# HELP kubelet_volume_stats_capacity_bytes Total capacity of the volume in bytes
+# TYPE kubelet_volume_stats_capacity_bytes gauge
+kubelet_volume_stats_capacity_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-0",type="fake"} 1073741824
+kubelet_volume_stats_capacity_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-1",type="fake"} 1073741824
+# HELP kubelet_volume_stats_inodes_free Number of free inodes in the volume
+# TYPE kubelet_volume_stats_inodes_free gauge
+kubelet_volume_stats_inodes_free{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-0",type="fake"} 65536
+kubelet_volume_stats_inodes_free{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-1",type="fake"} 65536
+# HELP kubelet_volume_stats_inodes Total number of inodes in the volume
+# TYPE kubelet_volume_stats_inodes gauge
+kubelet_volume_stats_inodes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-0",type="fake"} 65536
+kubelet_volume_stats_inodes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-1",type="fake"} 65536
+# HELP fake_metrics_stage Current stage information
+# TYPE fake_metrics_stage gauge
+fake_metrics_sts_bytes_high_1Gi{stage="2",description="bytes_high"} 1

--- a/config/overlays/kind/fake-metrics/sts_bytes_low_1Gi.txt
+++ b/config/overlays/kind/fake-metrics/sts_bytes_low_1Gi.txt
@@ -1,0 +1,19 @@
+# HELP kubelet_volume_stats_available_bytes Number of available bytes in the volume
+# TYPE kubelet_volume_stats_available_bytes gauge
+kubelet_volume_stats_available_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-0",type="fake"} 1073741824
+kubelet_volume_stats_available_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-1",type="fake"} 1073741824
+# HELP kubelet_volume_stats_capacity_bytes Total capacity of the volume in bytes
+# TYPE kubelet_volume_stats_capacity_bytes gauge
+kubelet_volume_stats_capacity_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-0",type="fake"} 1073741824
+kubelet_volume_stats_capacity_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-1",type="fake"} 1073741824
+# HELP kubelet_volume_stats_inodes_free Number of free inodes in the volume
+# TYPE kubelet_volume_stats_inodes_free gauge
+kubelet_volume_stats_inodes_free{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-0",type="fake"} 65536
+kubelet_volume_stats_inodes_free{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-1",type="fake"} 65536
+# HELP kubelet_volume_stats_inodes Total number of inodes in the volume
+# TYPE kubelet_volume_stats_inodes gauge
+kubelet_volume_stats_inodes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-0",type="fake"} 65536
+kubelet_volume_stats_inodes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-1",type="fake"} 65536
+# HELP fake_metrics_stage Current stage information
+# TYPE fake_metrics_stage gauge
+fake_metrics_sts_bytes_low_1Gi{stage="1",description="bytes_low"} 1

--- a/config/overlays/kind/fake-metrics/sts_bytes_low_2Gi.txt
+++ b/config/overlays/kind/fake-metrics/sts_bytes_low_2Gi.txt
@@ -1,0 +1,19 @@
+# HELP kubelet_volume_stats_available_bytes Number of available bytes in the volume
+# TYPE kubelet_volume_stats_available_bytes gauge
+kubelet_volume_stats_available_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-0",type="fake"} 2147483648
+kubelet_volume_stats_available_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-1",type="fake"} 2147483648
+# HELP kubelet_volume_stats_capacity_bytes Total capacity of the volume in bytes
+# TYPE kubelet_volume_stats_capacity_bytes gauge
+kubelet_volume_stats_capacity_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-0",type="fake"} 2147483648
+kubelet_volume_stats_capacity_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-1",type="fake"} 2147483648
+# HELP kubelet_volume_stats_inodes_free Number of free inodes in the volume
+# TYPE kubelet_volume_stats_inodes_free gauge
+kubelet_volume_stats_inodes_free{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-0",type="fake"} 131072
+kubelet_volume_stats_inodes_free{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-1",type="fake"} 131072
+# HELP kubelet_volume_stats_inodes Total number of inodes in the volume
+# TYPE kubelet_volume_stats_inodes gauge
+kubelet_volume_stats_inodes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-0",type="fake"} 131072
+kubelet_volume_stats_inodes{namespace="pvc-autoscaler-system",persistentvolumeclaim="data-test-sts-4-1",type="fake"} 131072
+# HELP fake_metrics_stage Current stage information
+# TYPE fake_metrics_stage gauge
+fake_metrics_sts_bytes_low_2Gi{stage="3",description="bytes_low"} 1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - "*"
+  resources:
+  - "*/scale"
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - events
@@ -20,6 +28,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -259,6 +259,85 @@ function _test_cooldown() {
   _cleanup "${_pod_name}" "${_pvc_name}" "${_pvca_name}" "${_namespace}"
 }
 
+# Tests the PVC autoscaler when targeting a StatefulSet. The PVCA selects a
+# StatefulSet via its scale subresource, the controller resolves the matching
+# pods and the PVCs they reference, and resizes all of them when the threshold
+# is reached.
+function _test_consume_space_and_resize_statefulset() {
+  local _sts_yaml="${_TEST_MANIFESTS_DIR}/sts-4.yaml"
+  local _pvca_yaml="${_TEST_MANIFESTS_DIR}/pvca-4.yaml"
+  local _sts_name=$( yq '.metadata.name' "${_sts_yaml}" )
+  local _pvca_name=$( yq '.metadata.name' "${_pvca_yaml}" )
+  local _namespace=$( yq '.metadata.namespace // "default"' "${_sts_yaml}" )
+  local _pvc_0="data-${_sts_name}-0"
+  local _pvc_1="data-${_sts_name}-1"
+
+  _msg_info "starting test: target StatefulSet, consume space and resize"
+  _msg_info "creating test statefulset and pvca ..."
+  kubectl create -f "${_sts_yaml}"
+  kubectl create -f "${_pvca_yaml}"
+
+  _msg_info "waiting for statefulset pods to be ready ..."
+  kubectl rollout status "statefulset/${_sts_name}" \
+          --namespace "${_namespace}" \
+          --timeout 10m
+
+  ${_SCRIPT_DIR}/set-volume-metrics-stage.sh sts_bytes_low_1Gi
+  _msg_info "waiting for PVC Autoscaler resource to have RecommendationAvailable condition ..."
+  kubectl wait "pvca/${_pvca_name}" \
+          --for condition=RecommendationAvailable \
+          --namespace "${_namespace}" \
+          --timeout 10m
+
+  # The StatefulSet's volumeClaimTemplate provisions PVCs at 1Gi.
+  _ensure_pvc_capacity "${_pvc_0}" "${_namespace}" 1Gi
+  _ensure_pvc_capacity "${_pvc_1}" "${_namespace}" 1Gi
+
+  # Drive both PVCs above the threshold simultaneously.
+  _msg_info "consuming 90% of the space on both PVCs ..."
+  ${_SCRIPT_DIR}/set-volume-metrics-stage.sh sts_bytes_high_1Gi
+
+  # Both PVCs should be picked up and resized by the same PVCA.
+  _wait_for_event Warning UsedSpaceThresholdReached "pvc/${_pvc_0}"
+  _wait_for_event Normal ResizingStorage "pvc/${_pvc_0}"
+  _wait_for_event Normal Resizing "pvc/${_pvc_0}"
+  _wait_for_event Normal FileSystemResizeSuccessful "pvc/${_pvc_0}"
+
+  _wait_for_event Warning UsedSpaceThresholdReached "pvc/${_pvc_1}"
+  _wait_for_event Normal ResizingStorage "pvc/${_pvc_1}"
+  _wait_for_event Normal Resizing "pvc/${_pvc_1}"
+  _wait_for_event Normal FileSystemResizeSuccessful "pvc/${_pvc_1}"
+
+  # Both PVCs should be at 2Gi now.
+  _ensure_pvc_capacity "${_pvc_0}" "${_namespace}" 2Gi
+  _ensure_pvc_capacity "${_pvc_1}" "${_namespace}" 2Gi
+
+  ${_SCRIPT_DIR}/set-volume-metrics-stage.sh sts_bytes_low_2Gi
+
+  _msg_info "waiting for PVC Autoscaler resource to have RecommendationAvailable condition ..."
+  kubectl wait "pvca/${_pvca_name}" \
+          --for condition=RecommendationAvailable \
+          --namespace "${_namespace}" \
+          --timeout 10m
+
+  _cleanup_statefulset "${_sts_name}" "${_pvca_name}" "${_namespace}" "${_pvc_0}" "${_pvc_1}"
+}
+
+# Cleanup helper for the StatefulSet-based test. StatefulSets do not delete
+# their PVCs, so we drop them explicitly.
+function _cleanup_statefulset() {
+  local _sts_name="${1}"
+  local _pvca_name="${2}"
+  local _namespace="${3}"
+  shift 3
+
+  kubectl --namespace "${_namespace}" delete pvca "${_pvca_name}"
+  kubectl --namespace "${_namespace}" delete statefulset "${_sts_name}"
+  for _pvc_name in "$@"; do
+    kubectl --namespace "${_namespace}" delete pvc "${_pvc_name}"
+  done
+}
+
 # Main entrypoint
 function _main() {  
   _msg_info "Waiting for pvc-autoscaler pods to become ready ..."
@@ -281,6 +360,11 @@ function _main() {
 
   if ! _test_cooldown; then
     _msg_error "test cooldown has failed" 0
+    _has_failed="true"
+  fi
+
+  if ! _test_consume_space_and_resize_statefulset; then
+    _msg_error "test consume space and resize for statefulset has failed" 0
     _has_failed="true"
   fi
 

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -54,7 +54,7 @@ function _test_consume_space_and_resize() {
   ${_SCRIPT_DIR}/set-volume-metrics-stage.sh pod_bytes_high_1Gi
 
   # Once we consume the space we expect to see these events for the PVC object.
-  _wait_for_event Warning FreeSpaceThresholdReached "pvc/${_pvc_name}"
+  _wait_for_event Warning UsedSpaceThresholdReached "pvc/${_pvc_name}"
   _wait_for_event Normal ResizingStorage "pvc/${_pvc_name}"
   _wait_for_event Normal Resizing "pvc/${_pvc_name}"
   _wait_for_event Normal FileSystemResizeSuccessful "pvc/${_pvc_name}"
@@ -139,7 +139,7 @@ function _test_consume_inodes_and_resize() {
   ${_SCRIPT_DIR}/set-volume-metrics-stage.sh pod_inode_high_1Gi
 
   # We should see these events
-  _wait_for_event Warning FreeInodesThresholdReached "pvc/${_pvc_name}"
+  _wait_for_event Warning UsedInodesThresholdReached "pvc/${_pvc_name}"
   _wait_for_event Normal ResizingStorage "pvc/${_pvc_name}"
   _wait_for_event Normal Resizing "pvc/${_pvc_name}"
   _wait_for_event Normal FileSystemResizeSuccessful "pvc/${_pvc_name}"
@@ -223,7 +223,7 @@ function _test_cooldown() {
   ${_SCRIPT_DIR}/set-volume-metrics-stage.sh pod_cooldown_high_1Gi
 
   # Once we consume the space we expect to see these events for the PVC object.
-  _wait_for_event Warning FreeSpaceThresholdReached "pvc/${_pvc_name}"
+  _wait_for_event Warning UsedSpaceThresholdReached "pvc/${_pvc_name}"
   _wait_for_event Normal ResizingStorage "pvc/${_pvc_name}"
   _wait_for_event Normal FileSystemResizeSuccessful "pvc/${_pvc_name}"
 

--- a/internal/periodic/conditions.go
+++ b/internal/periodic/conditions.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package periodic
+
+import (
+	"slices"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
+)
+
+// recommendationsConditionAggregator is a condition aggregator for the Recommended condition of the PVCA.
+type recommendationsConditionAggregator struct {
+	conditions []metav1.Condition
+}
+
+// addCondition adds a condition to the aggregator. Only conditions with false status can be aggregated.
+func (c *recommendationsConditionAggregator) addCondition(condition metav1.Condition) {
+	if condition.Status == metav1.ConditionFalse {
+		c.conditions = append(c.conditions, condition)
+	}
+}
+
+// getAggregatedCondition aggregates all conditions into one. If there are no false conditions, it
+// returns a true condition indicating that recommendations have been provided
+func (c *recommendationsConditionAggregator) getAggregatedCondition() metav1.Condition {
+	var (
+		status         = metav1.ConditionTrue
+		failureReasons = sets.New[string]()
+		failures       = make([]string, 0, len(c.conditions))
+	)
+
+	for _, condition := range c.conditions {
+		if condition.Status == metav1.ConditionFalse {
+			status = metav1.ConditionFalse
+			failureReasons.Insert(condition.Reason)
+			failures = append(failures, condition.Message)
+		}
+	}
+
+	if status == metav1.ConditionTrue {
+		return metav1.Condition{
+			Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+			Status:  metav1.ConditionTrue,
+			Reason:  ReasonRecommendationsProvided,
+			Message: "Recommendations have been provided",
+		}
+	}
+
+	slices.Sort(failures)
+	message := "Recommendations could not be provided for some PersistentVolumeClaims:"
+	for _, failure := range failures {
+		message = message + "\n- " + failure
+	}
+
+	reason := ReasonRecommendationsNotProvided
+	if failureReasons.Len() == 1 {
+		reason, _ = failureReasons.PopAny()
+	}
+
+	return metav1.Condition{
+		Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+		Reason:  reason,
+		Message: message,
+		Status:  status,
+	}
+}
+
+type resizingConditionAggregator struct {
+	conditions []metav1.Condition
+}
+
+func (c *resizingConditionAggregator) addCondition(condition metav1.Condition) {
+	c.conditions = append(c.conditions, condition)
+}
+
+func (c *resizingConditionAggregator) getAggregatedCondition() metav1.Condition {
+	if len(c.conditions) == 0 {
+		return metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}
+	}
+
+	var (
+		message           = "PersistentVolumeClaims cannot be resized:"
+		status            = metav1.ConditionFalse
+		conditionMessages = make([]string, 0, len(c.conditions))
+	)
+
+	for _, condition := range c.conditions {
+		conditionMessages = append(conditionMessages, condition.Message)
+		if condition.Status == metav1.ConditionTrue {
+			message = "PersistentVolumeClaims are being resized:"
+			status = metav1.ConditionTrue
+		}
+	}
+
+	slices.Sort(conditionMessages)
+	for _, conditionMessage := range conditionMessages {
+		message = message + "\n- " + conditionMessage
+	}
+
+	return metav1.Condition{
+		Type:    string(v1alpha1.ConditionTypeResizing),
+		Message: message,
+		Reason:  ReasonReconcile,
+		Status:  status,
+	}
+}

--- a/internal/periodic/conditions.go
+++ b/internal/periodic/conditions.go
@@ -13,12 +13,12 @@ import (
 	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 )
 
-// recommendationsConditionAggregator is a condition aggregator for the Recommended condition of the PVCA.
+// recommendationsConditionAggregator is a condition aggregator for the RecommendationAvailable condition of the PVCA.
 type recommendationsConditionAggregator struct {
 	conditions []metav1.Condition
 }
 
-// addCondition adds a condition to the aggregator. Only conditions with false status can be aggregated.
+// addCondition adds a condition to the aggregator. Only conditions with false status are aggregated.
 func (c *recommendationsConditionAggregator) addCondition(condition metav1.Condition) {
 	if condition.Status == metav1.ConditionFalse {
 		c.conditions = append(c.conditions, condition)
@@ -70,14 +70,19 @@ func (c *recommendationsConditionAggregator) getAggregatedCondition() metav1.Con
 	}
 }
 
+// resizingConditionAggregator is a condition aggregator for the Resizing condition of the PVCA.
 type resizingConditionAggregator struct {
 	conditions []metav1.Condition
 }
 
+// addCondition adds a condition to the aggregator
 func (c *resizingConditionAggregator) addCondition(condition metav1.Condition) {
 	c.conditions = append(c.conditions, condition)
 }
 
+// getAggregatedCondition aggregates all conditions into one. If there are no conditions, it returns an empty condition with the
+// Resizing type. If there is one condition with status true, the aggregated condition's status is also true to indicate that there
+// is a resize in progress.
 func (c *resizingConditionAggregator) getAggregatedCondition() metav1.Condition {
 	if len(c.conditions) == 0 {
 		return metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}

--- a/internal/periodic/conditions.go
+++ b/internal/periodic/conditions.go
@@ -91,11 +91,13 @@ func (c *resizingConditionAggregator) getAggregatedCondition() metav1.Condition 
 	var (
 		message           = "PersistentVolumeClaims cannot be resized:"
 		status            = metav1.ConditionFalse
+		reasons           = sets.New[string]()
 		conditionMessages = make([]string, 0, len(c.conditions))
 	)
 
 	for _, condition := range c.conditions {
 		conditionMessages = append(conditionMessages, condition.Message)
+		reasons.Insert(condition.Reason)
 		if condition.Status == metav1.ConditionTrue {
 			message = "PersistentVolumeClaims are being resized:"
 			status = metav1.ConditionTrue
@@ -107,10 +109,15 @@ func (c *resizingConditionAggregator) getAggregatedCondition() metav1.Condition 
 		message = message + "\n- " + conditionMessage
 	}
 
+	reason := ReasonReconcile
+	if reasons.Len() == 1 {
+		reason, _ = reasons.PopAny()
+	}
+
 	return metav1.Condition{
 		Type:    string(v1alpha1.ConditionTypeResizing),
 		Message: message,
-		Reason:  ReasonReconcile,
+		Reason:  reason,
 		Status:  status,
 	}
 }

--- a/internal/periodic/conditions.go
+++ b/internal/periodic/conditions.go
@@ -29,16 +29,16 @@ func (c *recommendationsConditionAggregator) addCondition(condition metav1.Condi
 // returns a true condition indicating that recommendations have been provided
 func (c *recommendationsConditionAggregator) getAggregatedCondition() metav1.Condition {
 	var (
-		status         = metav1.ConditionTrue
-		failureReasons = sets.New[string]()
-		failures       = make([]string, 0, len(c.conditions))
+		status          = metav1.ConditionTrue
+		failureReasons  = sets.New[string]()
+		failureMessages = make([]string, 0, len(c.conditions))
 	)
 
 	for _, condition := range c.conditions {
 		if condition.Status == metav1.ConditionFalse {
 			status = metav1.ConditionFalse
 			failureReasons.Insert(condition.Reason)
-			failures = append(failures, condition.Message)
+			failureMessages = append(failureMessages, condition.Message)
 		}
 	}
 
@@ -51,9 +51,9 @@ func (c *recommendationsConditionAggregator) getAggregatedCondition() metav1.Con
 		}
 	}
 
-	slices.Sort(failures)
+	slices.Sort(failureMessages)
 	message := "Recommendations could not be provided for some PersistentVolumeClaims:"
-	for _, failure := range failures {
+	for _, failure := range failureMessages {
 		message = message + "\n- " + failure
 	}
 

--- a/internal/periodic/conditions.go
+++ b/internal/periodic/conditions.go
@@ -59,6 +59,8 @@ func (c *recommendationsConditionAggregator) getAggregatedCondition() metav1.Con
 
 	reason := ReasonRecommendationsNotProvided
 	if failureReasons.Len() == 1 {
+		// The boolean return value is ignored as we are sure that there is at least one item
+		// in the set
 		reason, _ = failureReasons.PopAny()
 	}
 
@@ -84,6 +86,8 @@ func (c *resizingConditionAggregator) addCondition(condition metav1.Condition) {
 // Resizing type. If there is one condition with status true, the aggregated condition's status is also true to indicate that there
 // is a resize in progress.
 func (c *resizingConditionAggregator) getAggregatedCondition() metav1.Condition {
+	// When there are 0 conditions, return a condition with empty fields, except for the Resizing type.
+	// This can be used in calling functions to determine whether the condition can be removed from the status of the PVCA.
 	if len(c.conditions) == 0 {
 		return metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}
 	}
@@ -111,6 +115,8 @@ func (c *resizingConditionAggregator) getAggregatedCondition() metav1.Condition 
 
 	reason := ReasonReconcile
 	if reasons.Len() == 1 {
+		// The boolean return value is ignored as we are sure that there is at least one item
+		// in the set
 		reason, _ = reasons.PopAny()
 	}
 

--- a/internal/periodic/conditions_test.go
+++ b/internal/periodic/conditions_test.go
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package periodic
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
+)
+
+var _ = Describe("recommendationsConditionAggregator", func() {
+	var aggregator *recommendationsConditionAggregator
+
+	BeforeEach(func() {
+		aggregator = &recommendationsConditionAggregator{}
+	})
+
+	It("should return a true condition when no condition aggregated", func() {
+		condition := metav1.Condition{
+			Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+			Status:  metav1.ConditionTrue,
+			Reason:  ReasonRecommendationsProvided,
+			Message: "Recommendations have been provided",
+		}
+
+		Expect(aggregator.getAggregatedCondition()).To(Equal(condition))
+	})
+
+	It("should aggregate to False and only list failed conditions when any condition is False", func() {
+		aggregator.addCondition(metav1.Condition{
+			Status:  metav1.ConditionTrue,
+			Reason:  ReasonMetricsFetched,
+			Message: "pvc-a: ok",
+		})
+		aggregator.addCondition(metav1.Condition{
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonMetricsFetchError,
+			Message: "pvc-b: stale metrics",
+		})
+
+		got := aggregator.getAggregatedCondition()
+		Expect(got.Status).To(Equal(metav1.ConditionFalse))
+		Expect(got.Reason).To(Equal(ReasonMetricsFetchError))
+		Expect(got.Message).To(Equal("Recommendations could not be provided for some PersistentVolumeClaims:\n- pvc-b: stale metrics"))
+	})
+
+	It("should use RecommendationsNotProvided when failed conditions disagree on reason", func() {
+		aggregator.addCondition(metav1.Condition{
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonMetricsFetchError,
+			Message: "Recommendations could not be provided for some PersistentVolumeClaims:\n- pvc-a: stale metrics",
+		})
+		aggregator.addCondition(metav1.Condition{
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonRecommendationError,
+			Message: "Recommendations could not be provided for some PersistentVolumeClaims:\n- pvc-b: invalid",
+		})
+
+		got := aggregator.getAggregatedCondition()
+		Expect(got.Status).To(Equal(metav1.ConditionFalse))
+		Expect(got.Reason).To(Equal(ReasonRecommendationsNotProvided))
+	})
+
+	It("should sort failure messages deterministically regardless of insertion order", func() {
+		aggregator.addCondition(metav1.Condition{
+			Status: metav1.ConditionFalse, Reason: ReasonMetricsFetchError, Message: "pvc-c: failed",
+		})
+		aggregator.addCondition(metav1.Condition{
+			Status: metav1.ConditionFalse, Reason: ReasonMetricsFetchError, Message: "pvc-a: failed",
+		})
+		aggregator.addCondition(metav1.Condition{
+			Status: metav1.ConditionFalse, Reason: ReasonMetricsFetchError, Message: "pvc-b: failed",
+		})
+
+		got := aggregator.getAggregatedCondition()
+		Expect(got.Message).To(Equal("Recommendations could not be provided for some PersistentVolumeClaims:\n- pvc-a: failed\n- pvc-b: failed\n- pvc-c: failed"))
+	})
+})
+
+var _ = Describe("resizingConditionAggregator", func() {
+	var aggregator *resizingConditionAggregator
+
+	BeforeEach(func() {
+		aggregator = &resizingConditionAggregator{}
+	})
+
+	It("should return a Condition with only Type set when no conditions were added", func() {
+		Expect(aggregator.getAggregatedCondition()).To(Equal(metav1.Condition{
+			Type: string(v1alpha1.ConditionTypeResizing),
+		}))
+	})
+
+	It("should return the only condition one was added", func() {
+		condition := metav1.Condition{
+			Type:    string(v1alpha1.ConditionTypeResizing),
+			Status:  metav1.ConditionTrue,
+			Reason:  ReasonReconcile,
+			Message: "pvc-a: resizing from 1Gi to 2Gi",
+		}
+		aggregator.addCondition(condition)
+
+		expectedCondition := condition
+		expectedCondition.Message = "PersistentVolumeClaims are being resized:\n- pvc-a: resizing from 1Gi to 2Gi"
+		Expect(aggregator.getAggregatedCondition()).To(Equal(expectedCondition))
+	})
+
+	It("should aggregate to True when any condition is True", func() {
+		aggregator.addCondition(metav1.Condition{
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonReconcile,
+			Message: "pvc-a: max capacity reached",
+		})
+		aggregator.addCondition(metav1.Condition{
+			Status:  metav1.ConditionTrue,
+			Reason:  ReasonReconcile,
+			Message: "pvc-b: resizing from 1Gi to 2Gi",
+		})
+
+		got := aggregator.getAggregatedCondition()
+		Expect(got.Type).To(Equal(string(v1alpha1.ConditionTypeResizing)))
+		Expect(got.Reason).To(Equal(ReasonReconcile))
+		Expect(got.Status).To(Equal(metav1.ConditionTrue))
+		Expect(got.Message).To(Equal("PersistentVolumeClaims are being resized:\n- pvc-a: max capacity reached\n- pvc-b: resizing from 1Gi to 2Gi"))
+	})
+
+	It("should aggregate to False when all conditions are False", func() {
+		aggregator.addCondition(metav1.Condition{
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonPVCResizeCooldown,
+			Message: "pvc-a: cooldown duration has not elapsed yet",
+		})
+		aggregator.addCondition(metav1.Condition{
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonReconcile,
+			Message: "pvc-b: max capacity reached",
+		})
+
+		got := aggregator.getAggregatedCondition()
+		Expect(got.Type).To(Equal(string(v1alpha1.ConditionTypeResizing)))
+		Expect(got.Reason).To(Equal(ReasonReconcile))
+		Expect(got.Status).To(Equal(metav1.ConditionFalse))
+		Expect(got.Message).To(Equal("PersistentVolumeClaims cannot be resized:\n- pvc-a: cooldown duration has not elapsed yet\n- pvc-b: max capacity reached"))
+	})
+
+	It("should sort messages deterministically regardless of insertion order", func() {
+		aggregator.addCondition(metav1.Condition{
+			Status: metav1.ConditionTrue, Message: "pvc-c: resizing",
+		})
+		aggregator.addCondition(metav1.Condition{
+			Status: metav1.ConditionTrue, Message: "pvc-a: resizing",
+		})
+		aggregator.addCondition(metav1.Condition{
+			Status: metav1.ConditionTrue, Message: "pvc-b: resizing",
+		})
+
+		got := aggregator.getAggregatedCondition()
+		Expect(got.Message).To(Equal("PersistentVolumeClaims are being resized:\n- pvc-a: resizing\n- pvc-b: resizing\n- pvc-c: resizing"))
+	})
+})

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -292,7 +292,9 @@ func (r *Runner) reconcilePVCA(
 		return
 	}
 
-	ok, scalingReason, err := r.shouldReconcilePVC(ctx, pvca, pvc, volInfo)
+	policy := volumePolicyForPVC(pvca, pvc)
+
+	ok, scalingReason, err := r.shouldReconcilePVC(ctx, pvca, pvc, policy, volInfo)
 	if err != nil {
 		logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
 		metrics.SkippedTotal.WithLabelValues(pvca.Namespace, pvca.Name, err.Error()).Inc()
@@ -323,7 +325,7 @@ func (r *Runner) reconcilePVCA(
 	}
 
 	if ok && !inProgress {
-		if err := r.resizePVC(ctx, pvca, pvc, scalingReason); err != nil {
+		if err := r.resizePVC(ctx, pvca, pvc, policy, scalingReason); err != nil {
 			logger.Error(err, "failed to resize pvc")
 		}
 	} else if err := pvca.RemoveCondition(ctx, r.client, string(v1alpha1.ConditionTypeResizing)); err != nil {
@@ -377,11 +379,20 @@ func (r *Runner) updatePVCAStatus(ctx context.Context, obj *v1alpha1.PersistentV
 	return r.client.Status().Patch(ctx, obj, patch)
 }
 
+// volumePolicyForPVC returns the volume policy from the given
+// [v1alpha1.PersistentVolumeClaimAutoscaler] that applies to the specified PVC.
+// Currently only one volume policy is supported, so the first policy is always
+// returned. When multi-PVC support is added, this function will match the
+// policy to the specific PVC.
+func volumePolicyForPVC(pvca *v1alpha1.PersistentVolumeClaimAutoscaler, _ *corev1.PersistentVolumeClaim) v1alpha1.VolumePolicy {
+	return pvca.Spec.VolumePolicies[0]
+}
+
 // shouldReconcilePVC is a predicate which checks whether the
 // [corev1.PersistentVolumeClaim] object targeted by
 // [v1alpha1.PersistentVolumeClaimAutoscaler] should be considered for
 // reconciliation. When it returns true, it also returns the scaling reason.
-func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, volInfo *metricssource.VolumeInfo) (bool, string, error) {
+func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, volInfo *metricssource.VolumeInfo) (bool, string, error) {
 	if err := r.updatePVCAStatus(ctx, pvca, volInfo); err != nil {
 		return false, "", err
 	}
@@ -397,8 +408,6 @@ func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.Persiste
 		return false, "", fmt.Errorf(".status.capacity.storage is invalid: %s", currStatusSize.String())
 	}
 
-	// Only one volume policy is supported currently
-	policy := pvca.Spec.VolumePolicies[0]
 	if policy.MaxCapacity.Value() < currStatusSize.Value() {
 		return false, "", fmt.Errorf("max capacity (%s) cannot be less than current size (%s)", policy.MaxCapacity.String(), currStatusSize.String())
 	}
@@ -559,12 +568,9 @@ func (r *Runner) isResizeInProgress(ctx context.Context, pvca *v1alpha1.Persiste
 
 // resizePVC performs the actual resize of the PVC targeted by the given
 // [v1alpha1.PersistentVolumeClaimAutoscaler].
-func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, scalingReason string) error {
+func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, scalingReason string) error {
 	logger := log.FromContext(ctx).WithValues("pvc", pvc.Name)
 	currSpecSize := pvc.Spec.Resources.Requests.Storage()
-
-	// Currently only one policy is supported, since only one PVC can be targeted by a PVCA object
-	policy := pvca.Spec.VolumePolicies[0]
 
 	// Calculate the new size
 	stepPercent := float64(*policy.ScaleUp.StepPercent)

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -209,73 +209,7 @@ func (r *Runner) reconcileAll(ctx context.Context) error {
 	pvcaToPVCsMap, pvcToOwnersMap := r.fetchPVCsForPVCAs(ctx, logger, pvcaList.Items)
 
 	for pvca, pvcs := range pvcaToPVCsMap {
-		logger := logger.WithValues("pvca", client.ObjectKeyFromObject(pvca))
-
-		// TODO(plkokanov): When multi-PVC support is added, this must be updated to iterate over all PVCs.
-		// Currently, the PVCA can only target one PVC, so we only get the first element.
-		// Because of that, we can also skip reconciling the PVCA resource if
-		// other PVCAs also target the same PVC.
-		pvc := pvcs[0]
-		pvcObjKey := client.ObjectKeyFromObject(pvc)
-		logger = logger.WithValues("pvc", pvcObjKey)
-
-		if owners, ok := pvcToOwnersMap[pvcObjKey.String()]; ok && len(owners) > 1 {
-			logger.Info("skipping persistentvolumeclaim because it is scaled by multiple persistentvolumeclaimautoscalers", "pvcas", strings.Join(owners, ", "))
-			condition := metav1.Condition{
-				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
-				Status:  metav1.ConditionFalse,
-				Reason:  ReasonAmbiguousPVCA,
-				Message: fmt.Sprintf("PersistentVolumeClaim %s is scaled by multiple PersistentVolumeClaimAutoscalers: %s", pvcObjKey, strings.Join(owners, ", ")),
-			}
-			if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
-				logger.Info("failed to update status condition", "reason", err.Error())
-			}
-
-			continue
-		}
-
-		volInfo := metricsData[pvcObjKey]
-
-		ok, scalingReason, err := r.shouldReconcilePVC(ctx, pvca, volInfo)
-		if err != nil {
-			logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
-			metrics.SkippedTotal.WithLabelValues(pvca.Namespace, pvca.Name, err.Error()).Inc()
-			var conditionReason string
-			if errors.Is(err, common.ErrNoMetrics) {
-				conditionReason = ReasonMetricsFetchError
-			} else {
-				conditionReason = ReasonRecommendationError
-			}
-			condition := metav1.Condition{
-				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
-				Status:  metav1.ConditionFalse,
-				Reason:  conditionReason,
-				Message: fmt.Sprintf(" - %s: %s", pvcObjKey.Name, err.Error()),
-			}
-			if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
-				logger.Info("failed to update status condition", "reason", err.Error())
-			}
-
-			continue
-		}
-
-		if ok {
-			if err := r.resizePVC(ctx, pvca, scalingReason); err != nil {
-				logger.Error(err, "failed to resize pvc")
-			}
-		} else if err := pvca.RemoveCondition(ctx, r.client, string(v1alpha1.ConditionTypeResizing)); err != nil {
-			logger.Info("failed to remove status condition", "reason", err.Error())
-		}
-
-		condition := metav1.Condition{
-			Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
-			Status:  metav1.ConditionTrue,
-			Reason:  ReasonMetricsFetched,
-			Message: " - All metrics fetched successfully",
-		}
-		if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
-			logger.Info("failed to update status condition", "reason", err.Error())
-		}
+		r.reconcilePVCA(ctx, logger, pvca, pvcs, pvcToOwnersMap, metricsData)
 	}
 
 	return nil
@@ -316,6 +250,83 @@ func (r *Runner) fetchPVCsForPVCAs(ctx context.Context, logger logr.Logger, pers
 	}
 
 	return pvcaToPVCsMap, pvcToOwnersMap
+}
+
+func (r *Runner) reconcilePVCA(
+	ctx context.Context,
+	logger logr.Logger,
+	pvca *v1alpha1.PersistentVolumeClaimAutoscaler,
+	pvcs []*corev1.PersistentVolumeClaim,
+	pvcToOwnersMap map[string][]string,
+	metricsData metricssource.Metrics,
+) {
+	logger = logger.WithValues("pvca", client.ObjectKeyFromObject(pvca))
+
+	// TODO(plkokanov): When multi-PVC support is added, this must be updated to iterate over all PVCs.
+	// Currently, the PVCA can only target one PVC, so we only get the first element.
+	// Because of that, we can also skip reconciling the PVCA resource if
+	// other PVCAs also target the same PVC.
+	pvc := pvcs[0]
+	pvcObjKey := client.ObjectKeyFromObject(pvc)
+	logger = logger.WithValues("pvc", pvcObjKey)
+
+	if owners, ok := pvcToOwnersMap[pvcObjKey.String()]; ok && len(owners) > 1 {
+		logger.Info("skipping persistentvolumeclaim because it is scaled by multiple persistentvolumeclaimautoscalers", "pvcas", strings.Join(owners, ", "))
+		condition := metav1.Condition{
+			Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonAmbiguousPVCA,
+			Message: fmt.Sprintf("PersistentVolumeClaim %s is scaled by multiple PersistentVolumeClaimAutoscalers: %s", pvcObjKey, strings.Join(owners, ", ")),
+		}
+		if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
+			logger.Info("failed to update status condition", "reason", err.Error())
+		}
+
+		return
+	}
+
+	volInfo := metricsData[pvcObjKey]
+
+	ok, scalingReason, err := r.shouldReconcilePVC(ctx, pvca, volInfo)
+	if err != nil {
+		logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
+		metrics.SkippedTotal.WithLabelValues(pvca.Namespace, pvca.Name, err.Error()).Inc()
+		var conditionReason string
+		if errors.Is(err, common.ErrNoMetrics) {
+			conditionReason = ReasonMetricsFetchError
+		} else {
+			conditionReason = ReasonRecommendationError
+		}
+		condition := metav1.Condition{
+			Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+			Status:  metav1.ConditionFalse,
+			Reason:  conditionReason,
+			Message: fmt.Sprintf(" - %s: %s", pvcObjKey.Name, err.Error()),
+		}
+		if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
+			logger.Info("failed to update status condition", "reason", err.Error())
+		}
+
+		return
+	}
+
+	if ok {
+		if err := r.resizePVC(ctx, pvca, scalingReason); err != nil {
+			logger.Error(err, "failed to resize pvc")
+		}
+	} else if err := pvca.RemoveCondition(ctx, r.client, string(v1alpha1.ConditionTypeResizing)); err != nil {
+		logger.Info("failed to remove status condition", "reason", err.Error())
+	}
+
+	condition := metav1.Condition{
+		Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+		Status:  metav1.ConditionTrue,
+		Reason:  ReasonMetricsFetched,
+		Message: " - All metrics fetched successfully",
+	}
+	if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
+		logger.Info("failed to update status condition", "reason", err.Error())
+	}
 }
 
 // updatePVCAStatus updates the status of the

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -321,6 +321,7 @@ func (r *Runner) reconcilePVCA(
 				Reason:  ReasonPVCFetchError,
 				Message: fmt.Sprintf("Failed to get PersistentVolumeClaim %s: %s", pvcObjKey, err.Error()),
 			})
+
 			continue
 		}
 
@@ -363,7 +364,6 @@ func (r *Runner) reconcilePVCA(
 		}
 
 		setVolumeRecommendationForPVC(&volumeRecommendations, pvc.Name, volumeRecommendation)
-
 	}
 
 	if err := r.setStatus(ctx, pvca, recommendationConditons.getAggregatedCondition(), resizingConditions.getAggregatedCondition(), volumeRecommendations); err != nil {
@@ -440,6 +440,7 @@ func setVolumeRecommendationForPVC(volumeRecommendations *[]v1alpha1.VolumeRecom
 	for i := range *volumeRecommendations {
 		if (*volumeRecommendations)[i].Name == pvcName {
 			(*volumeRecommendations)[i] = volumeRecommendation
+
 			return
 		}
 	}
@@ -682,6 +683,7 @@ func (r *Runner) resizePVC(ctx context.Context, pvc *corev1.PersistentVolumeClai
 			Reason:  ReasonReconcile,
 			Message: fmt.Sprintf("%s: could not patch PersistentVolumeClaim with new target size %s", pvc.Name, targetSize.String()),
 		})
+
 		return volumeRecommendation, err
 	}
 

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -431,23 +431,23 @@ func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.Persiste
 		}
 	}
 
-	// Getting an error from FreeSpacePercentage() means that the
+	// Getting an error from UsedSpacePercentage() means that the
 	// capacity for the volume is zero, which in turn means that we
 	// didn't get any metrics for it.
-	freeSpace, err := volInfo.FreeSpacePercentage()
+	usedSpace, err := volInfo.UsedSpacePercentage()
 	if err != nil {
 		return false, "", common.ErrNoMetrics
 	}
 
 	// Even, if we don't have inode metrics we still want to proceed here.
-	freeInodes, err := volInfo.FreeInodesPercentage()
+	usedInodes, err := volInfo.UsedInodesPercentage()
 	if err != nil {
 		return false, "", common.ErrNoMetrics
 	}
 
 	// Get threshold from volume policy
 	// Currently only one policy is supported and is enforced by the CRD schema
-	threshold := 100 - *policy.ScaleUp.UtilizationThresholdPercent
+	threshold := *policy.ScaleUp.UtilizationThresholdPercent
 
 	// VolumeMode should be Filesystem
 	if pvc.Spec.VolumeMode == nil {
@@ -463,28 +463,28 @@ func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.Persiste
 	}
 
 	switch {
-	// Free space reached threshold
-	case freeSpace < threshold:
+	// Used space reached threshold
+	case usedSpace > threshold:
 		r.eventRecorder.Eventf(
 			pvc,
 			corev1.EventTypeWarning,
-			"FreeSpaceThresholdReached",
-			"free space (%d%%) is less than the configured threshold (%d%%)",
-			freeSpace,
+			"UsedSpaceThresholdReached",
+			"used space (%d%%) exceeds the configured threshold (%d%%)",
+			usedSpace,
 			threshold,
 		)
 		metrics.ThresholdReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name, "space").Inc()
 
 		return true, "passing storage threshold", nil
 
-	// Free inodes reached threshold
-	case volInfo.CapacityInodes > 0.0 && (freeInodes < threshold):
+	// Used inodes reached threshold
+	case volInfo.CapacityInodes > 0.0 && (usedInodes > threshold):
 		r.eventRecorder.Eventf(
 			pvc,
 			corev1.EventTypeWarning,
-			"FreeInodesThresholdReached",
-			"free inodes (%d%%) are less than the configured threshold (%d%%)",
-			freeInodes,
+			"UsedInodesThresholdReached",
+			"used inodes (%d%%) exceeds the configured threshold (%d%%)",
+			usedInodes,
 			threshold,
 		)
 		metrics.ThresholdReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name, "inodes").Inc()

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -246,6 +246,8 @@ func (r *Runner) fetchPVCsForPVCAs(ctx context.Context, logger logr.Logger, pers
 				Message: fmt.Sprintf("Failed to fetch PersistentVolumeClaims for PersistentVolumeClaimAutoscaler: %s", err.Error()),
 			}
 
+			// If the resizing condition is already set on the PVCA resource due to an ongoing resize, set it to Unknown here as
+			// it is not possible to check the actual resizing status of the PVCs, if they cannot be fetched.
 			resizingCondition := metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}
 			if existing := meta.FindStatusCondition(pvca.Status.Conditions, resizingCondition.Type); existing != nil {
 				resizingCondition = metav1.Condition{

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -285,7 +285,7 @@ func (r *Runner) reconcilePVCA(
 	logger = logger.WithValues("pvca", client.ObjectKeyFromObject(pvca))
 
 	resizingConditions := &resizingConditionAggregator{}
-	recommendationConditons := &recommendationsConditionAggregator{}
+	recommendationConditions := &recommendationsConditionAggregator{}
 
 	volumeRecommendations := make([]v1alpha1.VolumeRecommendation, 0, len(pvcs))
 	for _, volumeRecommendation := range pvca.Status.VolumeRecommendations {
@@ -302,7 +302,7 @@ func (r *Runner) reconcilePVCA(
 
 		if owners, ok := pvcToOwnersMap[pvcObjKey.String()]; ok && len(owners) > 1 {
 			logger.Info("skipping persistentvolumeclaim because it is scaled by multiple persistentvolumeclaimautoscalers", "pvcas", strings.Join(owners, ", "))
-			recommendationConditons.addCondition(metav1.Condition{
+			recommendationConditions.addCondition(metav1.Condition{
 				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
 				Status:  metav1.ConditionFalse,
 				Reason:  ReasonAmbiguousPVCA,
@@ -315,7 +315,7 @@ func (r *Runner) reconcilePVCA(
 		// Get a fresh copy of the pvc object.
 		if err := r.client.Get(ctx, pvcObjKey, pvc); err != nil {
 			logger.Info("failed to get persistentvolumeclaim", "reason", err.Error())
-			recommendationConditons.addCondition(metav1.Condition{
+			recommendationConditions.addCondition(metav1.Condition{
 				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
 				Status:  metav1.ConditionFalse,
 				Reason:  ReasonPVCFetchError,
@@ -329,7 +329,7 @@ func (r *Runner) reconcilePVCA(
 
 		if err := r.validatePVC(ctx, pvc, policy); err != nil {
 			logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
-			recommendationConditons.addCondition(metav1.Condition{
+			recommendationConditions.addCondition(metav1.Condition{
 				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
 				Status:  metav1.ConditionFalse,
 				Reason:  ReasonRecommendationError,
@@ -343,7 +343,7 @@ func (r *Runner) reconcilePVCA(
 		if err != nil {
 			logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
 			metrics.SkippedTotal.WithLabelValues(pvca.Namespace, pvca.Name, err.Error()).Inc()
-			recommendationConditons.addCondition(metav1.Condition{
+			recommendationConditions.addCondition(metav1.Condition{
 				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
 				Status:  metav1.ConditionFalse,
 				Reason:  ReasonMetricsFetchError,
@@ -366,7 +366,7 @@ func (r *Runner) reconcilePVCA(
 		setVolumeRecommendationForPVC(&volumeRecommendations, pvc.Name, volumeRecommendation)
 	}
 
-	if err := r.setStatus(ctx, pvca, recommendationConditons.getAggregatedCondition(), resizingConditions.getAggregatedCondition(), volumeRecommendations); err != nil {
+	if err := r.setStatus(ctx, pvca, recommendationConditions.getAggregatedCondition(), resizingConditions.getAggregatedCondition(), volumeRecommendations); err != nil {
 		logger.Error(err, "failed to update PVCA status")
 	}
 }

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -243,7 +243,7 @@ func (r *Runner) fetchPVCsForPVCAs(ctx context.Context, logger logr.Logger, pers
 				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
 				Status:  metav1.ConditionFalse,
 				Reason:  ReasonPVCFetchError,
-				Message: fmt.Sprintf("failed to fetch PersistentVolumeClaims for PersistentVolumeClaimAutoscaler: %s", err.Error()),
+				Message: fmt.Sprintf("Failed to fetch PersistentVolumeClaims for PersistentVolumeClaimAutoscaler: %s", err.Error()),
 			}
 
 			resizingCondition := metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}
@@ -256,7 +256,7 @@ func (r *Runner) fetchPVCsForPVCAs(ctx context.Context, logger logr.Logger, pers
 				}
 			}
 
-			if err := r.setStatus(ctx, &pvca, recommendationsCondition, resizingCondition, pvca.Status.VolumeRecommendations); err != nil {
+			if err := r.setStatus(ctx, &pvca, recommendationsCondition, resizingCondition, []v1alpha1.VolumeRecommendation{}); err != nil {
 				logger.Error(err, "failed to update PVCA status", "pvca", pvcaKey)
 			}
 

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -288,7 +288,6 @@ func (r *Runner) reconcilePVCA(
 		return
 	}
 
-	volInfo := metricsData[pvcObjKey]
 	// Get a fresh copy of the pvc object.
 	if err := r.client.Get(ctx, pvcObjKey, pvc); err != nil {
 		logger.Info("failed to get persistentvolumeclaim", "reason", err.Error())
@@ -313,7 +312,7 @@ func (r *Runner) reconcilePVCA(
 		return
 	}
 
-	ok, scalingReason, err := r.shouldReconcilePVC(ctx, pvca, pvc, policy, volInfo)
+	volumeRecommendation, err := r.updateVolumeRecommendationForPVC(ctx, pvca, pvc, metricsData[pvcObjKey])
 	if err != nil {
 		logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
 		metrics.SkippedTotal.WithLabelValues(pvca.Namespace, pvca.Name, err.Error()).Inc()
@@ -330,20 +329,6 @@ func (r *Runner) reconcilePVCA(
 		return
 	}
 
-	inProgress, err := r.isResizeInProgress(ctx, pvca, pvc, scalingReason)
-	if err != nil {
-		logger.Info("failed to determine whether persistentvolumeclaim is being resized", "reason", err.Error())
-		return
-	}
-
-	if ok && !inProgress {
-		if err := r.resizePVC(ctx, pvca, pvc, policy, scalingReason); err != nil {
-			logger.Error(err, "failed to resize pvc")
-		}
-	} else if err := pvca.RemoveCondition(ctx, r.client, string(v1alpha1.ConditionTypeResizing)); err != nil {
-		logger.Info("failed to remove status condition", "reason", err.Error())
-	}
-
 	condition := metav1.Condition{
 		Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
 		Status:  metav1.ConditionTrue,
@@ -353,42 +338,68 @@ func (r *Runner) reconcilePVCA(
 	if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
 		logger.Info("failed to update status condition", "reason", err.Error())
 	}
+
+	shouldResize, scalingReason := r.shouldResizePVC(ctx, pvca, pvc, policy, volumeRecommendation)
+
+	inProgress, err := r.isResizeInProgress(ctx, pvca, pvc, scalingReason)
+	if err != nil {
+		logger.Info("failed to determine whether persistentvolumeclaim is being resized", "reason", err.Error())
+		return
+	}
+
+	if shouldResize && !inProgress {
+		if err := r.resizePVC(ctx, pvca, pvc, policy, scalingReason, volumeRecommendation); err != nil {
+			logger.Error(err, "failed to resize pvc")
+		}
+	} else if err := pvca.RemoveCondition(ctx, r.client, string(v1alpha1.ConditionTypeResizing)); err != nil {
+		logger.Info("failed to remove status condition", "reason", err.Error())
+	}
 }
 
-// updatePVCAStatus updates the status of the
+// updateVolumeRecommendations updates the status of the
 // [v1alpha1.PersistentVolumeClaimAutoscaler] with the latest observed
 // information about the target [corev1.PersistentVolumeClaim].
-func (r *Runner) updatePVCAStatus(ctx context.Context, obj *v1alpha1.PersistentVolumeClaimAutoscaler, volInfo *metricssource.VolumeInfo) error {
+func (r *Runner) updateVolumeRecommendationForPVC(ctx context.Context, obj *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, volInfo *metricssource.VolumeInfo) (v1alpha1.VolumeRecommendation, error) {
 	patch := client.MergeFrom(obj.DeepCopy())
 	now := time.Now()
 	obj.Status.LastCheck = metav1.NewTime(now)
 	obj.Status.NextCheck = metav1.NewTime(now.Add(r.interval))
 
-	// Start with existing recommendation to preserve fields set during resize,
-	// or create a new one if none exists
-	var volumeRecommendation v1alpha1.VolumeRecommendation
-	if len(obj.Status.VolumeRecommendations) > 0 {
-		volumeRecommendation = obj.Status.VolumeRecommendations[0]
-	}
-	volumeRecommendation.Name = obj.Spec.TargetRef.Name
+	volumeRecommendation := getOrCreateVolumeRecommendationForPVC(obj, pvc.Name)
 
-	if volInfo != nil {
-		usedSpace, err := volInfo.UsedSpacePercentage()
-		if err != nil {
-			return fmt.Errorf("failed to get used space percentage: %w", err)
-		}
-		volumeRecommendation.Current.UsedSpacePercent = &usedSpace
-
-		usedInodes, err := volInfo.UsedInodesPercentage()
-		if err != nil {
-			return fmt.Errorf("failed to get used inodes percentage: %w", err)
-		}
-		volumeRecommendation.Current.UsedInodesPercent = &usedInodes
+	// No metrics found, nothing to do for now
+	if volInfo == nil {
+		return v1alpha1.VolumeRecommendation{}, common.ErrNoMetrics
 	}
 
-	obj.Status.VolumeRecommendations = []v1alpha1.VolumeRecommendation{volumeRecommendation}
+	usedSpace, err := volInfo.UsedSpacePercentage()
+	if err != nil {
+		return v1alpha1.VolumeRecommendation{}, fmt.Errorf("failed to get used space percentage: %w", err)
+	}
+	volumeRecommendation.Current.UsedSpacePercent = &usedSpace
 
-	return r.client.Status().Patch(ctx, obj, patch)
+	usedInodes, err := volInfo.UsedInodesPercentage()
+	if err != nil {
+		return v1alpha1.VolumeRecommendation{}, fmt.Errorf("failed to get used inodes percentage: %w", err)
+	}
+	volumeRecommendation.Current.UsedInodesPercent = &usedInodes
+
+	currStatusSize := pvc.Status.Capacity.Storage()
+
+	// Detect whether the metrics source is reporting stale data. Stale
+	// metrics data would be when the volume info metrics reported by the
+	// metrics source deviate from the current PVC size indicated by
+	// `.status.capacity.storage'
+	if statusSize, ok := currStatusSize.AsInt64(); ok {
+		delta := math.Abs(float64(statusSize) - float64(volInfo.CapacityBytes))
+		tolerance := math.Max(common.MaxCapacityDeviationRatio*float64(statusSize), float64(common.ScalingResolutionBytes)/2)
+		if delta > tolerance {
+			return v1alpha1.VolumeRecommendation{}, fmt.Errorf("stale metrics data detected: pvc size=%d bytes, metrics size=%d bytes: %w", statusSize, volInfo.CapacityBytes, common.ErrStaleMetrics)
+		}
+	}
+
+	setVolumeRecommendationForPVC(obj, pvc.Name, volumeRecommendation)
+	return volumeRecommendation, r.client.Status().Patch(ctx, obj, patch)
 }
 
 // volumePolicyForPVC returns the volume policy from the given
@@ -398,6 +409,33 @@ func (r *Runner) updatePVCAStatus(ctx context.Context, obj *v1alpha1.PersistentV
 // policy to the specific PVC.
 func volumePolicyForPVC(pvca *v1alpha1.PersistentVolumeClaimAutoscaler, _ *corev1.PersistentVolumeClaim) v1alpha1.VolumePolicy {
 	return pvca.Spec.VolumePolicies[0]
+}
+
+// getOrCreateVolumeRecommendationForPVC returns the VolumeRecommendation for
+// the given PVC name. If no recommendation exists yet, a new one is created and returned.
+func getOrCreateVolumeRecommendationForPVC(pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvcName string) v1alpha1.VolumeRecommendation {
+	for i := range pvca.Status.VolumeRecommendations {
+		if pvca.Status.VolumeRecommendations[i].Name == pvcName {
+			return pvca.Status.VolumeRecommendations[i]
+		}
+	}
+
+	return v1alpha1.VolumeRecommendation{
+		Name: pvcName,
+	}
+}
+
+// setVolumeRecommendationForPVC sets the volumeRecommendation for the PVC in the PVCA.
+// If it did not exist before, it is appended to the list of volume recommendations
+func setVolumeRecommendationForPVC(pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvcName string, volumeRecommendation v1alpha1.VolumeRecommendation) {
+	for i := range pvca.Status.VolumeRecommendations {
+		if pvca.Status.VolumeRecommendations[i].Name == pvcName {
+			pvca.Status.VolumeRecommendations[i] = volumeRecommendation
+			return
+		}
+	}
+
+	pvca.Status.VolumeRecommendations = append(pvca.Status.VolumeRecommendations, volumeRecommendation)
 }
 
 // validatePVC checks whether the [corev1.PersistentVolumeClaim] is valid for
@@ -441,84 +479,49 @@ func (r *Runner) validatePVC(ctx context.Context, pvc *corev1.PersistentVolumeCl
 	return nil
 }
 
-// shouldReconcilePVC is a predicate which checks whether the
+// shouldResizePVC is a predicate which checks whether the
 // [corev1.PersistentVolumeClaim] object targeted by
 // [v1alpha1.PersistentVolumeClaimAutoscaler] should be considered for
 // reconciliation. When it returns true, it also returns the scaling reason.
-func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, volInfo *metricssource.VolumeInfo) (bool, string, error) {
-	if err := r.updatePVCAStatus(ctx, pvca, volInfo); err != nil {
-		return false, "", err
-	}
-
-	// No metrics found, nothing to do for now
-	if volInfo == nil {
-		return false, "", common.ErrNoMetrics
-	}
-
-	currStatusSize := pvc.Status.Capacity.Storage()
-
-	// Detect whether the metrics source is reporting stale data. Stale
-	// metrics data would be when the volume info metrics reported by the
-	// metrics source deviate from the current PVC size indicated by
-	// `.status.capacity.storage'
-	if statusSize, ok := currStatusSize.AsInt64(); ok {
-		delta := math.Abs(float64(statusSize) - float64(volInfo.CapacityBytes))
-		tolerance := math.Max(common.MaxCapacityDeviationRatio*float64(statusSize), float64(common.ScalingResolutionBytes)/2)
-		if delta > tolerance {
-			return false, "", fmt.Errorf("stale metrics data detected: pvc size=%d bytes, metrics size=%d bytes: %w", statusSize, volInfo.CapacityBytes, common.ErrStaleMetrics)
-		}
-	}
-
-	// Getting an error from UsedSpacePercentage() means that the
-	// capacity for the volume is zero, which in turn means that we
-	// didn't get any metrics for it.
-	usedSpace, err := volInfo.UsedSpacePercentage()
-	if err != nil {
-		return false, "", common.ErrNoMetrics
-	}
-
-	// Even, if we don't have inode metrics we still want to proceed here.
-	usedInodes, err := volInfo.UsedInodesPercentage()
-	if err != nil {
-		return false, "", common.ErrNoMetrics
-	}
-
-	// Get threshold from volume policy
-	// Currently only one policy is supported and is enforced by the CRD schema
-	threshold := *policy.ScaleUp.UtilizationThresholdPercent
+func (r *Runner) shouldResizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, volumeRecommendation v1alpha1.VolumeRecommendation) (bool, string) {
+	var (
+		threshold         = *policy.ScaleUp.UtilizationThresholdPercent
+		usedSpacePercent  = ptr.Deref(volumeRecommendation.Current.UsedSpacePercent, 0)
+		usedInodesPercent = ptr.Deref(volumeRecommendation.Current.UsedInodesPercent, 0)
+	)
 
 	switch {
 	// Used space reached threshold
-	case usedSpace > threshold:
+	case usedSpacePercent > threshold:
 		r.eventRecorder.Eventf(
 			pvc,
 			corev1.EventTypeWarning,
 			"UsedSpaceThresholdReached",
 			"used space (%d%%) exceeds the configured threshold (%d%%)",
-			usedSpace,
+			usedSpacePercent,
 			threshold,
 		)
 		metrics.ThresholdReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name, "space").Inc()
 
-		return true, "passing storage threshold", nil
+		return true, "passing storage threshold"
 
 	// Used inodes reached threshold
-	case volInfo.CapacityInodes > 0.0 && (usedInodes > threshold):
+	case usedInodesPercent > threshold:
 		r.eventRecorder.Eventf(
 			pvc,
 			corev1.EventTypeWarning,
 			"UsedInodesThresholdReached",
 			"used inodes (%d%%) exceeds the configured threshold (%d%%)",
-			usedInodes,
+			usedInodesPercent,
 			threshold,
 		)
 		metrics.ThresholdReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name, "inodes").Inc()
 
-		return true, "passing inodes threshold", nil
+		return true, "passing inodes threshold"
 
 	// No need to reconcile the PVC for now
 	default:
-		return false, "", nil
+		return false, ""
 	}
 }
 
@@ -566,8 +569,9 @@ func (r *Runner) isResizeInProgress(ctx context.Context, pvca *v1alpha1.Persiste
 
 	// If previously recorded size is equal to the current status it means
 	// we are still waiting for the resize to complete
-	if pvca.Status.VolumeRecommendations[0].Current.Size != nil &&
-		pvca.Status.VolumeRecommendations[0].Current.Size.Equal(*currStatusSize) {
+	volumeRecommendation := getOrCreateVolumeRecommendationForPVC(pvca, pvc.Name)
+	if volumeRecommendation.Current.Size != nil &&
+		volumeRecommendation.Current.Size.Equal(*currStatusSize) {
 		logger.Info("persistent volume claim is still being resized")
 		condition := metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeResizing),
@@ -584,7 +588,7 @@ func (r *Runner) isResizeInProgress(ctx context.Context, pvca *v1alpha1.Persiste
 
 // resizePVC performs the actual resize of the PVC targeted by the given
 // [v1alpha1.PersistentVolumeClaimAutoscaler].
-func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, scalingReason string) error {
+func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, scalingReason string, volumeRecommendation v1alpha1.VolumeRecommendation) error {
 	logger := log.FromContext(ctx).WithValues("pvc", pvc.Name)
 	currSpecSize := pvc.Spec.Resources.Requests.Storage()
 
@@ -629,7 +633,7 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 	}
 
 	if policy.ScaleUp.CooldownDuration != nil {
-		lastResizeTime := pvca.Status.VolumeRecommendations[0].LastResizeTime
+		lastResizeTime := volumeRecommendation.LastResizeTime
 		if lastResizeTime != nil {
 			elapsed := time.Since(lastResizeTime.Time)
 			cooldown := policy.ScaleUp.CooldownDuration.Duration
@@ -668,9 +672,11 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 	}
 
 	pvcaPatch := client.MergeFrom(pvca.DeepCopy())
-	pvca.Status.VolumeRecommendations[0].Current.Size = pvc.Status.Capacity.Storage()
-	pvca.Status.VolumeRecommendations[0].Target.Size = targetSize
-	pvca.Status.VolumeRecommendations[0].LastResizeTime = ptr.To(metav1.Now())
+	volumeRecommendation.Current.Size = pvc.Status.Capacity.Storage()
+	volumeRecommendation.Target.Size = targetSize
+	volumeRecommendation.LastResizeTime = ptr.To(metav1.Now())
+	setVolumeRecommendationForPVC(pvca, pvc.Name, volumeRecommendation)
+
 	if err := r.client.Status().Patch(ctx, pvca, pvcaPatch); err != nil {
 		return err
 	}

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -313,9 +313,16 @@ func (r *Runner) reconcilePVCA(
 		}
 
 		return
+
 	}
 
-	if ok {
+	inProgress, err := r.isResizeInProgress(ctx, pvca, pvc, scalingReason)
+	if err != nil {
+		logger.Info("failed to determine whether persistentvolumeclaim is being resized", "reason", err.Error())
+		return
+	}
+
+	if ok && !inProgress {
 		if err := r.resizePVC(ctx, pvca, pvc, scalingReason); err != nil {
 			logger.Error(err, "failed to resize pvc")
 		}
@@ -490,17 +497,12 @@ func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.Persiste
 	}
 }
 
-// resizePVC performs the actual resize of the PVC targeted by the given
-// [v1alpha1.PersistentVolumeClaimAutoscaler].
-func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, scalingReason string) error {
+// isResizeInProgress checks whether the PVC is currently being resized.
+// Returns true if a resize operation is in progress.
+func (r *Runner) isResizeInProgress(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, scalingReason string) (bool, error) {
 	logger := log.FromContext(ctx).WithValues("pvc", pvc.Name)
-	currSpecSize := pvc.Spec.Resources.Requests.Storage()
 	currStatusSize := pvc.Status.Capacity.Storage()
 
-	// Currently only one policy is supported, since only one PVC can be targeted by a PVCA object
-	policy := pvca.Spec.VolumePolicies[0]
-
-	// Make sure that the PVC is not being modified at the moment.
 	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimResizing) {
 		logger.Info("resize has been started")
 		condition := metav1.Condition{
@@ -510,7 +512,7 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 			Message: fmt.Sprintf(" - %s: is being scaled due to %s, resize has been started", pvc.Name, scalingReason),
 		}
 
-		return pvca.SetCondition(ctx, r.client, condition)
+		return true, pvca.SetCondition(ctx, r.client, condition)
 	}
 
 	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimFileSystemResizePending) {
@@ -522,7 +524,7 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 			Message: fmt.Sprintf(" - %s: is being scaled due to %s, file system resize is pending", pvc.Name, scalingReason),
 		}
 
-		return pvca.SetCondition(ctx, r.client, condition)
+		return true, pvca.SetCondition(ctx, r.client, condition)
 	}
 
 	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimVolumeModifyingVolume) {
@@ -534,7 +536,7 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 			Message: fmt.Sprintf(" - %s: is being scaled due to %s, volume is being modified", pvc.Name, scalingReason),
 		}
 
-		return pvca.SetCondition(ctx, r.client, condition)
+		return true, pvca.SetCondition(ctx, r.client, condition)
 	}
 
 	// If previously recorded size is equal to the current status it means
@@ -549,8 +551,20 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 			Message: fmt.Sprintf(" - %s: is being scaled due to %s, persistent volume claim is still being resized", pvc.Name, scalingReason),
 		}
 
-		return pvca.SetCondition(ctx, r.client, condition)
+		return true, pvca.SetCondition(ctx, r.client, condition)
 	}
+
+	return false, nil
+}
+
+// resizePVC performs the actual resize of the PVC targeted by the given
+// [v1alpha1.PersistentVolumeClaimAutoscaler].
+func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, scalingReason string) error {
+	logger := log.FromContext(ctx).WithValues("pvc", pvc.Name)
+	currSpecSize := pvc.Spec.Resources.Requests.Storage()
+
+	// Currently only one policy is supported, since only one PVC can be targeted by a PVCA object
+	policy := pvca.Spec.VolumePolicies[0]
 
 	// Calculate the new size
 	stepPercent := float64(*policy.ScaleUp.StepPercent)
@@ -632,7 +646,7 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 	}
 
 	pvcaPatch := client.MergeFrom(pvca.DeepCopy())
-	pvca.Status.VolumeRecommendations[0].Current.Size = currStatusSize
+	pvca.Status.VolumeRecommendations[0].Current.Size = pvc.Status.Capacity.Storage()
 	pvca.Status.VolumeRecommendations[0].Target.Size = targetSize
 	pvca.Status.VolumeRecommendations[0].LastResizeTime = ptr.To(metav1.Now())
 	if err := r.client.Status().Patch(ctx, pvca, pvcaPatch); err != nil {

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -9,12 +9,14 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -75,6 +77,10 @@ const (
 	ReasonAmbiguousPVCA = "AmbiguousPersistentVolumeClaimAutoscaler"
 	// ReasonRecommendationError indicates an error occurred during recommendation computation.
 	ReasonRecommendationError = "RecommendationError"
+	// ReasonRecommendationsProvided indicates that all recommendations have been computed and added to the status.
+	ReasonRecommendationsProvided = "RecommendationsProvided"
+	// ReasonRecommendationsNotProvided is a generic reason that not all recommendations have been computed and added to the status.
+	ReasonRecommendationsNotProvided = "RecommendationsNotProvided"
 	// ReasonReconcile condition reason for the Resizing condition.
 	ReasonReconcile = "Reconcile"
 	// ReasonPVCResizeCooldown indicates that the PVC resize is in cooldown period.
@@ -228,17 +234,30 @@ func (r *Runner) fetchPVCsForPVCAs(ctx context.Context, logger logr.Logger, pers
 	)
 
 	for _, pvca := range persistentVolumeClaimAutoscalers {
+		pvcaKey := client.ObjectKeyFromObject(&pvca)
 		persistentVolumeClaims, err := r.pvcFetcher.Fetch(ctx, &pvca)
 		if err != nil {
-			logger.Error(err, "failed to fetch persistentvolumeclaims for persistentvolumeclaimautoscaler", "pvca", client.ObjectKeyFromObject(&pvca))
-			condition := metav1.Condition{
+			logger.Error(err, "failed to fetch persistentvolumeclaims for persistentvolumeclaimautoscaler", "pvca", pvcaKey)
+
+			recommendationsCondition := metav1.Condition{
 				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
 				Status:  metav1.ConditionFalse,
 				Reason:  ReasonPVCFetchError,
 				Message: fmt.Sprintf("failed to fetch PersistentVolumeClaims for PersistentVolumeClaimAutoscaler: %s", err.Error()),
 			}
-			if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
-				logger.Info("failed to update status condition", "pvca", client.ObjectKeyFromObject(&pvca), "reason", err.Error())
+
+			resizingCondition := metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}
+			if existing := meta.FindStatusCondition(pvca.Status.Conditions, resizingCondition.Type); existing != nil {
+				resizingCondition = metav1.Condition{
+					Type:    string(v1alpha1.ConditionTypeResizing),
+					Status:  metav1.ConditionUnknown,
+					Reason:  ReasonPVCFetchError,
+					Message: "Resizing state is unknown: failed to fetch PersistentVolumeClaims",
+				}
+			}
+
+			if err := r.setStatus(ctx, &pvca, recommendationsCondition, resizingCondition, pvca.Status.VolumeRecommendations); err != nil {
+				logger.Error(err, "failed to update PVCA status", "pvca", pvcaKey)
 			}
 
 			continue
@@ -248,7 +267,7 @@ func (r *Runner) fetchPVCsForPVCAs(ctx context.Context, logger logr.Logger, pers
 
 		for _, pvc := range persistentVolumeClaims {
 			key := client.ObjectKeyFromObject(pvc).String()
-			pvcToOwnersMap[key] = append(pvcToOwnersMap[key], client.ObjectKeyFromObject(&pvca).String())
+			pvcToOwnersMap[key] = append(pvcToOwnersMap[key], pvcaKey.String())
 		}
 	}
 
@@ -265,107 +284,98 @@ func (r *Runner) reconcilePVCA(
 ) {
 	logger = logger.WithValues("pvca", client.ObjectKeyFromObject(pvca))
 
-	// TODO(plkokanov): When multi-PVC support is added, this must be updated to iterate over all PVCs.
-	// Currently, the PVCA can only target one PVC, so we only get the first element.
-	// Because of that, we can also skip reconciling the PVCA resource if
-	// other PVCAs also target the same PVC.
-	pvc := pvcs[0]
-	pvcObjKey := client.ObjectKeyFromObject(pvc)
-	logger = logger.WithValues("pvc", pvcObjKey)
+	resizingConditions := &resizingConditionAggregator{}
+	recommendationConditons := &recommendationsConditionAggregator{}
 
-	if owners, ok := pvcToOwnersMap[pvcObjKey.String()]; ok && len(owners) > 1 {
-		logger.Info("skipping persistentvolumeclaim because it is scaled by multiple persistentvolumeclaimautoscalers", "pvcas", strings.Join(owners, ", "))
-		condition := metav1.Condition{
-			Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
-			Status:  metav1.ConditionFalse,
-			Reason:  ReasonAmbiguousPVCA,
-			Message: fmt.Sprintf("PersistentVolumeClaim %s is scaled by multiple PersistentVolumeClaimAutoscalers: %s", pvcObjKey, strings.Join(owners, ", ")),
+	volumeRecommendations := make([]v1alpha1.VolumeRecommendation, 0, len(pvcs))
+	for _, volumeRecommendation := range pvca.Status.VolumeRecommendations {
+		if slices.ContainsFunc(pvcs, func(pvc *corev1.PersistentVolumeClaim) bool {
+			return pvc.Name == volumeRecommendation.Name
+		}) {
+			volumeRecommendations = append(volumeRecommendations, volumeRecommendation)
 		}
-		if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
-			logger.Info("failed to update status condition", "reason", err.Error())
-		}
-
-		return
 	}
 
-	// Get a fresh copy of the pvc object.
-	if err := r.client.Get(ctx, pvcObjKey, pvc); err != nil {
-		logger.Info("failed to get persistentvolumeclaim", "reason", err.Error())
-		return
-	}
+	for _, pvc := range pvcs {
+		pvcObjKey := client.ObjectKeyFromObject(pvc)
+		logger := logger.WithValues("pvc", pvcObjKey)
 
-	policy := volumePolicyForPVC(pvca, pvc)
+		if owners, ok := pvcToOwnersMap[pvcObjKey.String()]; ok && len(owners) > 1 {
+			logger.Info("skipping persistentvolumeclaim because it is scaled by multiple persistentvolumeclaimautoscalers", "pvcas", strings.Join(owners, ", "))
+			recommendationConditons.addCondition(metav1.Condition{
+				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+				Status:  metav1.ConditionFalse,
+				Reason:  ReasonAmbiguousPVCA,
+				Message: fmt.Sprintf("PersistentVolumeClaim %s is scaled by multiple PersistentVolumeClaimAutoscalers: %s", pvcObjKey, strings.Join(owners, ", ")),
+			})
 
-	if err := r.validatePVC(ctx, pvc, policy); err != nil {
-		logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
-		metrics.SkippedTotal.WithLabelValues(pvca.Namespace, pvca.Name, err.Error()).Inc()
-		condition := metav1.Condition{
-			Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
-			Status:  metav1.ConditionFalse,
-			Reason:  ReasonRecommendationError,
-			Message: fmt.Sprintf(" - %s: %s", pvcObjKey.Name, err.Error()),
-		}
-		if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
-			logger.Info("failed to update status condition", "reason", err.Error())
+			continue
 		}
 
-		return
-	}
-
-	volumeRecommendation, err := r.updateVolumeRecommendationForPVC(ctx, pvca, pvc, metricsData[pvcObjKey])
-	if err != nil {
-		logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
-		metrics.SkippedTotal.WithLabelValues(pvca.Namespace, pvca.Name, err.Error()).Inc()
-		condition := metav1.Condition{
-			Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
-			Status:  metav1.ConditionFalse,
-			Reason:  ReasonMetricsFetchError,
-			Message: fmt.Sprintf(" - %s: %s", pvcObjKey.Name, err.Error()),
-		}
-		if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
-			logger.Info("failed to update status condition", "reason", err.Error())
+		// Get a fresh copy of the pvc object.
+		if err := r.client.Get(ctx, pvcObjKey, pvc); err != nil {
+			logger.Info("failed to get persistentvolumeclaim", "reason", err.Error())
+			recommendationConditons.addCondition(metav1.Condition{
+				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+				Status:  metav1.ConditionFalse,
+				Reason:  ReasonPVCFetchError,
+				Message: fmt.Sprintf("Failed to get PersistentVolumeClaim %s: %s", pvcObjKey, err.Error()),
+			})
+			continue
 		}
 
-		return
-	}
+		policy := volumePolicyForPVC(pvca, pvc)
 
-	condition := metav1.Condition{
-		Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
-		Status:  metav1.ConditionTrue,
-		Reason:  ReasonMetricsFetched,
-		Message: " - All metrics fetched successfully",
-	}
-	if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
-		logger.Info("failed to update status condition", "reason", err.Error())
-	}
+		if err := r.validatePVC(ctx, pvc, policy); err != nil {
+			logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
+			recommendationConditons.addCondition(metav1.Condition{
+				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+				Status:  metav1.ConditionFalse,
+				Reason:  ReasonRecommendationError,
+				Message: fmt.Sprintf("%s: %s", pvcObjKey.Name, err.Error()),
+			})
 
-	shouldResize, scalingReason := r.shouldResizePVC(ctx, pvca, pvc, policy, volumeRecommendation)
-
-	inProgress, err := r.isResizeInProgress(ctx, pvca, pvc, scalingReason)
-	if err != nil {
-		logger.Info("failed to determine whether persistentvolumeclaim is being resized", "reason", err.Error())
-		return
-	}
-
-	if shouldResize && !inProgress {
-		if err := r.resizePVC(ctx, pvca, pvc, policy, scalingReason, volumeRecommendation); err != nil {
-			logger.Error(err, "failed to resize pvc")
+			continue
 		}
-	} else if err := pvca.RemoveCondition(ctx, r.client, string(v1alpha1.ConditionTypeResizing)); err != nil {
-		logger.Info("failed to remove status condition", "reason", err.Error())
+
+		volumeRecommendation, err := r.updateVolumeRecommendationForPVC(volumeRecommendations, pvc, metricsData[pvcObjKey])
+		if err != nil {
+			logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
+			metrics.SkippedTotal.WithLabelValues(pvca.Namespace, pvca.Name, err.Error()).Inc()
+			recommendationConditons.addCondition(metav1.Condition{
+				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+				Status:  metav1.ConditionFalse,
+				Reason:  ReasonMetricsFetchError,
+				Message: fmt.Sprintf("%s: %s", pvcObjKey.Name, err.Error()),
+			})
+
+			continue
+		}
+
+		shouldResize, scalingReason := r.shouldResizePVC(pvc, policy, volumeRecommendation)
+		inProgress := r.isResizeInProgress(ctx, pvc, scalingReason, volumeRecommendation, resizingConditions)
+
+		if shouldResize && !inProgress {
+			volumeRecommendation, err = r.resizePVC(ctx, pvc, policy, scalingReason, volumeRecommendation, resizingConditions)
+			if err != nil {
+				logger.Error(err, "failed to resize pvc")
+			}
+		}
+
+		setVolumeRecommendationForPVC(&volumeRecommendations, pvc.Name, volumeRecommendation)
+
+	}
+
+	if err := r.setStatus(ctx, pvca, recommendationConditons.getAggregatedCondition(), resizingConditions.getAggregatedCondition(), volumeRecommendations); err != nil {
+		logger.Error(err, "failed to update PVCA status")
 	}
 }
 
 // updateVolumeRecommendations updates the status of the
 // [v1alpha1.PersistentVolumeClaimAutoscaler] with the latest observed
 // information about the target [corev1.PersistentVolumeClaim].
-func (r *Runner) updateVolumeRecommendationForPVC(ctx context.Context, obj *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, volInfo *metricssource.VolumeInfo) (v1alpha1.VolumeRecommendation, error) {
-	patch := client.MergeFrom(obj.DeepCopy())
-	now := time.Now()
-	obj.Status.LastCheck = metav1.NewTime(now)
-	obj.Status.NextCheck = metav1.NewTime(now.Add(r.interval))
-
-	volumeRecommendation := getOrCreateVolumeRecommendationForPVC(obj, pvc.Name)
+func (r *Runner) updateVolumeRecommendationForPVC(volumeRecommendations []v1alpha1.VolumeRecommendation, pvc *corev1.PersistentVolumeClaim, volInfo *metricssource.VolumeInfo) (v1alpha1.VolumeRecommendation, error) {
+	volumeRecommendation := getOrCreateVolumeRecommendationForPVC(volumeRecommendations, pvc.Name)
 
 	// No metrics found, nothing to do for now
 	if volInfo == nil {
@@ -398,8 +408,7 @@ func (r *Runner) updateVolumeRecommendationForPVC(ctx context.Context, obj *v1al
 		}
 	}
 
-	setVolumeRecommendationForPVC(obj, pvc.Name, volumeRecommendation)
-	return volumeRecommendation, r.client.Status().Patch(ctx, obj, patch)
+	return volumeRecommendation, nil
 }
 
 // volumePolicyForPVC returns the volume policy from the given
@@ -413,10 +422,10 @@ func volumePolicyForPVC(pvca *v1alpha1.PersistentVolumeClaimAutoscaler, _ *corev
 
 // getOrCreateVolumeRecommendationForPVC returns the VolumeRecommendation for
 // the given PVC name. If no recommendation exists yet, a new one is created and returned.
-func getOrCreateVolumeRecommendationForPVC(pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvcName string) v1alpha1.VolumeRecommendation {
-	for i := range pvca.Status.VolumeRecommendations {
-		if pvca.Status.VolumeRecommendations[i].Name == pvcName {
-			return pvca.Status.VolumeRecommendations[i]
+func getOrCreateVolumeRecommendationForPVC(volumeRecommendations []v1alpha1.VolumeRecommendation, pvcName string) v1alpha1.VolumeRecommendation {
+	for i := range volumeRecommendations {
+		if volumeRecommendations[i].Name == pvcName {
+			return volumeRecommendations[i]
 		}
 	}
 
@@ -427,15 +436,15 @@ func getOrCreateVolumeRecommendationForPVC(pvca *v1alpha1.PersistentVolumeClaimA
 
 // setVolumeRecommendationForPVC sets the volumeRecommendation for the PVC in the PVCA.
 // If it did not exist before, it is appended to the list of volume recommendations
-func setVolumeRecommendationForPVC(pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvcName string, volumeRecommendation v1alpha1.VolumeRecommendation) {
-	for i := range pvca.Status.VolumeRecommendations {
-		if pvca.Status.VolumeRecommendations[i].Name == pvcName {
-			pvca.Status.VolumeRecommendations[i] = volumeRecommendation
+func setVolumeRecommendationForPVC(volumeRecommendations *[]v1alpha1.VolumeRecommendation, pvcName string, volumeRecommendation v1alpha1.VolumeRecommendation) {
+	for i := range *volumeRecommendations {
+		if (*volumeRecommendations)[i].Name == pvcName {
+			(*volumeRecommendations)[i] = volumeRecommendation
 			return
 		}
 	}
 
-	pvca.Status.VolumeRecommendations = append(pvca.Status.VolumeRecommendations, volumeRecommendation)
+	*volumeRecommendations = append(*volumeRecommendations, volumeRecommendation)
 }
 
 // validatePVC checks whether the [corev1.PersistentVolumeClaim] is valid for
@@ -483,7 +492,7 @@ func (r *Runner) validatePVC(ctx context.Context, pvc *corev1.PersistentVolumeCl
 // [corev1.PersistentVolumeClaim] object targeted by
 // [v1alpha1.PersistentVolumeClaimAutoscaler] should be considered for
 // reconciliation. When it returns true, it also returns the scaling reason.
-func (r *Runner) shouldResizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, volumeRecommendation v1alpha1.VolumeRecommendation) (bool, string) {
+func (r *Runner) shouldResizePVC(pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, volumeRecommendation v1alpha1.VolumeRecommendation) (bool, string) {
 	var (
 		threshold         = *policy.ScaleUp.UtilizationThresholdPercent
 		usedSpacePercent  = ptr.Deref(volumeRecommendation.Current.UsedSpacePercent, 0)
@@ -527,68 +536,67 @@ func (r *Runner) shouldResizePVC(ctx context.Context, pvca *v1alpha1.PersistentV
 
 // isResizeInProgress checks whether the PVC is currently being resized.
 // Returns true if a resize operation is in progress.
-func (r *Runner) isResizeInProgress(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, scalingReason string) (bool, error) {
+func (r *Runner) isResizeInProgress(ctx context.Context, pvc *corev1.PersistentVolumeClaim, scalingReason string, volumeRecommendation v1alpha1.VolumeRecommendation, resizingConditions *resizingConditionAggregator) bool {
 	logger := log.FromContext(ctx).WithValues("pvc", pvc.Name)
 	currStatusSize := pvc.Status.Capacity.Storage()
 
 	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimResizing) {
 		logger.Info("resize has been started")
-		condition := metav1.Condition{
+		resizingConditions.addCondition(metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf(" - %s: is being scaled due to %s, resize has been started", pvc.Name, scalingReason),
-		}
+			Message: fmt.Sprintf("%s: is being scaled due to %s, resize has been started", pvc.Name, scalingReason),
+		})
 
-		return true, pvca.SetCondition(ctx, r.client, condition)
+		return true
 	}
 
 	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimFileSystemResizePending) {
 		logger.Info("filesystem resize is pending")
-		condition := metav1.Condition{
+		resizingConditions.addCondition(metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf(" - %s: is being scaled due to %s, file system resize is pending", pvc.Name, scalingReason),
-		}
+			Message: fmt.Sprintf("%s: is being scaled due to %s, file system resize is pending", pvc.Name, scalingReason),
+		})
 
-		return true, pvca.SetCondition(ctx, r.client, condition)
+		return true
 	}
 
 	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimVolumeModifyingVolume) {
 		logger.Info("volume is being modified")
-		condition := metav1.Condition{
+		resizingConditions.addCondition(metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf(" - %s: is being scaled due to %s, volume is being modified", pvc.Name, scalingReason),
-		}
+			Message: fmt.Sprintf("%s: is being scaled due to %s, volume is being modified", pvc.Name, scalingReason),
+		})
 
-		return true, pvca.SetCondition(ctx, r.client, condition)
+		return true
 	}
 
 	// If previously recorded size is equal to the current status it means
 	// we are still waiting for the resize to complete
-	volumeRecommendation := getOrCreateVolumeRecommendationForPVC(pvca, pvc.Name)
 	if volumeRecommendation.Current.Size != nil &&
 		volumeRecommendation.Current.Size.Equal(*currStatusSize) {
 		logger.Info("persistent volume claim is still being resized")
-		condition := metav1.Condition{
+		resizingConditions.addCondition(metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf(" - %s: is being scaled due to %s, persistent volume claim is still being resized", pvc.Name, scalingReason),
-		}
+			Message: fmt.Sprintf("%s: is being scaled due to %s, persistent volume claim is still being resized", pvc.Name, scalingReason),
+		})
 
-		return true, pvca.SetCondition(ctx, r.client, condition)
+		return true
 	}
 
-	return false, nil
+	return false
 }
 
 // resizePVC performs the actual resize of the PVC targeted by the given
 // [v1alpha1.PersistentVolumeClaimAutoscaler].
-func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, scalingReason string, volumeRecommendation v1alpha1.VolumeRecommendation) error {
+func (r *Runner) resizePVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, scalingReason string, volumeRecommendation v1alpha1.VolumeRecommendation, resizingConditions *resizingConditionAggregator) (v1alpha1.VolumeRecommendation, error) {
 	logger := log.FromContext(ctx).WithValues("pvc", pvc.Name)
 	currSpecSize := pvc.Spec.Resources.Requests.Storage()
 
@@ -604,11 +612,11 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 	case 0:
 		logger.Info("new and current size are the same")
 
-		return nil
+		return volumeRecommendation, nil
 	case -1:
 		logger.Info("new size is less than current")
 
-		return nil
+		return volumeRecommendation, nil
 	}
 
 	// We don't want to exceed the max capacity
@@ -622,14 +630,14 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 		)
 		logger.Info("max capacity reached")
 		metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
-		condition := metav1.Condition{
+		resizingConditions.addCondition(metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionFalse,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf(" - %s: max capacity reached", pvc.Name),
-		}
+			Message: fmt.Sprintf("%s: max capacity reached", pvc.Name),
+		})
 
-		return pvca.SetCondition(ctx, r.client, condition)
+		return volumeRecommendation, nil
 	}
 
 	if policy.ScaleUp.CooldownDuration != nil {
@@ -640,14 +648,14 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 			if elapsed < cooldown {
 				remaining := cooldown - elapsed
 				logger.Info("cooldown period not elapsed", "remaining", remaining.String())
-				condition := metav1.Condition{
+				resizingConditions.addCondition(metav1.Condition{
 					Type:    string(v1alpha1.ConditionTypeResizing),
 					Status:  metav1.ConditionFalse,
 					Reason:  ReasonPVCResizeCooldown,
-					Message: fmt.Sprintf("- %s: cooldown duration has not elapsed yet", pvc.Name),
-				}
+					Message: fmt.Sprintf("%s: cooldown duration has not elapsed yet", pvc.Name),
+				})
 
-				return pvca.SetCondition(ctx, r.client, condition)
+				return volumeRecommendation, nil
 			}
 		}
 	}
@@ -668,25 +676,57 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 	pvcPatch := client.MergeFrom(pvc.DeepCopy())
 	pvc.Spec.Resources.Requests[corev1.ResourceStorage] = *targetSize
 	if err := r.client.Patch(ctx, pvc, pvcPatch); err != nil {
-		return err
+		resizingConditions.addCondition(metav1.Condition{
+			Type:    string(v1alpha1.ConditionTypeResizing),
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonReconcile,
+			Message: fmt.Sprintf("%s: could not patch PersistentVolumeClaim with new target size %s", pvc.Name, targetSize.String()),
+		})
+		return volumeRecommendation, err
 	}
 
-	pvcaPatch := client.MergeFrom(pvca.DeepCopy())
 	volumeRecommendation.Current.Size = pvc.Status.Capacity.Storage()
 	volumeRecommendation.Target.Size = targetSize
 	volumeRecommendation.LastResizeTime = ptr.To(metav1.Now())
-	setVolumeRecommendationForPVC(pvca, pvc.Name, volumeRecommendation)
 
-	if err := r.client.Status().Patch(ctx, pvca, pvcaPatch); err != nil {
-		return err
-	}
-
-	condition := metav1.Condition{
+	resizingConditions.addCondition(metav1.Condition{
 		Type:    string(v1alpha1.ConditionTypeResizing),
 		Status:  metav1.ConditionTrue,
 		Reason:  ReasonReconcile,
-		Message: fmt.Sprintf("- %s: resizing from %s to %s due to %s", pvc.Name, currSpecSize.String(), targetSize.String(), scalingReason),
+		Message: fmt.Sprintf("%s: resizing from %s to %s due to %s", pvc.Name, currSpecSize.String(), targetSize.String(), scalingReason),
+	})
+
+	return volumeRecommendation, nil
+}
+
+// setStatus updates the status of the [v1alpha1.PersistentVolumeClaimAutoscaler]
+// with the given conditions and the latest volume recommendations. For each
+// condition, an empty Message is treated as a sentinel value: the condition is
+// removed from the status by Type rather than set.
+func (r *Runner) setStatus(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, recommendationsCondition metav1.Condition, resizingCondition metav1.Condition, volumeRecommendations []v1alpha1.VolumeRecommendation) error {
+	patch := client.MergeFrom(pvca.DeepCopy())
+	conditions := pvca.Status.Conditions
+	if len(conditions) == 0 {
+		conditions = make([]metav1.Condition, 0)
+	}
+	now := time.Now()
+	pvca.Status.LastCheck = metav1.NewTime(now)
+	pvca.Status.NextCheck = metav1.NewTime(now.Add(r.interval))
+
+	for _, condition := range []metav1.Condition{resizingCondition, recommendationsCondition} {
+		if condition.Message == "" {
+			meta.RemoveStatusCondition(&conditions, condition.Type)
+		} else {
+			meta.SetStatusCondition(&conditions, condition)
+		}
 	}
 
-	return pvca.SetCondition(ctx, r.client, condition)
+	pvca.Status.Conditions = conditions
+
+	slices.SortFunc(volumeRecommendations, func(vr1, vr2 v1alpha1.VolumeRecommendation) int {
+		return strings.Compare(vr1.Name, vr2.Name)
+	})
+	pvca.Status.VolumeRecommendations = volumeRecommendations
+
+	return r.client.Status().Patch(ctx, pvca, patch)
 }

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -60,6 +60,9 @@ var ErrNoClient = errors.New("no client provided")
 // configured without a [pvcfetcher.Fetcher].
 var ErrNoPVCFetcher = errors.New("no PersistentVolumeClaim fetcher provided")
 
+// ErrPVCNotBound is returned when the PVC is not in the Bound phase.
+var ErrPVCNotBound = errors.New("PersistentVolumeClaim is not bound")
+
 // Condition reasons for the RecommendationAvailable condition
 const (
 	// ReasonMetricsFetched indicates that metrics were successfully fetched and computed.
@@ -294,20 +297,13 @@ func (r *Runner) reconcilePVCA(
 
 	policy := volumePolicyForPVC(pvca, pvc)
 
-	ok, scalingReason, err := r.shouldReconcilePVC(ctx, pvca, pvc, policy, volInfo)
-	if err != nil {
+	if err := r.validatePVC(ctx, pvc, policy); err != nil {
 		logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
 		metrics.SkippedTotal.WithLabelValues(pvca.Namespace, pvca.Name, err.Error()).Inc()
-		var conditionReason string
-		if errors.Is(err, common.ErrNoMetrics) {
-			conditionReason = ReasonMetricsFetchError
-		} else {
-			conditionReason = ReasonRecommendationError
-		}
 		condition := metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
 			Status:  metav1.ConditionFalse,
-			Reason:  conditionReason,
+			Reason:  ReasonRecommendationError,
 			Message: fmt.Sprintf(" - %s: %s", pvcObjKey.Name, err.Error()),
 		}
 		if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
@@ -315,7 +311,23 @@ func (r *Runner) reconcilePVCA(
 		}
 
 		return
+	}
 
+	ok, scalingReason, err := r.shouldReconcilePVC(ctx, pvca, pvc, policy, volInfo)
+	if err != nil {
+		logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
+		metrics.SkippedTotal.WithLabelValues(pvca.Namespace, pvca.Name, err.Error()).Inc()
+		condition := metav1.Condition{
+			Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonMetricsFetchError,
+			Message: fmt.Sprintf(" - %s: %s", pvcObjKey.Name, err.Error()),
+		}
+		if err := pvca.SetCondition(ctx, r.client, condition); err != nil {
+			logger.Info("failed to update status condition", "reason", err.Error())
+		}
+
+		return
 	}
 
 	inProgress, err := r.isResizeInProgress(ctx, pvca, pvc, scalingReason)
@@ -388,6 +400,47 @@ func volumePolicyForPVC(pvca *v1alpha1.PersistentVolumeClaimAutoscaler, _ *corev
 	return pvca.Spec.VolumePolicies[0]
 }
 
+// validatePVC checks whether the [corev1.PersistentVolumeClaim] is valid for
+// reconciliation based on its current state and the associated volume policy.
+func (r *Runner) validatePVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy) error {
+	currStatusSize := pvc.Status.Capacity.Storage()
+	if currStatusSize.IsZero() {
+		return fmt.Errorf(".status.capacity.storage is invalid: %s", currStatusSize.String())
+	}
+
+	if policy.MaxCapacity.Value() < currStatusSize.Value() {
+		return fmt.Errorf("max capacity (%s) cannot be less than current size (%s)", policy.MaxCapacity.String(), currStatusSize.String())
+	}
+
+	// We need a StorageClass with expansion support
+	scName := ptr.Deref(pvc.Spec.StorageClassName, "")
+	if scName == "" {
+		return ErrStorageClassNotFound
+	}
+
+	var sc storagev1.StorageClass
+	scKey := types.NamespacedName{Name: scName}
+	if err := r.client.Get(ctx, scKey, &sc); err != nil {
+		return err
+	}
+
+	if !ptr.Deref(sc.AllowVolumeExpansion, false) {
+		return ErrStorageClassDoesNotSupportExpansion
+	}
+
+	// VolumeMode should be Filesystem
+	if pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode != corev1.PersistentVolumeFilesystem {
+		return ErrVolumeModeIsNotFilesystem
+	}
+
+	// The PVC should be bound
+	if pvc.Status.Phase != corev1.ClaimBound {
+		return ErrPVCNotBound
+	}
+
+	return nil
+}
+
 // shouldReconcilePVC is a predicate which checks whether the
 // [corev1.PersistentVolumeClaim] object targeted by
 // [v1alpha1.PersistentVolumeClaimAutoscaler] should be considered for
@@ -402,31 +455,7 @@ func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.Persiste
 		return false, "", common.ErrNoMetrics
 	}
 
-	// Validate the PVC itself against the spec
 	currStatusSize := pvc.Status.Capacity.Storage()
-	if currStatusSize.IsZero() {
-		return false, "", fmt.Errorf(".status.capacity.storage is invalid: %s", currStatusSize.String())
-	}
-
-	if policy.MaxCapacity.Value() < currStatusSize.Value() {
-		return false, "", fmt.Errorf("max capacity (%s) cannot be less than current size (%s)", policy.MaxCapacity.String(), currStatusSize.String())
-	}
-
-	// We need a StorageClass with expansion support
-	scName := ptr.Deref(pvc.Spec.StorageClassName, "")
-	if scName == "" {
-		return false, "", ErrStorageClassNotFound
-	}
-
-	var sc storagev1.StorageClass
-	scKey := types.NamespacedName{Name: scName}
-	if err := r.client.Get(ctx, scKey, &sc); err != nil {
-		return false, "", err
-	}
-
-	if !ptr.Deref(sc.AllowVolumeExpansion, false) {
-		return false, "", ErrStorageClassDoesNotSupportExpansion
-	}
 
 	// Detect whether the metrics source is reporting stale data. Stale
 	// metrics data would be when the volume info metrics reported by the
@@ -457,19 +486,6 @@ func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.Persiste
 	// Get threshold from volume policy
 	// Currently only one policy is supported and is enforced by the CRD schema
 	threshold := *policy.ScaleUp.UtilizationThresholdPercent
-
-	// VolumeMode should be Filesystem
-	if pvc.Spec.VolumeMode == nil {
-		return false, "", nil
-	}
-	if *pvc.Spec.VolumeMode != corev1.PersistentVolumeFilesystem {
-		return false, "", ErrVolumeModeIsNotFilesystem
-	}
-
-	// The PVC should be bound
-	if pvc.Status.Phase != corev1.ClaimBound {
-		return false, "", nil
-	}
 
 	switch {
 	// Used space reached threshold

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -356,10 +356,10 @@ func (r *Runner) reconcilePVCA(
 		}
 
 		shouldResize, scalingReason := r.shouldResizePVC(pvc, policy, volumeRecommendation)
-		inProgress := r.isResizeInProgress(ctx, pvc, scalingReason, volumeRecommendation, resizingConditions)
+		inProgress := r.isResizeInProgress(logger, pvc, scalingReason, volumeRecommendation, resizingConditions)
 
 		if shouldResize && !inProgress {
-			volumeRecommendation, err = r.resizePVC(ctx, pvc, policy, scalingReason, volumeRecommendation, resizingConditions)
+			volumeRecommendation, err = r.resizePVC(ctx, logger, pvc, policy, scalingReason, volumeRecommendation, resizingConditions)
 			if err != nil {
 				logger.Error(err, "failed to resize pvc")
 			}
@@ -539,8 +539,7 @@ func (r *Runner) shouldResizePVC(pvc *corev1.PersistentVolumeClaim, policy v1alp
 
 // isResizeInProgress checks whether the PVC is currently being resized.
 // Returns true if a resize operation is in progress.
-func (r *Runner) isResizeInProgress(ctx context.Context, pvc *corev1.PersistentVolumeClaim, scalingReason string, volumeRecommendation v1alpha1.VolumeRecommendation, resizingConditions *resizingConditionAggregator) bool {
-	logger := log.FromContext(ctx).WithValues("pvc", pvc.Name)
+func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVolumeClaim, scalingReason string, volumeRecommendation v1alpha1.VolumeRecommendation, resizingConditions *resizingConditionAggregator) bool {
 	currStatusSize := pvc.Status.Capacity.Storage()
 
 	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimResizing) {
@@ -599,8 +598,7 @@ func (r *Runner) isResizeInProgress(ctx context.Context, pvc *corev1.PersistentV
 
 // resizePVC performs the actual resize of the PVC targeted by the given
 // [v1alpha1.PersistentVolumeClaimAutoscaler].
-func (r *Runner) resizePVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, scalingReason string, volumeRecommendation v1alpha1.VolumeRecommendation, resizingConditions *resizingConditionAggregator) (v1alpha1.VolumeRecommendation, error) {
-	logger := log.FromContext(ctx).WithValues("pvc", pvc.Name)
+func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, scalingReason string, volumeRecommendation v1alpha1.VolumeRecommendation, resizingConditions *resizingConditionAggregator) (v1alpha1.VolumeRecommendation, error) {
 	currSpecSize := pvc.Spec.Resources.Requests.Storage()
 
 	// Calculate the new size

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -286,8 +286,13 @@ func (r *Runner) reconcilePVCA(
 	}
 
 	volInfo := metricsData[pvcObjKey]
+	// Get a fresh copy of the pvc object.
+	if err := r.client.Get(ctx, pvcObjKey, pvc); err != nil {
+		logger.Info("failed to get persistentvolumeclaim", "reason", err.Error())
+		return
+	}
 
-	ok, scalingReason, err := r.shouldReconcilePVC(ctx, pvca, volInfo)
+	ok, scalingReason, err := r.shouldReconcilePVC(ctx, pvca, pvc, volInfo)
 	if err != nil {
 		logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
 		metrics.SkippedTotal.WithLabelValues(pvca.Namespace, pvca.Name, err.Error()).Inc()
@@ -311,7 +316,7 @@ func (r *Runner) reconcilePVCA(
 	}
 
 	if ok {
-		if err := r.resizePVC(ctx, pvca, scalingReason); err != nil {
+		if err := r.resizePVC(ctx, pvca, pvc, scalingReason); err != nil {
 			logger.Error(err, "failed to resize pvc")
 		}
 	} else if err := pvca.RemoveCondition(ctx, r.client, string(v1alpha1.ConditionTypeResizing)); err != nil {
@@ -369,13 +374,7 @@ func (r *Runner) updatePVCAStatus(ctx context.Context, obj *v1alpha1.PersistentV
 // [corev1.PersistentVolumeClaim] object targeted by
 // [v1alpha1.PersistentVolumeClaimAutoscaler] should be considered for
 // reconciliation. When it returns true, it also returns the scaling reason.
-func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, volInfo *metricssource.VolumeInfo) (bool, string, error) {
-	pvcObjKey := client.ObjectKey{Namespace: pvca.Namespace, Name: pvca.Spec.TargetRef.Name}
-	pvcObj := &corev1.PersistentVolumeClaim{}
-	if err := r.client.Get(ctx, pvcObjKey, pvcObj); err != nil {
-		return false, "", err
-	}
-
+func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, volInfo *metricssource.VolumeInfo) (bool, string, error) {
 	if err := r.updatePVCAStatus(ctx, pvca, volInfo); err != nil {
 		return false, "", err
 	}
@@ -386,7 +385,7 @@ func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.Persiste
 	}
 
 	// Validate the PVC itself against the spec
-	currStatusSize := pvcObj.Status.Capacity.Storage()
+	currStatusSize := pvc.Status.Capacity.Storage()
 	if currStatusSize.IsZero() {
 		return false, "", fmt.Errorf(".status.capacity.storage is invalid: %s", currStatusSize.String())
 	}
@@ -398,7 +397,7 @@ func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.Persiste
 	}
 
 	// We need a StorageClass with expansion support
-	scName := ptr.Deref(pvcObj.Spec.StorageClassName, "")
+	scName := ptr.Deref(pvc.Spec.StorageClassName, "")
 	if scName == "" {
 		return false, "", ErrStorageClassNotFound
 	}
@@ -444,15 +443,15 @@ func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.Persiste
 	threshold := 100 - *policy.ScaleUp.UtilizationThresholdPercent
 
 	// VolumeMode should be Filesystem
-	if pvcObj.Spec.VolumeMode == nil {
+	if pvc.Spec.VolumeMode == nil {
 		return false, "", nil
 	}
-	if *pvcObj.Spec.VolumeMode != corev1.PersistentVolumeFilesystem {
+	if *pvc.Spec.VolumeMode != corev1.PersistentVolumeFilesystem {
 		return false, "", ErrVolumeModeIsNotFilesystem
 	}
 
 	// The PVC should be bound
-	if pvcObj.Status.Phase != corev1.ClaimBound {
+	if pvc.Status.Phase != corev1.ClaimBound {
 		return false, "", nil
 	}
 
@@ -460,28 +459,28 @@ func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.Persiste
 	// Free space reached threshold
 	case freeSpace < threshold:
 		r.eventRecorder.Eventf(
-			pvcObj,
+			pvc,
 			corev1.EventTypeWarning,
 			"FreeSpaceThresholdReached",
 			"free space (%d%%) is less than the configured threshold (%d%%)",
 			freeSpace,
 			threshold,
 		)
-		metrics.ThresholdReachedTotal.WithLabelValues(pvcObj.Namespace, pvcObj.Name, "space").Inc()
+		metrics.ThresholdReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name, "space").Inc()
 
 		return true, "passing storage threshold", nil
 
 	// Free inodes reached threshold
 	case volInfo.CapacityInodes > 0.0 && (freeInodes < threshold):
 		r.eventRecorder.Eventf(
-			pvcObj,
+			pvc,
 			corev1.EventTypeWarning,
 			"FreeInodesThresholdReached",
 			"free inodes (%d%%) are less than the configured threshold (%d%%)",
 			freeInodes,
 			threshold,
 		)
-		metrics.ThresholdReachedTotal.WithLabelValues(pvcObj.Namespace, pvcObj.Name, "inodes").Inc()
+		metrics.ThresholdReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name, "inodes").Inc()
 
 		return true, "passing inodes threshold", nil
 
@@ -493,52 +492,46 @@ func (r *Runner) shouldReconcilePVC(ctx context.Context, pvca *v1alpha1.Persiste
 
 // resizePVC performs the actual resize of the PVC targeted by the given
 // [v1alpha1.PersistentVolumeClaimAutoscaler].
-func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, scalingReason string) error {
-	pvcObjKey := client.ObjectKey{Namespace: pvca.Namespace, Name: pvca.Spec.TargetRef.Name}
-	pvcObj := &corev1.PersistentVolumeClaim{}
-	if err := r.client.Get(ctx, pvcObjKey, pvcObj); err != nil {
-		return client.IgnoreNotFound(err)
-	}
-
-	logger := log.FromContext(ctx).WithValues("pvc", pvcObj.Name)
-	currSpecSize := pvcObj.Spec.Resources.Requests.Storage()
-	currStatusSize := pvcObj.Status.Capacity.Storage()
+func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvc *corev1.PersistentVolumeClaim, scalingReason string) error {
+	logger := log.FromContext(ctx).WithValues("pvc", pvc.Name)
+	currSpecSize := pvc.Spec.Resources.Requests.Storage()
+	currStatusSize := pvc.Status.Capacity.Storage()
 
 	// Currently only one policy is supported, since only one PVC can be targeted by a PVCA object
 	policy := pvca.Spec.VolumePolicies[0]
 
 	// Make sure that the PVC is not being modified at the moment.
-	if utils.IsPersistentVolumeClaimConditionTrue(pvcObj, corev1.PersistentVolumeClaimResizing) {
+	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimResizing) {
 		logger.Info("resize has been started")
 		condition := metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf(" - %s: is being scaled due to %s, resize has been started", pvcObj.Name, scalingReason),
+			Message: fmt.Sprintf(" - %s: is being scaled due to %s, resize has been started", pvc.Name, scalingReason),
 		}
 
 		return pvca.SetCondition(ctx, r.client, condition)
 	}
 
-	if utils.IsPersistentVolumeClaimConditionTrue(pvcObj, corev1.PersistentVolumeClaimFileSystemResizePending) {
+	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimFileSystemResizePending) {
 		logger.Info("filesystem resize is pending")
 		condition := metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf(" - %s: is being scaled due to %s, file system resize is pending", pvcObj.Name, scalingReason),
+			Message: fmt.Sprintf(" - %s: is being scaled due to %s, file system resize is pending", pvc.Name, scalingReason),
 		}
 
 		return pvca.SetCondition(ctx, r.client, condition)
 	}
 
-	if utils.IsPersistentVolumeClaimConditionTrue(pvcObj, corev1.PersistentVolumeClaimVolumeModifyingVolume) {
+	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimVolumeModifyingVolume) {
 		logger.Info("volume is being modified")
 		condition := metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf(" - %s: is being scaled due to %s, volume is being modified", pvcObj.Name, scalingReason),
+			Message: fmt.Sprintf(" - %s: is being scaled due to %s, volume is being modified", pvc.Name, scalingReason),
 		}
 
 		return pvca.SetCondition(ctx, r.client, condition)
@@ -553,7 +546,7 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf(" - %s: is being scaled due to %s, persistent volume claim is still being resized", pvcObj.Name, scalingReason),
+			Message: fmt.Sprintf(" - %s: is being scaled due to %s, persistent volume claim is still being resized", pvc.Name, scalingReason),
 		}
 
 		return pvca.SetCondition(ctx, r.client, condition)
@@ -581,19 +574,19 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 	// We don't want to exceed the max capacity
 	if targetSize.Value() > policy.MaxCapacity.Value() {
 		r.eventRecorder.Eventf(
-			pvcObj,
+			pvc,
 			corev1.EventTypeWarning,
 			"MaxCapacityReached",
 			"max capacity (%s) has been reached, will not resize",
 			policy.MaxCapacity.String(),
 		)
 		logger.Info("max capacity reached")
-		metrics.MaxCapacityReachedTotal.WithLabelValues(pvcObj.Namespace, pvcObj.Name).Inc()
+		metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
 		condition := metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionFalse,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf(" - %s: max capacity reached", pvcObj.Name),
+			Message: fmt.Sprintf(" - %s: max capacity reached", pvc.Name),
 		}
 
 		return pvca.SetCondition(ctx, r.client, condition)
@@ -611,7 +604,7 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 					Type:    string(v1alpha1.ConditionTypeResizing),
 					Status:  metav1.ConditionFalse,
 					Reason:  ReasonPVCResizeCooldown,
-					Message: fmt.Sprintf("- %s: cooldown duration has not elapsed yet", pvcObj.Name),
+					Message: fmt.Sprintf("- %s: cooldown duration has not elapsed yet", pvc.Name),
 				}
 
 				return pvca.SetCondition(ctx, r.client, condition)
@@ -621,9 +614,9 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 
 	// And finally we should be good to resize now
 	logger.Info("resizing persistent volume claim", "from", currSpecSize.String(), "to", targetSize.String())
-	metrics.ResizedTotal.WithLabelValues(pvcObj.Namespace, pvcObj.Name).Inc()
+	metrics.ResizedTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
 	r.eventRecorder.Eventf(
-		pvcObj,
+		pvc,
 		corev1.EventTypeNormal,
 		"ResizingStorage",
 		"resizing storage from %s to %s",
@@ -632,9 +625,9 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 	)
 
 	// Update PVC and PVCA resources
-	pvcPatch := client.MergeFrom(pvcObj.DeepCopy())
-	pvcObj.Spec.Resources.Requests[corev1.ResourceStorage] = *targetSize
-	if err := r.client.Patch(ctx, pvcObj, pvcPatch); err != nil {
+	pvcPatch := client.MergeFrom(pvc.DeepCopy())
+	pvc.Spec.Resources.Requests[corev1.ResourceStorage] = *targetSize
+	if err := r.client.Patch(ctx, pvc, pvcPatch); err != nil {
 		return err
 	}
 
@@ -650,7 +643,7 @@ func (r *Runner) resizePVC(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 		Type:    string(v1alpha1.ConditionTypeResizing),
 		Status:  metav1.ConditionTrue,
 		Reason:  ReasonReconcile,
-		Message: fmt.Sprintf("- %s: resizing from %s to %s due to %s", pvcObj.Name, currSpecSize.String(), targetSize.String(), scalingReason),
+		Message: fmt.Sprintf("- %s: resizing from %s to %s due to %s", pvc.Name, currSpecSize.String(), targetSize.String(), scalingReason),
 	}
 
 	return pvca.SetCondition(ctx, r.client, condition)

--- a/internal/periodic/periodic_suite_test.go
+++ b/internal/periodic/periodic_suite_test.go
@@ -13,6 +13,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"
@@ -71,6 +72,9 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 
 	err = corev1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = appsv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = v1alpha1.AddToScheme(scheme.Scheme)

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -716,8 +716,8 @@ var _ = Describe("Periodic Runner", func() {
 			})
 		})
 
-		Describe("#resizePVC", func() {
-			DescribeTable("should handle resize based on PVC conditions and threshold type",
+		Describe("#isResizeInProgress", func() {
+			DescribeTable("should detect whether resize is in progress based on PVC conditions",
 				func(
 					pvcConditionType *corev1.PersistentVolumeClaimConditionType,
 					recommendedSize string,
@@ -726,7 +726,7 @@ var _ = Describe("Periodic Runner", func() {
 					reason string,
 					expectedLogSubstring string,
 					expectedMessageRegex string,
-					expectResize bool,
+					expectInProgress bool,
 				) {
 					if pvcConditionType != nil {
 						By("Patching shared pvc with condition")
@@ -756,15 +756,113 @@ var _ = Describe("Periodic Runner", func() {
 					logger := zap.New(zap.WriteTo(w))
 					newCtx := log.IntoContext(parentCtx, logger)
 
+					inProgress, err := runner.isResizeInProgress(newCtx, pvca, pvc, reason)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(inProgress).To(Equal(expectInProgress))
+
+					if expectInProgress {
+						if expectedLogSubstring != "" {
+							Expect(buf.String()).To(ContainSubstring(expectedLogSubstring))
+						}
+
+						Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
+						Expect(pvca.Status.Conditions).To(ContainElement(And(
+							HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
+							HaveField("Status", metav1.ConditionTrue),
+							HaveField("Reason", ReasonReconcile),
+							HaveField("Message", MatchRegexp(expectedMessageRegex)),
+						)))
+					}
+				},
+				Entry("should detect resize has been started",
+					ptr.To(corev1.PersistentVolumeClaimResizing),
+					"1Gi",
+					ptr.To(95),
+					nil,
+					"passing storage threshold",
+					"resize has been started",
+					`storage threshold.*resize has been started`,
+					true,
+				),
+				Entry("should detect filesystem resize is pending",
+					ptr.To(corev1.PersistentVolumeClaimFileSystemResizePending),
+					"1Gi",
+					nil,
+					ptr.To(95),
+					"passing inodes threshold",
+					"filesystem resize is pending",
+					`passing inodes threshold.*file system resize is pending`,
+					true,
+				),
+				Entry("should detect volume is being modified",
+					ptr.To(corev1.PersistentVolumeClaimVolumeModifyingVolume),
+					"1Gi",
+					ptr.To(95),
+					nil,
+					"passing storage threshold",
+					"volume is being modified",
+					`storage threshold.*volume is being modified`,
+					true,
+				),
+				Entry("should detect pvc is still being resized",
+					nil,
+					"1Gi",
+					nil,
+					ptr.To(95),
+					"passing inodes threshold",
+					"persistent volume claim is still being resized",
+					`passing inodes threshold.*persistent volume claim is still being resized`,
+					true,
+				),
+				Entry("should return false when no resize is in progress",
+					nil,
+					"2Gi",
+					ptr.To(95),
+					nil,
+					"passing storage threshold",
+					"",
+					"",
+					false,
+				),
+			)
+		})
+
+		Describe("#resizePVC", func() {
+			DescribeTable("should resize based on threshold type",
+				func(
+					recommendedSize string,
+					usedSpacePercent *int,
+					usedInodesPercent *int,
+					reason string,
+					expectedLogSubstring string,
+					expectedMessageRegex string,
+				) {
+					By("Patching shared pvca with volume recommendation")
+					pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+					pvca.Status.VolumeRecommendations = []v1alpha1.VolumeRecommendation{
+						{
+							Name: "test-pvc",
+							Current: v1alpha1.CurrentVolumeStatus{
+								Size:              ptr.To(resource.MustParse(recommendedSize)),
+								UsedSpacePercent:  usedSpacePercent,
+								UsedInodesPercent: usedInodesPercent,
+							},
+						},
+					}
+					Expect(k8sClient.Status().Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+					var buf strings.Builder
+					w := io.MultiWriter(GinkgoWriter, &buf)
+					logger := zap.New(zap.WriteTo(w))
+					newCtx := log.IntoContext(parentCtx, logger)
+
 					Expect(runner.resizePVC(newCtx, pvca, pvc, reason)).To(Succeed())
 					Expect(buf.String()).To(ContainSubstring(expectedLogSubstring))
 
-					if expectResize {
-						By("Verifying PVC was resized")
-						var resizedPvc corev1.PersistentVolumeClaim
-						Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &resizedPvc)).To(Succeed())
-						Expect(resizedPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse(recommendedSize)))
-					}
+					By("Verifying PVC was resized")
+					var resizedPvc corev1.PersistentVolumeClaim
+					Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &resizedPvc)).To(Succeed())
+					Expect(resizedPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse(recommendedSize)))
 
 					Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
 					Expect(pvca.Status.Conditions).To(ContainElement(And(
@@ -774,65 +872,21 @@ var _ = Describe("Periodic Runner", func() {
 						HaveField("Message", MatchRegexp(expectedMessageRegex)),
 					)))
 				},
-				Entry("should skip resize if pvc resize has been started",
-					ptr.To(corev1.PersistentVolumeClaimResizing),
-					"1Gi",
-					ptr.To(95),
-					nil,
-					"passing storage threshold",
-					"resize has been started",
-					`storage threshold.*resize has been started`,
-					false,
-				),
-				Entry("should skip resize if filesystem resize is pending",
-					ptr.To(corev1.PersistentVolumeClaimFileSystemResizePending),
-					"1Gi",
-					nil,
-					ptr.To(95),
-					"passing inodes threshold",
-					"filesystem resize is pending",
-					`passing inodes threshold.*file system resize is pending`,
-					false,
-				),
-				Entry("should skip resize if volume is being modified",
-					ptr.To(corev1.PersistentVolumeClaimVolumeModifyingVolume),
-					"1Gi",
-					ptr.To(95),
-					nil,
-					"passing storage threshold",
-					"volume is being modified",
-					`storage threshold.*volume is being modified`,
-					false,
-				),
-				Entry("should skip resize if pvc is still being resized",
-					nil,
-					"1Gi",
-					nil,
-					ptr.To(95),
-					"passing inodes threshold",
-					"persistent volume claim is still being resized",
-					`passing inodes threshold.*persistent volume claim is still being resized`,
-					false,
-				),
 				Entry("should successfully resize the pvc based on storage threshold",
-					nil,
 					"2Gi",
 					ptr.To(95),
 					nil,
 					"passing storage threshold",
 					"resizing persistent volume claim",
 					`resizing from 1Gi to 2Gi.*passing storage threshold`,
-					true,
 				),
 				Entry("should successfully resize the pvc based on inodes threshold",
-					nil,
 					"2Gi",
 					nil,
 					ptr.To(95),
 					"passing inodes threshold",
 					"resizing persistent volume claim",
 					`resizing from 1Gi to 2Gi.*passing inodes threshold`,
-					true,
 				),
 			)
 

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -32,6 +32,8 @@ import (
 	testutils "github.com/gardener/pvc-autoscaler/test/utils"
 )
 
+const nonExistentPVCName = "non-existent-pvc"
+
 // creates a new test periodic runner
 func newRunner() (*Runner, error) {
 	metricsSource := fake.New(
@@ -52,7 +54,7 @@ func newRunner() (*Runner, error) {
 // createPodWithPVC creates a Pod in the "default" namespace with the given
 // labels and a single PVC volume referencing claimName. The Pod is registered
 // for cleanup via DeferCleanup.
-func createPodWithPVC(ctx context.Context, name string, labels map[string]string, claimName string) *corev1.Pod {
+func createPodWithPVC(ctx context.Context, name string, labels map[string]string, claimName string) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -73,7 +75,6 @@ func createPodWithPVC(ctx context.Context, name string, labels map[string]string
 	DeferCleanup(func() {
 		Expect(testutils.CleanupObject(ctx, k8sClient, pod)).To(Succeed())
 	})
-	return pod
 }
 
 var _ = Describe("Periodic Runner", func() {
@@ -507,7 +508,7 @@ var _ = Describe("Periodic Runner", func() {
 			It("should not reconcile when PVCA targets non-existent PVC", func() {
 				By("Patching PVCA to target a non-existent PVC")
 				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
-				pvca.Spec.TargetRef.Name = "non-existent-pvc"
+				pvca.Spec.TargetRef.Name = nonExistentPVCName
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
 
 				By("Registering metrics for the test PVC")
@@ -696,7 +697,7 @@ var _ = Describe("Periodic Runner", func() {
 
 				By("Patching PVCA to target a non-existent PVC so the fetcher fails")
 				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
-				pvca.Spec.TargetRef.Name = "non-existent-pvc"
+				pvca.Spec.TargetRef.Name = nonExistentPVCName
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
 
 				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
@@ -720,7 +721,7 @@ var _ = Describe("Periodic Runner", func() {
 			It("should not set a Resizing condition on PVC fetch failure when none existed before", func() {
 				By("Patching PVCA to target a non-existent PVC so the fetcher fails")
 				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
-				pvca.Spec.TargetRef.Name = "non-existent-pvc"
+				pvca.Spec.TargetRef.Name = nonExistentPVCName
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
 
 				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
@@ -985,7 +986,7 @@ var _ = Describe("Periodic Runner", func() {
 				})
 
 				By("Creating a Pod that references a PVC which does not exist")
-				createPodWithPVC(parentCtx, "missing-pvc-pod", selectorLabels, "non-existent-pvc")
+				createPodWithPVC(parentCtx, "missing-pvc-pod", selectorLabels, nonExistentPVCName)
 
 				By("Patching the PVCA to target the Deployment")
 				pvcaPatch := client.MergeFrom(pvca.DeepCopy())

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Periodic Runner", func() {
 						Expect(k8sClient.Patch(parentCtx, pvca, patch)).To(Succeed())
 					}
 
-					ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, volInfo)
+					ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
 					Expect(ok).To(BeFalse())
 					if expectedErr != nil {
 						Expect(err).To(MatchError(expectedErr))
@@ -223,11 +223,6 @@ var _ = Describe("Periodic Runner", func() {
 						Expect(err).To(HaveOccurred())
 					}
 				},
-				Entry("should return error when PVC is not found",
-					"non-existent-pvc",
-					nil,
-					nil,
-				),
 				Entry("should return ErrNoMetrics when volInfo is nil",
 					"",
 					nil,
@@ -266,7 +261,7 @@ var _ = Describe("Periodic Runner", func() {
 					AvailableInodes: 1000,
 					CapacityInodes:  1000,
 				}
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, volInfo)
+				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(MatchError(common.ErrStaleMetrics))
 
@@ -277,7 +272,7 @@ var _ = Describe("Periodic Runner", func() {
 					AvailableInodes: 1000,
 					CapacityInodes:  1000,
 				}
-				ok, _, err = runner.shouldReconcilePVC(parentCtx, pvca, volInfo)
+				ok, _, err = runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -324,7 +319,7 @@ var _ = Describe("Periodic Runner", func() {
 					CapacityInodes:  1000,
 					AvailableInodes: 500,
 				}
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, volInfo)
+				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(MatchError(ErrStorageClassNotFound))
 			})
@@ -388,7 +383,7 @@ var _ = Describe("Periodic Runner", func() {
 					CapacityInodes:  1000,
 					AvailableInodes: 500,
 				}
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, volInfo)
+				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(MatchError(ErrStorageClassDoesNotSupportExpansion))
 			})
@@ -435,7 +430,7 @@ var _ = Describe("Periodic Runner", func() {
 					CapacityInodes:  1000,
 				}
 
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, volInfo)
+				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(MatchError(ErrVolumeModeIsNotFilesystem))
 			})
@@ -448,7 +443,7 @@ var _ = Describe("Periodic Runner", func() {
 					CapacityInodes:  10000,
 				}
 
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, volInfo)
+				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
 				Expect(ok).To(BeFalse())
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -466,7 +461,7 @@ var _ = Describe("Periodic Runner", func() {
 					CapacityInodes:  1000,
 				}
 
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, volInfo)
+				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
 				Expect(ok).To(BeFalse())
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -494,7 +489,7 @@ var _ = Describe("Periodic Runner", func() {
 						CapacityInodes:  1000,
 					}
 
-					ok, reason, err := testRunner.shouldReconcilePVC(parentCtx, pvca, volInfo)
+					ok, reason, err := testRunner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
 					Expect(ok).To(BeTrue())
 					Expect(reason).To(Equal("passing storage threshold"))
 					Expect(err).ToNot(HaveOccurred())
@@ -512,7 +507,7 @@ var _ = Describe("Periodic Runner", func() {
 						CapacityInodes:  1000,
 					}
 
-					ok, reason, err := testRunner.shouldReconcilePVC(parentCtx, pvca, volInfo)
+					ok, reason, err := testRunner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
 					Expect(ok).To(BeTrue())
 					Expect(reason).To(Equal("passing inodes threshold"))
 					Expect(err).ToNot(HaveOccurred())
@@ -761,7 +756,7 @@ var _ = Describe("Periodic Runner", func() {
 					logger := zap.New(zap.WriteTo(w))
 					newCtx := log.IntoContext(parentCtx, logger)
 
-					Expect(runner.resizePVC(newCtx, pvca, reason)).To(Succeed())
+					Expect(runner.resizePVC(newCtx, pvca, pvc, reason)).To(Succeed())
 					Expect(buf.String()).To(ContainSubstring(expectedLogSubstring))
 
 					if expectResize {
@@ -860,7 +855,7 @@ var _ = Describe("Periodic Runner", func() {
 				newCtx := log.IntoContext(parentCtx, logger)
 
 				By("Performing first resize")
-				Expect(runner.resizePVC(newCtx, pvca, "passing storage threshold")).To(Succeed())
+				Expect(runner.resizePVC(newCtx, pvca, pvc, "passing storage threshold")).To(Succeed())
 
 				wantLog := `"resizing persistent volume claim","pvc":"test-pvc","from":"1Gi","to":"2Gi"}`
 				Expect(buf.String()).To(ContainSubstring(wantLog))
@@ -879,7 +874,7 @@ var _ = Describe("Periodic Runner", func() {
 				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
 
 				By("Performing second resize")
-				Expect(runner.resizePVC(newCtx, pvca, "passing storage threshold")).To(Succeed())
+				Expect(runner.resizePVC(newCtx, pvca, &resizedPvc, "passing storage threshold")).To(Succeed())
 
 				wantLog = `"resizing persistent volume claim","pvc":"test-pvc","from":"2Gi","to":"3Gi"}`
 				Expect(buf.String()).To(ContainSubstring(wantLog))
@@ -895,7 +890,7 @@ var _ = Describe("Periodic Runner", func() {
 
 				By("Expecting third attempt to fail with max capacity reached")
 				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
-				Expect(runner.resizePVC(newCtx, pvca, "passing storage threshold")).To(Succeed())
+				Expect(runner.resizePVC(newCtx, pvca, &resizedPvc, "passing storage threshold")).To(Succeed())
 				Expect(buf.String()).To(ContainSubstring("max capacity reached"))
 
 				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
@@ -932,7 +927,7 @@ var _ = Describe("Periodic Runner", func() {
 					newCtx := log.IntoContext(parentCtx, logger)
 
 					beforeResize := time.Now()
-					Expect(runner.resizePVC(newCtx, pvca, "passing storage threshold")).To(Succeed())
+					Expect(runner.resizePVC(newCtx, pvca, pvc, "passing storage threshold")).To(Succeed())
 					Expect(buf.String()).To(ContainSubstring(expectedLog))
 
 					var pvcObj corev1.PersistentVolumeClaim

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -481,7 +481,7 @@ var _ = Describe("Periodic Runner", func() {
 					WithEventRecorder(eventRecorder)(testRunner)
 				})
 
-				It("should reconcile - free space threshold reached", func() {
+				It("should reconcile - used space threshold reached", func() {
 					volInfo := &metricssource.VolumeInfo{
 						AvailableBytes:  90 * 1024 * 1024,
 						CapacityBytes:   1024 * 1024 * 1024,
@@ -495,11 +495,11 @@ var _ = Describe("Periodic Runner", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					event := <-eventRecorder.Events
-					wantEvent := `Warning FreeSpaceThresholdReached free space (8%) is less than the configured threshold (20%)`
+					wantEvent := `Warning UsedSpaceThresholdReached used space (92%) exceeds the configured threshold (80%)`
 					Expect(event).To(Equal(wantEvent))
 				})
 
-				It("should reconcile when free inodes threshold reached", func() {
+				It("should reconcile when used inodes threshold reached", func() {
 					volInfo := &metricssource.VolumeInfo{
 						AvailableBytes:  1024 * 1024 * 1024,
 						CapacityBytes:   1024 * 1024 * 1024,
@@ -513,7 +513,7 @@ var _ = Describe("Periodic Runner", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					event := <-eventRecorder.Events
-					wantEvent := `Warning FreeInodesThresholdReached free inodes (9%) are less than the configured threshold (20%)`
+					wantEvent := `Warning UsedInodesThresholdReached used inodes (91%) exceeds the configured threshold (80%)`
 					Expect(event).To(Equal(wantEvent))
 				})
 			})

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -172,27 +172,84 @@ var _ = Describe("Periodic Runner", func() {
 			})
 		})
 
-		Describe("#updatePVCAStatus", func() {
-			It("should update the pvca with unknown values", func() {
-				Expect(runner.updatePVCAStatus(parentCtx, pvca, nil)).To(Succeed())
-				Expect(pvca.Status.LastCheck).NotTo(Equal(metav1.Time{}))
-				Expect(pvca.Status.NextCheck).NotTo(Equal(metav1.Time{}))
-				Expect(pvca.Status.VolumeRecommendations).To(ConsistOf(v1alpha1.VolumeRecommendation{
+		Describe("#updateVolumeRecommendationForPVC", func() {
+			It("should return ErrNoMetrics when volInfo is nil", func() {
+				volumeRecommendation, err := runner.updateVolumeRecommendationForPVC(parentCtx, pvca, pvc, nil)
+				Expect(volumeRecommendation).To(Equal(v1alpha1.VolumeRecommendation{}))
+				Expect(err).To(MatchError(common.ErrNoMetrics))
+			})
+
+			It("should return ErrStaleMetrics when metrics capacity deviates by more than 0.5Gi (small PVC)", func() {
+				volInfo := &metricssource.VolumeInfo{
+					AvailableBytes:  9 * 1024 * 1024,
+					CapacityBytes:   200 * 1024 * 1024, // delta ~824MiB > 0.5Gi tolerance
+					AvailableInodes: 1000,
+					CapacityInodes:  1000,
+				}
+
+				volumeRecommendation, err := runner.updateVolumeRecommendationForPVC(parentCtx, pvca, pvc, volInfo)
+				Expect(volumeRecommendation).To(Equal(v1alpha1.VolumeRecommendation{}))
+				Expect(err).To(MatchError(common.ErrStaleMetrics))
+			})
+
+			It("should apply 2% tolerance for stale metrics detection (large PVC)", func() {
+				By("Patching PVC to 100Gi and PVCA maxCapacity to 200Gi")
+				specPatch := client.MergeFrom(pvc.DeepCopy())
+				pvc.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("100Gi")
+				Expect(k8sClient.Patch(parentCtx, pvc, specPatch)).To(Succeed())
+
+				statusPatch := client.MergeFrom(pvc.DeepCopy())
+				pvc.Status.Capacity[corev1.ResourceStorage] = resource.MustParse("100Gi")
+				Expect(k8sClient.Status().Patch(parentCtx, pvc, statusPatch)).To(Succeed())
+
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("200Gi")
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				By("Calling updateVolumeRecommendationForPVC with metrics deviating by 3Gi")
+				volInfo := &metricssource.VolumeInfo{
+					AvailableBytes:  9 * 1024 * 1024,
+					CapacityBytes:   97 * 1024 * 1024 * 1024, // delta 3Gi > 2% tolerance
+					AvailableInodes: 1000,
+					CapacityInodes:  1000,
+				}
+				volumeRecommendation, err := runner.updateVolumeRecommendationForPVC(parentCtx, pvca, pvc, volInfo)
+				Expect(volumeRecommendation).To(Equal(v1alpha1.VolumeRecommendation{}))
+				Expect(err).To(MatchError(common.ErrStaleMetrics))
+
+				By("Calling updateVolumeRecommendationForPVC with metrics deviating by 1Gi")
+				volInfo = &metricssource.VolumeInfo{
+					AvailableBytes:  9 * 1024 * 1024,
+					CapacityBytes:   99 * 1024 * 1024 * 1024, // delta 1Gi < 2% tolerance
+					AvailableInodes: 1000,
+					CapacityInodes:  1000,
+				}
+				usedSpace, _ := volInfo.UsedSpacePercentage()
+				usedInodes, _ := volInfo.UsedInodesPercentage()
+
+				volumeRecommendation, err = runner.updateVolumeRecommendationForPVC(parentCtx, pvca, pvc, volInfo)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(volumeRecommendation).To(Equal(v1alpha1.VolumeRecommendation{
 					Name: pvc.Name,
+					Current: v1alpha1.CurrentVolumeStatus{
+						UsedSpacePercent:  ptr.To(usedSpace),
+						UsedInodesPercent: ptr.To(usedInodes),
+					},
 				}))
 			})
 
 			It("should update the pvca with valid percentage values", func() {
 				volInfo := &metricssource.VolumeInfo{
-					AvailableBytes:  1234,
-					CapacityBytes:   123450,
-					CapacityInodes:  2000,
-					AvailableInodes: 12345,
+					AvailableBytes:  9 * 1024 * 1024,
+					CapacityBytes:   1024 * 1024 * 1024,
+					CapacityInodes:  1000,
+					AvailableInodes: 1000,
 				}
 				usedSpace, _ := volInfo.UsedSpacePercentage()
 				usedInodes, _ := volInfo.UsedInodesPercentage()
 
-				Expect(runner.updatePVCAStatus(parentCtx, pvca, volInfo)).To(Succeed())
+				_, err := runner.updateVolumeRecommendationForPVC(parentCtx, pvca, pvc, volInfo)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(pvca.Status.LastCheck).NotTo(Equal(metav1.Time{}))
 				Expect(pvca.Status.NextCheck).NotTo(Equal(metav1.Time{}))
 				Expect(pvca.Status.VolumeRecommendations).To(ConsistOf(v1alpha1.VolumeRecommendation{
@@ -352,89 +409,19 @@ var _ = Describe("Periodic Runner", func() {
 			})
 		})
 
-		Describe("#shouldReconcilePVC", func() {
-			DescribeTable("error scenarios",
-				func(targetPVCName string, volInfo *metricssource.VolumeInfo, expectedErr error) {
-					if targetPVCName != "" {
-						By("Patching shared pvca to target " + targetPVCName)
-						patch := client.MergeFrom(pvca.DeepCopy())
-						pvca.Spec.TargetRef.Name = targetPVCName
-						Expect(k8sClient.Patch(parentCtx, pvca, patch)).To(Succeed())
-					}
-
-					ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
-					Expect(ok).To(BeFalse())
-					if expectedErr != nil {
-						Expect(err).To(MatchError(expectedErr))
-					} else {
-						Expect(err).To(HaveOccurred())
-					}
-				},
-				Entry("should return ErrNoMetrics when volInfo is nil",
-					"",
-					nil,
-					common.ErrNoMetrics,
-				),
-				Entry("should return ErrStaleMetrics when metrics capacity deviates by more than 0.5Gi (small PVC)",
-					"",
-					&metricssource.VolumeInfo{
-						AvailableBytes:  9 * 1024 * 1024,
-						CapacityBytes:   200 * 1024 * 1024, // delta ~824MiB > 0.5Gi tolerance
-						AvailableInodes: 1000,
-						CapacityInodes:  1000,
-					},
-					common.ErrStaleMetrics,
-				),
-			)
-
-			It("should apply 2% tolerance for stale metrics detection (large PVC)", func() {
-				By("Patching PVC to 100Gi and PVCA maxCapacity to 200Gi")
-				specPatch := client.MergeFrom(pvc.DeepCopy())
-				pvc.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("100Gi")
-				Expect(k8sClient.Patch(parentCtx, pvc, specPatch)).To(Succeed())
-
-				statusPatch := client.MergeFrom(pvc.DeepCopy())
-				pvc.Status.Capacity[corev1.ResourceStorage] = resource.MustParse("100Gi")
-				Expect(k8sClient.Status().Patch(parentCtx, pvc, statusPatch)).To(Succeed())
-
-				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
-				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("200Gi")
-				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
-
-				By("Calling shouldReconcilePVC with metrics deviating by 3Gi")
-				volInfo := &metricssource.VolumeInfo{
-					AvailableBytes:  9 * 1024 * 1024,
-					CapacityBytes:   97 * 1024 * 1024 * 1024, // delta 3Gi > 2% tolerance
-					AvailableInodes: 1000,
-					CapacityInodes:  1000,
-				}
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
-				Expect(ok).To(BeFalse())
-				Expect(err).To(MatchError(common.ErrStaleMetrics))
-
-				By("Calling shouldReconcilePVC with metrics deviating by 1Gi")
-				volInfo = &metricssource.VolumeInfo{
-					AvailableBytes:  9 * 1024 * 1024,
-					CapacityBytes:   99 * 1024 * 1024 * 1024, // delta 1Gi < 2% tolerance
-					AvailableInodes: 1000,
-					CapacityInodes:  1000,
-				}
-				ok, _, err = runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(ok).To(BeTrue())
-			})
-
+		Describe("#shouldResizePVC", func() {
 			It("should not reconcile when threshold is not reached", func() {
-				volInfo := &metricssource.VolumeInfo{
-					AvailableBytes:  1024 * 1024 * 1024,
-					CapacityBytes:   1024 * 1024 * 1024,
-					AvailableInodes: 10000,
-					CapacityInodes:  10000,
+				volumeRecommendation := v1alpha1.VolumeRecommendation{
+					Name: pvc.Name,
+					Current: v1alpha1.CurrentVolumeStatus{
+						UsedSpacePercent:  ptr.To(50),
+						UsedInodesPercent: ptr.To(50),
+					},
 				}
 
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
+				ok, reason := runner.shouldResizePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volumeRecommendation)
 				Expect(ok).To(BeFalse())
-				Expect(err).ToNot(HaveOccurred())
+				Expect(reason).To(BeEmpty())
 			})
 
 			Context("Should reconcile when thresholds are reached", func() {
@@ -453,17 +440,17 @@ var _ = Describe("Periodic Runner", func() {
 				})
 
 				It("should reconcile - used space threshold reached", func() {
-					volInfo := &metricssource.VolumeInfo{
-						AvailableBytes:  90 * 1024 * 1024,
-						CapacityBytes:   1024 * 1024 * 1024,
-						AvailableInodes: 1000,
-						CapacityInodes:  1000,
+					volumeRecommendation := v1alpha1.VolumeRecommendation{
+						Name: pvc.Name,
+						Current: v1alpha1.CurrentVolumeStatus{
+							UsedSpacePercent:  ptr.To(92),
+							UsedInodesPercent: ptr.To(0),
+						},
 					}
 
-					ok, reason, err := testRunner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
+					ok, reason := testRunner.shouldResizePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volumeRecommendation)
 					Expect(ok).To(BeTrue())
 					Expect(reason).To(Equal("passing storage threshold"))
-					Expect(err).ToNot(HaveOccurred())
 
 					event := <-eventRecorder.Events
 					wantEvent := `Warning UsedSpaceThresholdReached used space (92%) exceeds the configured threshold (80%)`
@@ -471,17 +458,17 @@ var _ = Describe("Periodic Runner", func() {
 				})
 
 				It("should reconcile when used inodes threshold reached", func() {
-					volInfo := &metricssource.VolumeInfo{
-						AvailableBytes:  1024 * 1024 * 1024,
-						CapacityBytes:   1024 * 1024 * 1024,
-						AvailableInodes: 90,
-						CapacityInodes:  1000,
+					volumeRecommendation := v1alpha1.VolumeRecommendation{
+						Name: pvc.Name,
+						Current: v1alpha1.CurrentVolumeStatus{
+							UsedSpacePercent:  ptr.To(0),
+							UsedInodesPercent: ptr.To(91),
+						},
 					}
 
-					ok, reason, err := testRunner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
+					ok, reason := testRunner.shouldResizePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volumeRecommendation)
 					Expect(ok).To(BeTrue())
 					Expect(reason).To(Equal("passing inodes threshold"))
-					Expect(err).ToNot(HaveOccurred())
 
 					event := <-eventRecorder.Events
 					wantEvent := `Warning UsedInodesThresholdReached used inodes (91%) exceeds the configured threshold (80%)`
@@ -827,7 +814,7 @@ var _ = Describe("Periodic Runner", func() {
 					logger := zap.New(zap.WriteTo(w))
 					newCtx := log.IntoContext(parentCtx, logger)
 
-					Expect(runner.resizePVC(newCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), reason)).To(Succeed())
+					Expect(runner.resizePVC(newCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), reason, getOrCreateVolumeRecommendationForPVC(pvca, pvc.Name))).To(Succeed())
 					Expect(buf.String()).To(ContainSubstring(expectedLogSubstring))
 
 					By("Verifying PVC was resized")
@@ -880,7 +867,7 @@ var _ = Describe("Periodic Runner", func() {
 				newCtx := log.IntoContext(parentCtx, logger)
 
 				By("Performing first resize")
-				Expect(runner.resizePVC(newCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold")).To(Succeed())
+				Expect(runner.resizePVC(newCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold", getOrCreateVolumeRecommendationForPVC(pvca, pvc.Name))).To(Succeed())
 
 				wantLog := `"resizing persistent volume claim","pvc":"test-pvc","from":"1Gi","to":"2Gi"}`
 				Expect(buf.String()).To(ContainSubstring(wantLog))
@@ -899,7 +886,7 @@ var _ = Describe("Periodic Runner", func() {
 				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
 
 				By("Performing second resize")
-				Expect(runner.resizePVC(newCtx, pvca, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold")).To(Succeed())
+				Expect(runner.resizePVC(newCtx, pvca, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold", getOrCreateVolumeRecommendationForPVC(pvca, resizedPvc.Name))).To(Succeed())
 
 				wantLog = `"resizing persistent volume claim","pvc":"test-pvc","from":"2Gi","to":"3Gi"}`
 				Expect(buf.String()).To(ContainSubstring(wantLog))
@@ -915,7 +902,7 @@ var _ = Describe("Periodic Runner", func() {
 
 				By("Expecting third attempt to fail with max capacity reached")
 				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
-				Expect(runner.resizePVC(newCtx, pvca, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold")).To(Succeed())
+				Expect(runner.resizePVC(newCtx, pvca, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold", getOrCreateVolumeRecommendationForPVC(pvca, resizedPvc.Name))).To(Succeed())
 				Expect(buf.String()).To(ContainSubstring("max capacity reached"))
 
 				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
@@ -952,7 +939,7 @@ var _ = Describe("Periodic Runner", func() {
 					newCtx := log.IntoContext(parentCtx, logger)
 
 					beforeResize := time.Now()
-					Expect(runner.resizePVC(newCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold")).To(Succeed())
+					Expect(runner.resizePVC(newCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold", getOrCreateVolumeRecommendationForPVC(pvca, pvc.Name))).To(Succeed())
 					Expect(buf.String()).To(ContainSubstring(expectedLog))
 
 					var pvcObj corev1.PersistentVolumeClaim

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -205,6 +205,153 @@ var _ = Describe("Periodic Runner", func() {
 			})
 		})
 
+		Describe("#validatePVC", func() {
+			It("should return ErrStorageClassNotFound", func() {
+				By("Creating a PVC without a StorageClass")
+				pvc, err := testutils.CreatePVC(parentCtx, k8sClient, "pvc-without-storageclass", "1Gi", nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() {
+					By("Deleting PVC without a StorageClass")
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvc)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), pvc)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				By("Creating PVCA targeting the PVC without StorageClass")
+				targetRef := autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "v1",
+					Kind:       "PersistentVolumeClaim",
+					Name:       "pvc-without-storageclass",
+				}
+
+				pvca, err := testutils.CreatePersistentVolumeClaimAutoscaler(
+					parentCtx,
+					k8sClient,
+					"pvca-without-storageclass",
+					targetRef,
+					defaultVolumePolicies,
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pvca).NotTo(BeNil())
+				DeferCleanup(func() {
+					By("Deleting PVCA targeting the PVC without StorageClass")
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvca)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				err = runner.validatePVC(parentCtx, pvc, volumePolicyForPVC(pvca, pvc))
+				Expect(err).To(MatchError(ErrStorageClassNotFound))
+			})
+
+			It("should return ErrStorageClassDoesNotSupportExpansion", func() {
+				By("Creating a StorageClass that does not support volume expansion")
+				scName := "storageclass-without-expansion"
+				sc := &storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: scName,
+					},
+					Provisioner:          "no-provisioner",
+					VolumeBindingMode:    ptr.To(storagev1.VolumeBindingImmediate),
+					AllowVolumeExpansion: ptr.To(false),
+					ReclaimPolicy:        ptr.To(corev1.PersistentVolumeReclaimDelete),
+				}
+				Expect(k8sClient.Create(parentCtx, sc)).To(Succeed())
+				DeferCleanup(func() {
+					By("Deleting StorageClass that does not support volume expansion")
+					Expect(client.IgnoreNotFound(k8sClient.Delete(parentCtx, sc))).To(Succeed())
+				})
+
+				By("Creating a test PVC using the StorageClass")
+				pvc, err := testutils.CreatePVC(parentCtx, k8sClient, "pvc-sc-no-expansion", "1Gi", ptr.To(scName), nil)
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() {
+					By("Deleting the PVC with StorageClass")
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvc)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), pvc)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				By("Creating PVCA targeting the PVC with StorageClass")
+				targetRef := autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "v1",
+					Kind:       "PersistentVolumeClaim",
+					Name:       "pvc-sc-no-expansion",
+				}
+
+				pvca, err := testutils.CreatePersistentVolumeClaimAutoscaler(
+					parentCtx,
+					k8sClient,
+					"pvca-sc-no-expansion",
+					targetRef,
+					defaultVolumePolicies,
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pvca).NotTo(BeNil())
+				DeferCleanup(func() {
+					By("Deleting PVCA targeting the PVC with StorageClass")
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvca)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				err = runner.validatePVC(parentCtx, pvc, volumePolicyForPVC(pvca, pvc))
+				Expect(err).To(MatchError(ErrStorageClassDoesNotSupportExpansion))
+			})
+
+			It("should return ErrVolumeModeIsNotFilesystem", func() {
+				By("Creating PVC with block volume")
+				pvc, err := testutils.CreatePVC(parentCtx, k8sClient, "pvc-block-mode", "1Gi", ptr.To(testutils.StorageClassName), ptr.To(corev1.PersistentVolumeBlock))
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvc)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), pvc)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				By("Creating PVCA targeting the PVC with block volume")
+				targetRef := autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "v1",
+					Kind:       "PersistentVolumeClaim",
+					Name:       "pvc-block-mode",
+				}
+				pvca, err := testutils.CreatePersistentVolumeClaimAutoscaler(
+					parentCtx,
+					k8sClient,
+					"pvca-block-mode",
+					targetRef,
+					defaultVolumePolicies,
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pvca).NotTo(BeNil())
+				DeferCleanup(func() {
+					By("Deleting the PVCA targeting the PVC with block volume")
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvca)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				err = runner.validatePVC(parentCtx, pvc, volumePolicyForPVC(pvca, pvc))
+				Expect(err).To(MatchError(ErrVolumeModeIsNotFilesystem))
+			})
+
+			It("should return ErrPVCNotBound when PVC is not bound", func() {
+				By("Patching test PVC to simulate lost claim")
+				patch := client.MergeFrom(pvc.DeepCopy())
+				pvc.Status.Phase = corev1.ClaimLost
+				Expect(k8sClient.Status().Patch(parentCtx, pvc, patch)).To(Succeed())
+
+				err := runner.validatePVC(parentCtx, pvc, volumePolicyForPVC(pvca, pvc))
+				Expect(err).To(MatchError(ErrPVCNotBound))
+			})
+		})
+
 		Describe("#shouldReconcilePVC", func() {
 			DescribeTable("error scenarios",
 				func(targetPVCName string, volInfo *metricssource.VolumeInfo, expectedErr error) {
@@ -277,188 +424,12 @@ var _ = Describe("Periodic Runner", func() {
 				Expect(ok).To(BeTrue())
 			})
 
-			It("should return ErrStorageClassNotFound", func() {
-				By("Creating a PVC without a StorageClass")
-				pvc, err := testutils.CreatePVC(parentCtx, k8sClient, "pvc-without-storageclass", "1Gi", nil, nil)
-				Expect(err).NotTo(HaveOccurred())
-				DeferCleanup(func() {
-					By("Deleting PVC without a StorageClass")
-					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvc)).To(Succeed())
-					Eventually(func() error {
-						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), pvc)
-					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
-				})
-
-				By("Creating PVCA targeting the PVC without StorageClass")
-				targetRef := autoscalingv1.CrossVersionObjectReference{
-					APIVersion: "v1",
-					Kind:       "PersistentVolumeClaim",
-					Name:       "pvc-without-storageclass",
-				}
-
-				pvca, err := testutils.CreatePersistentVolumeClaimAutoscaler(
-					parentCtx,
-					k8sClient,
-					"pvca-without-storageclass",
-					targetRef,
-					defaultVolumePolicies,
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pvca).NotTo(BeNil())
-				DeferCleanup(func() {
-					By("Deleting PVCA targeting the PVC without StorageClass")
-					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvca)).To(Succeed())
-					Eventually(func() error {
-						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)
-					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
-				})
-
-				volInfo := &metricssource.VolumeInfo{
-					CapacityBytes:   1073741824, // 1Gi
-					AvailableBytes:  536870912,  // 512Mi
-					CapacityInodes:  1000,
-					AvailableInodes: 500,
-				}
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
-				Expect(ok).To(BeFalse())
-				Expect(err).To(MatchError(ErrStorageClassNotFound))
-			})
-
-			It("should return ErrStorageClassDoesNotSupportExpansion", func() {
-				By("Creating a StorageClass that does not support volume expansion")
-				scName := "storageclass-without-expansion"
-				sc := &storagev1.StorageClass{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: scName,
-					},
-					Provisioner:          "no-provisioner",
-					VolumeBindingMode:    ptr.To(storagev1.VolumeBindingImmediate),
-					AllowVolumeExpansion: ptr.To(false),
-					ReclaimPolicy:        ptr.To(corev1.PersistentVolumeReclaimDelete),
-				}
-				Expect(k8sClient.Create(parentCtx, sc)).To(Succeed())
-				DeferCleanup(func() {
-					By("Deleting StorageClass that does not support volume expansion")
-					Expect(client.IgnoreNotFound(k8sClient.Delete(parentCtx, sc))).To(Succeed())
-				})
-
-				By("Creating a test PVC using the StorageClass")
-				pvc, err := testutils.CreatePVC(parentCtx, k8sClient, "pvc-sc-no-expansion", "1Gi", ptr.To(scName), nil)
-				Expect(err).NotTo(HaveOccurred())
-				DeferCleanup(func() {
-					By("Deleting the PVC with StorageClass")
-					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvc)).To(Succeed())
-					Eventually(func() error {
-						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), pvc)
-					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
-				})
-
-				By("Creating PVCA targeting the PVC with StorageClass")
-				targetRef := autoscalingv1.CrossVersionObjectReference{
-					APIVersion: "v1",
-					Kind:       "PersistentVolumeClaim",
-					Name:       "pvc-sc-no-expansion",
-				}
-
-				pvca, err := testutils.CreatePersistentVolumeClaimAutoscaler(
-					parentCtx,
-					k8sClient,
-					"pvca-sc-no-expansion",
-					targetRef,
-					defaultVolumePolicies,
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pvca).NotTo(BeNil())
-				DeferCleanup(func() {
-					By("Deleting PVCA targeting the PVC with StorageClass")
-					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvca)).To(Succeed())
-					Eventually(func() error {
-						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)
-					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
-				})
-
-				volInfo := &metricssource.VolumeInfo{
-					CapacityBytes:   1073741824, // 1Gi
-					AvailableBytes:  536870912,  // 512Mi
-					CapacityInodes:  1000,
-					AvailableInodes: 500,
-				}
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
-				Expect(ok).To(BeFalse())
-				Expect(err).To(MatchError(ErrStorageClassDoesNotSupportExpansion))
-			})
-
-			It("should return ErrVolumeModeIsNotFilesystem", func() {
-				By("Creating PVC with block volume")
-				pvc, err := testutils.CreatePVC(parentCtx, k8sClient, "pvc-block-mode", "1Gi", ptr.To(testutils.StorageClassName), ptr.To(corev1.PersistentVolumeBlock))
-				Expect(err).NotTo(HaveOccurred())
-				DeferCleanup(func() {
-					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvc)).To(Succeed())
-					Eventually(func() error {
-						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), pvc)
-					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
-				})
-
-				By("Creating PVCA targeting the PVC with block volume")
-				targetRef := autoscalingv1.CrossVersionObjectReference{
-					APIVersion: "v1",
-					Kind:       "PersistentVolumeClaim",
-					Name:       "pvc-block-mode",
-				}
-				pvca, err := testutils.CreatePersistentVolumeClaimAutoscaler(
-					parentCtx,
-					k8sClient,
-					"pvca-block-mode",
-					targetRef,
-					defaultVolumePolicies,
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pvca).NotTo(BeNil())
-				DeferCleanup(func() {
-					By("Deleting the PVCA targeting the PVC with block volume")
-					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvca)).To(Succeed())
-					Eventually(func() error {
-						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)
-					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
-				})
-
-				By("Calling shouldReconcilePVC with sample volume info metrics")
-				volInfo := &metricssource.VolumeInfo{
-					AvailableBytes:  1000,
-					CapacityBytes:   1024 * 1024 * 1024,
-					AvailableInodes: 1000,
-					CapacityInodes:  1000,
-				}
-
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
-				Expect(ok).To(BeFalse())
-				Expect(err).To(MatchError(ErrVolumeModeIsNotFilesystem))
-			})
-
 			It("should not reconcile when threshold is not reached", func() {
 				volInfo := &metricssource.VolumeInfo{
 					AvailableBytes:  1024 * 1024 * 1024,
 					CapacityBytes:   1024 * 1024 * 1024,
 					AvailableInodes: 10000,
 					CapacityInodes:  10000,
-				}
-
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
-				Expect(ok).To(BeFalse())
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("should not reconcile - lost pvc claim", func() {
-				By("Patching test PVC to simulate lost claim")
-				patch := client.MergeFrom(pvc.DeepCopy())
-				pvc.Status.Phase = corev1.ClaimLost
-				Expect(k8sClient.Status().Patch(parentCtx, pvc, patch)).To(Succeed())
-
-				volInfo := &metricssource.VolumeInfo{
-					AvailableBytes:  1000,
-					CapacityBytes:   1024 * 1024 * 1024,
-					AvailableInodes: 1000,
-					CapacityInodes:  1000,
 				}
 
 				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -1170,10 +1170,9 @@ var _ = Describe("Periodic Runner", func() {
 					var buf strings.Builder
 					w := io.MultiWriter(GinkgoWriter, &buf)
 					logger := zap.New(zap.WriteTo(w))
-					newCtx := log.IntoContext(parentCtx, logger)
 
 					aggregator := &resizingConditionAggregator{}
-					inProgress := runner.isResizeInProgress(newCtx, pvc, reason, volumeRecommendation, aggregator)
+					inProgress := runner.isResizeInProgress(logger, pvc, reason, volumeRecommendation, aggregator)
 					Expect(inProgress).To(Equal(expectInProgress))
 
 					if expectInProgress {
@@ -1265,10 +1264,9 @@ var _ = Describe("Periodic Runner", func() {
 					var buf strings.Builder
 					w := io.MultiWriter(GinkgoWriter, &buf)
 					logger := zap.New(zap.WriteTo(w))
-					newCtx := log.IntoContext(parentCtx, logger)
 
 					aggregator := &resizingConditionAggregator{}
-					updatedRecommendation, err := runner.resizePVC(newCtx, pvc, volumePolicyForPVC(pvca, pvc), reason, volumeRecommendation, aggregator)
+					updatedRecommendation, err := runner.resizePVC(parentCtx, logger, pvc, volumePolicyForPVC(pvca, pvc), reason, volumeRecommendation, aggregator)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(buf.String()).To(ContainSubstring(expectedLogSubstring))
 
@@ -1315,12 +1313,11 @@ var _ = Describe("Periodic Runner", func() {
 
 				var buf strings.Builder
 				w := io.MultiWriter(GinkgoWriter, &buf)
-				logger := zap.New(zap.WriteTo(w))
-				newCtx := log.IntoContext(parentCtx, logger)
+				logger := zap.New(zap.WriteTo(w)).WithValues("pvc", "test-pvc")
 
 				By("Performing first resize")
 				aggregator := &resizingConditionAggregator{}
-				volumeRecommendation, err := runner.resizePVC(newCtx, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold", volumeRecommendation, aggregator)
+				volumeRecommendation, err := runner.resizePVC(parentCtx, logger, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold", volumeRecommendation, aggregator)
 				Expect(err).NotTo(HaveOccurred())
 
 				wantLog := `"resizing persistent volume claim","pvc":"test-pvc","from":"1Gi","to":"2Gi"}`
@@ -1338,7 +1335,7 @@ var _ = Describe("Periodic Runner", func() {
 
 				By("Performing second resize")
 				aggregator = &resizingConditionAggregator{}
-				volumeRecommendation, err = runner.resizePVC(newCtx, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold", volumeRecommendation, aggregator)
+				volumeRecommendation, err = runner.resizePVC(parentCtx, logger, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold", volumeRecommendation, aggregator)
 				Expect(err).NotTo(HaveOccurred())
 
 				wantLog = `"resizing persistent volume claim","pvc":"test-pvc","from":"2Gi","to":"3Gi"}`
@@ -1355,7 +1352,7 @@ var _ = Describe("Periodic Runner", func() {
 
 				By("Expecting third attempt to fail with max capacity reached")
 				aggregator = &resizingConditionAggregator{}
-				_, err = runner.resizePVC(newCtx, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold", volumeRecommendation, aggregator)
+				_, err = runner.resizePVC(parentCtx, logger, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold", volumeRecommendation, aggregator)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(buf.String()).To(ContainSubstring("max capacity reached"))
 
@@ -1384,11 +1381,10 @@ var _ = Describe("Periodic Runner", func() {
 
 					var buf strings.Builder
 					logger := zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &buf)))
-					newCtx := log.IntoContext(parentCtx, logger)
 
 					beforeResize := time.Now()
 					aggregator := &resizingConditionAggregator{}
-					updatedRecommendation, err := runner.resizePVC(newCtx, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold", volumeRecommendation, aggregator)
+					updatedRecommendation, err := runner.resizePVC(parentCtx, logger, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold", volumeRecommendation, aggregator)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(buf.String()).To(ContainSubstring(expectedLog))
 

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Periodic Runner", func() {
 
 		Describe("#updateVolumeRecommendationForPVC", func() {
 			It("should return ErrNoMetrics when volInfo is nil", func() {
-				volumeRecommendation, err := runner.updateVolumeRecommendationForPVC(parentCtx, pvca, pvc, nil)
+				volumeRecommendation, err := runner.updateVolumeRecommendationForPVC(nil, pvc, nil)
 				Expect(volumeRecommendation).To(Equal(v1alpha1.VolumeRecommendation{}))
 				Expect(err).To(MatchError(common.ErrNoMetrics))
 			})
@@ -187,7 +187,7 @@ var _ = Describe("Periodic Runner", func() {
 					CapacityInodes:  1000,
 				}
 
-				volumeRecommendation, err := runner.updateVolumeRecommendationForPVC(parentCtx, pvca, pvc, volInfo)
+				volumeRecommendation, err := runner.updateVolumeRecommendationForPVC(nil, pvc, volInfo)
 				Expect(volumeRecommendation).To(Equal(v1alpha1.VolumeRecommendation{}))
 				Expect(err).To(MatchError(common.ErrStaleMetrics))
 			})
@@ -213,7 +213,7 @@ var _ = Describe("Periodic Runner", func() {
 					AvailableInodes: 1000,
 					CapacityInodes:  1000,
 				}
-				volumeRecommendation, err := runner.updateVolumeRecommendationForPVC(parentCtx, pvca, pvc, volInfo)
+				volumeRecommendation, err := runner.updateVolumeRecommendationForPVC(nil, pvc, volInfo)
 				Expect(volumeRecommendation).To(Equal(v1alpha1.VolumeRecommendation{}))
 				Expect(err).To(MatchError(common.ErrStaleMetrics))
 
@@ -227,7 +227,7 @@ var _ = Describe("Periodic Runner", func() {
 				usedSpace, _ := volInfo.UsedSpacePercentage()
 				usedInodes, _ := volInfo.UsedInodesPercentage()
 
-				volumeRecommendation, err = runner.updateVolumeRecommendationForPVC(parentCtx, pvca, pvc, volInfo)
+				volumeRecommendation, err = runner.updateVolumeRecommendationForPVC(nil, pvc, volInfo)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(volumeRecommendation).To(Equal(v1alpha1.VolumeRecommendation{
 					Name: pvc.Name,
@@ -238,7 +238,7 @@ var _ = Describe("Periodic Runner", func() {
 				}))
 			})
 
-			It("should update the pvca with valid percentage values", func() {
+			It("should return a recommendation with valid percentage values", func() {
 				volInfo := &metricssource.VolumeInfo{
 					AvailableBytes:  9 * 1024 * 1024,
 					CapacityBytes:   1024 * 1024 * 1024,
@@ -248,11 +248,9 @@ var _ = Describe("Periodic Runner", func() {
 				usedSpace, _ := volInfo.UsedSpacePercentage()
 				usedInodes, _ := volInfo.UsedInodesPercentage()
 
-				_, err := runner.updateVolumeRecommendationForPVC(parentCtx, pvca, pvc, volInfo)
+				volumeRecommendation, err := runner.updateVolumeRecommendationForPVC(nil, pvc, volInfo)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(pvca.Status.LastCheck).NotTo(Equal(metav1.Time{}))
-				Expect(pvca.Status.NextCheck).NotTo(Equal(metav1.Time{}))
-				Expect(pvca.Status.VolumeRecommendations).To(ConsistOf(v1alpha1.VolumeRecommendation{
+				Expect(volumeRecommendation).To(Equal(v1alpha1.VolumeRecommendation{
 					Name: pvc.Name,
 					Current: v1alpha1.CurrentVolumeStatus{
 						UsedSpacePercent:  ptr.To(usedSpace),
@@ -419,7 +417,7 @@ var _ = Describe("Periodic Runner", func() {
 					},
 				}
 
-				ok, reason := runner.shouldResizePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volumeRecommendation)
+				ok, reason := runner.shouldResizePVC(pvc, volumePolicyForPVC(pvca, pvc), volumeRecommendation)
 				Expect(ok).To(BeFalse())
 				Expect(reason).To(BeEmpty())
 			})
@@ -448,7 +446,7 @@ var _ = Describe("Periodic Runner", func() {
 						},
 					}
 
-					ok, reason := testRunner.shouldResizePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volumeRecommendation)
+					ok, reason := testRunner.shouldResizePVC(pvc, volumePolicyForPVC(pvca, pvc), volumeRecommendation)
 					Expect(ok).To(BeTrue())
 					Expect(reason).To(Equal("passing storage threshold"))
 
@@ -466,7 +464,7 @@ var _ = Describe("Periodic Runner", func() {
 						},
 					}
 
-					ok, reason := testRunner.shouldResizePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volumeRecommendation)
+					ok, reason := testRunner.shouldResizePVC(pvc, volumePolicyForPVC(pvca, pvc), volumeRecommendation)
 					Expect(ok).To(BeTrue())
 					Expect(reason).To(Equal("passing inodes threshold"))
 
@@ -577,7 +575,7 @@ var _ = Describe("Periodic Runner", func() {
 				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
 					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
 					HaveField("Status", metav1.ConditionTrue),
-					HaveField("Reason", ReasonMetricsFetched),
+					HaveField("Reason", ReasonRecommendationsProvided),
 				)))
 			})
 
@@ -653,6 +651,58 @@ var _ = Describe("Periodic Runner", func() {
 					HaveField("Reason", Not(Equal(ReasonAmbiguousPVCA))),
 				)))
 			})
+
+			It("should set Resizing to Unknown on PVC fetch failure when it was previously set", func() {
+				By("Seeding the PVCA with an existing Resizing condition")
+				patch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Status.Conditions = []metav1.Condition{
+					{
+						Type:               string(v1alpha1.ConditionTypeResizing),
+						Status:             metav1.ConditionTrue,
+						Reason:             ReasonReconcile,
+						Message:            "previous resize",
+						LastTransitionTime: metav1.Now(),
+					},
+				}
+				Expect(k8sClient.Status().Patch(parentCtx, pvca, patch)).To(Succeed())
+
+				By("Patching PVCA to target a non-existent PVC so the fetcher fails")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.TargetRef.Name = "non-existent-pvc"
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+
+				By("Verifying the Resizing condition transitions to Unknown")
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
+					HaveField("Status", metav1.ConditionUnknown),
+					HaveField("Reason", ReasonPVCFetchError),
+					HaveField("Message", Equal("Resizing state is unknown: failed to fetch PersistentVolumeClaims")),
+				)))
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
+					HaveField("Status", metav1.ConditionFalse),
+					HaveField("Reason", ReasonPVCFetchError),
+				)))
+			})
+
+			It("should not set a Resizing condition on PVC fetch failure when none existed before", func() {
+				By("Patching PVCA to target a non-existent PVC so the fetcher fails")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.TargetRef.Name = "non-existent-pvc"
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				for _, cond := range updatedPVCA.Status.Conditions {
+					Expect(cond.Type).NotTo(Equal(string(v1alpha1.ConditionTypeResizing)))
+				}
+			})
 		})
 
 		Describe("Start", func() {
@@ -695,27 +745,22 @@ var _ = Describe("Periodic Runner", func() {
 						Expect(k8sClient.Status().Patch(parentCtx, pvc, patch)).To(Succeed())
 					}
 
-					By("Patching shared pvca with volume recommendation")
-					pvcaPatch := client.MergeFrom(pvca.DeepCopy())
-					pvca.Status.VolumeRecommendations = []v1alpha1.VolumeRecommendation{
-						{
-							Name: "test-pvc",
-							Current: v1alpha1.CurrentVolumeStatus{
-								Size:              ptr.To(resource.MustParse(recommendedSize)),
-								UsedSpacePercent:  usedSpacePercent,
-								UsedInodesPercent: usedInodesPercent,
-							},
+					volumeRecommendation := v1alpha1.VolumeRecommendation{
+						Name: "test-pvc",
+						Current: v1alpha1.CurrentVolumeStatus{
+							Size:              ptr.To(resource.MustParse(recommendedSize)),
+							UsedSpacePercent:  usedSpacePercent,
+							UsedInodesPercent: usedInodesPercent,
 						},
 					}
-					Expect(k8sClient.Status().Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
 
 					var buf strings.Builder
 					w := io.MultiWriter(GinkgoWriter, &buf)
 					logger := zap.New(zap.WriteTo(w))
 					newCtx := log.IntoContext(parentCtx, logger)
 
-					inProgress, err := runner.isResizeInProgress(newCtx, pvca, pvc, reason)
-					Expect(err).NotTo(HaveOccurred())
+					aggregator := &resizingConditionAggregator{}
+					inProgress := runner.isResizeInProgress(newCtx, pvc, reason, volumeRecommendation, aggregator)
 					Expect(inProgress).To(Equal(expectInProgress))
 
 					if expectInProgress {
@@ -723,13 +768,14 @@ var _ = Describe("Periodic Runner", func() {
 							Expect(buf.String()).To(ContainSubstring(expectedLogSubstring))
 						}
 
-						Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
-						Expect(pvca.Status.Conditions).To(ContainElement(And(
+						Expect(aggregator.getAggregatedCondition()).To(And(
 							HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
 							HaveField("Status", metav1.ConditionTrue),
 							HaveField("Reason", ReasonReconcile),
 							HaveField("Message", MatchRegexp(expectedMessageRegex)),
-						)))
+						))
+					} else {
+						Expect(aggregator.getAggregatedCondition().Message).To(BeEmpty())
 					}
 				},
 				Entry("should detect resize has been started",
@@ -795,26 +841,22 @@ var _ = Describe("Periodic Runner", func() {
 					expectedLogSubstring string,
 					expectedMessageRegex string,
 				) {
-					By("Patching shared pvca with volume recommendation")
-					pvcaPatch := client.MergeFrom(pvca.DeepCopy())
-					pvca.Status.VolumeRecommendations = []v1alpha1.VolumeRecommendation{
-						{
-							Name: "test-pvc",
-							Current: v1alpha1.CurrentVolumeStatus{
-								Size:              ptr.To(resource.MustParse(recommendedSize)),
-								UsedSpacePercent:  usedSpacePercent,
-								UsedInodesPercent: usedInodesPercent,
-							},
+					volumeRecommendation := v1alpha1.VolumeRecommendation{
+						Name: pvc.Name,
+						Current: v1alpha1.CurrentVolumeStatus{
+							UsedSpacePercent:  usedSpacePercent,
+							UsedInodesPercent: usedInodesPercent,
 						},
 					}
-					Expect(k8sClient.Status().Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
 
 					var buf strings.Builder
 					w := io.MultiWriter(GinkgoWriter, &buf)
 					logger := zap.New(zap.WriteTo(w))
 					newCtx := log.IntoContext(parentCtx, logger)
 
-					Expect(runner.resizePVC(newCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), reason, getOrCreateVolumeRecommendationForPVC(pvca, pvc.Name))).To(Succeed())
+					aggregator := &resizingConditionAggregator{}
+					updatedRecommendation, err := runner.resizePVC(newCtx, pvc, volumePolicyForPVC(pvca, pvc), reason, volumeRecommendation, aggregator)
+					Expect(err).NotTo(HaveOccurred())
 					Expect(buf.String()).To(ContainSubstring(expectedLogSubstring))
 
 					By("Verifying PVC was resized")
@@ -822,13 +864,15 @@ var _ = Describe("Periodic Runner", func() {
 					Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &resizedPvc)).To(Succeed())
 					Expect(resizedPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse(recommendedSize)))
 
-					Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
-					Expect(pvca.Status.Conditions).To(ContainElement(And(
+					Expect(updatedRecommendation.Target.Size).NotTo(BeNil())
+					Expect(*updatedRecommendation.Target.Size).To(Equal(resource.MustParse(recommendedSize)))
+
+					Expect(aggregator.getAggregatedCondition()).To(And(
 						HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
 						HaveField("Status", metav1.ConditionTrue),
 						HaveField("Reason", ReasonReconcile),
 						HaveField("Message", MatchRegexp(expectedMessageRegex)),
-					)))
+					))
 				},
 				Entry("should successfully resize the pvc based on storage threshold",
 					"2Gi",
@@ -849,17 +893,12 @@ var _ = Describe("Periodic Runner", func() {
 			)
 
 			It("should not resize if max capacity has been reached", func() {
-				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
-				pvca.Status.VolumeRecommendations = []v1alpha1.VolumeRecommendation{
-					{
-						Name: "test-pvc",
-						Current: v1alpha1.CurrentVolumeStatus{
-							Size:             ptr.To(resource.MustParse("3Gi")),
-							UsedSpacePercent: ptr.To(95),
-						},
+				volumeRecommendation := v1alpha1.VolumeRecommendation{
+					Name: pvc.Name,
+					Current: v1alpha1.CurrentVolumeStatus{
+						UsedSpacePercent: ptr.To(95),
 					},
 				}
-				Expect(k8sClient.Status().Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
 
 				var buf strings.Builder
 				w := io.MultiWriter(GinkgoWriter, &buf)
@@ -867,7 +906,9 @@ var _ = Describe("Periodic Runner", func() {
 				newCtx := log.IntoContext(parentCtx, logger)
 
 				By("Performing first resize")
-				Expect(runner.resizePVC(newCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold", getOrCreateVolumeRecommendationForPVC(pvca, pvc.Name))).To(Succeed())
+				aggregator := &resizingConditionAggregator{}
+				volumeRecommendation, err := runner.resizePVC(newCtx, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold", volumeRecommendation, aggregator)
+				Expect(err).NotTo(HaveOccurred())
 
 				wantLog := `"resizing persistent volume claim","pvc":"test-pvc","from":"1Gi","to":"2Gi"}`
 				Expect(buf.String()).To(ContainSubstring(wantLog))
@@ -882,11 +923,10 @@ var _ = Describe("Periodic Runner", func() {
 				resizedPvc.Status.Capacity[corev1.ResourceStorage] = firstIncreaseCap
 				Expect(k8sClient.Status().Patch(parentCtx, &resizedPvc, patch)).To(Succeed())
 
-				By("Re-fetching the pvca to get the updated status")
-				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
-
 				By("Performing second resize")
-				Expect(runner.resizePVC(newCtx, pvca, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold", getOrCreateVolumeRecommendationForPVC(pvca, resizedPvc.Name))).To(Succeed())
+				aggregator = &resizingConditionAggregator{}
+				volumeRecommendation, err = runner.resizePVC(newCtx, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold", volumeRecommendation, aggregator)
+				Expect(err).NotTo(HaveOccurred())
 
 				wantLog = `"resizing persistent volume claim","pvc":"test-pvc","from":"2Gi","to":"3Gi"}`
 				Expect(buf.String()).To(ContainSubstring(wantLog))
@@ -901,36 +941,31 @@ var _ = Describe("Periodic Runner", func() {
 				Expect(k8sClient.Status().Patch(parentCtx, &resizedPvc, patch)).To(Succeed())
 
 				By("Expecting third attempt to fail with max capacity reached")
-				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
-				Expect(runner.resizePVC(newCtx, pvca, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold", getOrCreateVolumeRecommendationForPVC(pvca, resizedPvc.Name))).To(Succeed())
+				aggregator = &resizingConditionAggregator{}
+				_, err = runner.resizePVC(newCtx, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold", volumeRecommendation, aggregator)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(buf.String()).To(ContainSubstring("max capacity reached"))
 
-				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
-				Expect(pvca.Status.Conditions).To(ContainElement(And(
+				Expect(aggregator.getAggregatedCondition()).To(And(
 					HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
 					HaveField("Status", metav1.ConditionFalse),
 					HaveField("Reason", ReasonReconcile),
 					HaveField("Message", ContainSubstring("max capacity reached")),
-				)))
+				))
 			})
 
 			DescribeTable("should handle cooldown duration",
 				func(lastResizeOffset time.Duration, expectResize bool, expectedLog string) {
-					pvcaPatch := client.MergeFrom(pvca.DeepCopy())
 					lastResizeTime := metav1.NewTime(time.Now().Add(lastResizeOffset))
-					pvca.Status.VolumeRecommendations = []v1alpha1.VolumeRecommendation{
-						{
-							Name: "test-pvc",
-							Current: v1alpha1.CurrentVolumeStatus{
-								Size:             ptr.To(resource.MustParse("2Gi")),
-								UsedSpacePercent: ptr.To(95),
-							},
-							LastResizeTime: &lastResizeTime,
+					volumeRecommendation := v1alpha1.VolumeRecommendation{
+						Name: pvc.Name,
+						Current: v1alpha1.CurrentVolumeStatus{
+							UsedSpacePercent: ptr.To(95),
 						},
+						LastResizeTime: &lastResizeTime,
 					}
-					Expect(k8sClient.Status().Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
 
-					pvcaPatch = client.MergeFrom(pvca.DeepCopy())
+					pvcaPatch := client.MergeFrom(pvca.DeepCopy())
 					pvca.Spec.VolumePolicies[0].ScaleUp.CooldownDuration = &metav1.Duration{Duration: time.Hour}
 					Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
 
@@ -939,7 +974,9 @@ var _ = Describe("Periodic Runner", func() {
 					newCtx := log.IntoContext(parentCtx, logger)
 
 					beforeResize := time.Now()
-					Expect(runner.resizePVC(newCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold", getOrCreateVolumeRecommendationForPVC(pvca, pvc.Name))).To(Succeed())
+					aggregator := &resizingConditionAggregator{}
+					updatedRecommendation, err := runner.resizePVC(newCtx, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold", volumeRecommendation, aggregator)
+					Expect(err).NotTo(HaveOccurred())
 					Expect(buf.String()).To(ContainSubstring(expectedLog))
 
 					var pvcObj corev1.PersistentVolumeClaim
@@ -947,9 +984,8 @@ var _ = Describe("Periodic Runner", func() {
 					if expectResize {
 						Expect(pvcObj.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("2Gi")))
 
-						Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
-						Expect(pvca.Status.VolumeRecommendations[0].LastResizeTime).NotTo(BeNil())
-						Expect(pvca.Status.VolumeRecommendations[0].LastResizeTime.Time).To(BeTemporally("~", beforeResize, time.Second))
+						Expect(updatedRecommendation.LastResizeTime).NotTo(BeNil())
+						Expect(updatedRecommendation.LastResizeTime.Time).To(BeTemporally("~", beforeResize, time.Second))
 					} else {
 						Expect(pvcObj.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
 					}
@@ -965,6 +1001,117 @@ var _ = Describe("Periodic Runner", func() {
 					"resizing persistent volume claim",
 				),
 			)
+		})
+
+		Describe("#SetStatus", func() {
+			It("should set LastCheck and NextCheck based on the runner interval", func() {
+				WithInterval(2 * time.Minute)(runner)
+
+				before := time.Now()
+				emptyRec := metav1.Condition{Type: string(v1alpha1.ConditionTypeRecommendationAvailable)}
+				emptyRes := metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}
+				Expect(runner.setStatus(parentCtx, pvca, emptyRec, emptyRes, nil)).To(Succeed())
+
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.LastCheck.Time).To(BeTemporally("~", before, 5*time.Second))
+				Expect(updatedPVCA.Status.NextCheck.Time).To(BeTemporally("~", before.Add(2*time.Minute), 5*time.Second))
+			})
+
+			It("should persist the recommendations condition with the aggregated message", func() {
+				recAgg := &recommendationsConditionAggregator{}
+				recAgg.addCondition(metav1.Condition{
+					Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+					Status:  metav1.ConditionTrue,
+					Reason:  ReasonMetricsFetched,
+					Message: "pvc-a: metrics fetched successfully",
+				})
+				recAgg.addCondition(metav1.Condition{
+					Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+					Status:  metav1.ConditionFalse,
+					Reason:  ReasonMetricsFetchError,
+					Message: "pvc-b: stale metrics",
+				})
+
+				emptyRes := metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}
+				Expect(runner.setStatus(parentCtx, pvca, recAgg.getAggregatedCondition(), emptyRes, nil)).To(Succeed())
+
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
+					HaveField("Status", metav1.ConditionFalse),
+					HaveField("Reason", ReasonMetricsFetchError),
+					HaveField("Message", ContainSubstring("pvc-b: stale metrics")),
+				)))
+			})
+
+			It("should persist the resizing condition when a non-empty condition is provided", func() {
+				resAgg := &resizingConditionAggregator{}
+				resAgg.addCondition(metav1.Condition{
+					Type:    string(v1alpha1.ConditionTypeResizing),
+					Status:  metav1.ConditionTrue,
+					Reason:  ReasonReconcile,
+					Message: "pvc-a: resizing from 1Gi to 2Gi",
+				})
+
+				emptyRec := metav1.Condition{Type: string(v1alpha1.ConditionTypeRecommendationAvailable)}
+				Expect(runner.setStatus(parentCtx, pvca, emptyRec, resAgg.getAggregatedCondition(), nil)).To(Succeed())
+
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
+					HaveField("Status", metav1.ConditionTrue),
+					HaveField("Reason", ReasonReconcile),
+					HaveField("Message", Equal("PersistentVolumeClaims are being resized:\n- pvc-a: resizing from 1Gi to 2Gi")),
+				)))
+			})
+
+			It("should remove an existing resizing condition when an empty condition is provided", func() {
+				By("Seeding the PVCA with an existing Resizing condition")
+				patch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Status.Conditions = []metav1.Condition{
+					{
+						Type:               string(v1alpha1.ConditionTypeResizing),
+						Status:             metav1.ConditionTrue,
+						Reason:             ReasonReconcile,
+						Message:            "stale resize",
+						LastTransitionTime: metav1.Now(),
+					},
+				}
+				Expect(k8sClient.Status().Patch(parentCtx, pvca, patch)).To(Succeed())
+
+				emptyRec := metav1.Condition{Type: string(v1alpha1.ConditionTypeRecommendationAvailable)}
+				emptyRes := metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}
+				Expect(runner.setStatus(parentCtx, pvca, emptyRec, emptyRes, nil)).To(Succeed())
+
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				for _, cond := range updatedPVCA.Status.Conditions {
+					Expect(cond.Type).NotTo(Equal(string(v1alpha1.ConditionTypeResizing)))
+				}
+			})
+
+			It("should sort volume recommendations by name before persisting", func() {
+				recommendations := []v1alpha1.VolumeRecommendation{
+					{Name: "pvc-c"},
+					{Name: "pvc-a"},
+					{Name: "pvc-b"},
+				}
+
+				emptyRec := metav1.Condition{Type: string(v1alpha1.ConditionTypeRecommendationAvailable)}
+				emptyRes := metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}
+				Expect(runner.setStatus(parentCtx, pvca, emptyRec, emptyRes, recommendations)).To(Succeed())
+
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				names := make([]string, 0, len(updatedPVCA.Status.VolumeRecommendations))
+				for _, vr := range updatedPVCA.Status.VolumeRecommendations {
+					names = append(names, vr.Name)
+				}
+				Expect(names).To(Equal([]string{"pvc-a", "pvc-b", "pvc-c"}))
+			})
 		})
 	})
 })

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Periodic Runner", func() {
 						Expect(k8sClient.Patch(parentCtx, pvca, patch)).To(Succeed())
 					}
 
-					ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
+					ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
 					Expect(ok).To(BeFalse())
 					if expectedErr != nil {
 						Expect(err).To(MatchError(expectedErr))
@@ -261,7 +261,7 @@ var _ = Describe("Periodic Runner", func() {
 					AvailableInodes: 1000,
 					CapacityInodes:  1000,
 				}
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
+				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(MatchError(common.ErrStaleMetrics))
 
@@ -272,7 +272,7 @@ var _ = Describe("Periodic Runner", func() {
 					AvailableInodes: 1000,
 					CapacityInodes:  1000,
 				}
-				ok, _, err = runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
+				ok, _, err = runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -319,7 +319,7 @@ var _ = Describe("Periodic Runner", func() {
 					CapacityInodes:  1000,
 					AvailableInodes: 500,
 				}
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
+				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(MatchError(ErrStorageClassNotFound))
 			})
@@ -383,7 +383,7 @@ var _ = Describe("Periodic Runner", func() {
 					CapacityInodes:  1000,
 					AvailableInodes: 500,
 				}
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
+				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(MatchError(ErrStorageClassDoesNotSupportExpansion))
 			})
@@ -430,7 +430,7 @@ var _ = Describe("Periodic Runner", func() {
 					CapacityInodes:  1000,
 				}
 
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
+				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
 				Expect(ok).To(BeFalse())
 				Expect(err).To(MatchError(ErrVolumeModeIsNotFilesystem))
 			})
@@ -443,7 +443,7 @@ var _ = Describe("Periodic Runner", func() {
 					CapacityInodes:  10000,
 				}
 
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
+				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
 				Expect(ok).To(BeFalse())
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -461,7 +461,7 @@ var _ = Describe("Periodic Runner", func() {
 					CapacityInodes:  1000,
 				}
 
-				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
+				ok, _, err := runner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
 				Expect(ok).To(BeFalse())
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -489,7 +489,7 @@ var _ = Describe("Periodic Runner", func() {
 						CapacityInodes:  1000,
 					}
 
-					ok, reason, err := testRunner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
+					ok, reason, err := testRunner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
 					Expect(ok).To(BeTrue())
 					Expect(reason).To(Equal("passing storage threshold"))
 					Expect(err).ToNot(HaveOccurred())
@@ -507,7 +507,7 @@ var _ = Describe("Periodic Runner", func() {
 						CapacityInodes:  1000,
 					}
 
-					ok, reason, err := testRunner.shouldReconcilePVC(parentCtx, pvca, pvc, volInfo)
+					ok, reason, err := testRunner.shouldReconcilePVC(parentCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), volInfo)
 					Expect(ok).To(BeTrue())
 					Expect(reason).To(Equal("passing inodes threshold"))
 					Expect(err).ToNot(HaveOccurred())
@@ -856,7 +856,7 @@ var _ = Describe("Periodic Runner", func() {
 					logger := zap.New(zap.WriteTo(w))
 					newCtx := log.IntoContext(parentCtx, logger)
 
-					Expect(runner.resizePVC(newCtx, pvca, pvc, reason)).To(Succeed())
+					Expect(runner.resizePVC(newCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), reason)).To(Succeed())
 					Expect(buf.String()).To(ContainSubstring(expectedLogSubstring))
 
 					By("Verifying PVC was resized")
@@ -909,7 +909,7 @@ var _ = Describe("Periodic Runner", func() {
 				newCtx := log.IntoContext(parentCtx, logger)
 
 				By("Performing first resize")
-				Expect(runner.resizePVC(newCtx, pvca, pvc, "passing storage threshold")).To(Succeed())
+				Expect(runner.resizePVC(newCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold")).To(Succeed())
 
 				wantLog := `"resizing persistent volume claim","pvc":"test-pvc","from":"1Gi","to":"2Gi"}`
 				Expect(buf.String()).To(ContainSubstring(wantLog))
@@ -928,7 +928,7 @@ var _ = Describe("Periodic Runner", func() {
 				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
 
 				By("Performing second resize")
-				Expect(runner.resizePVC(newCtx, pvca, &resizedPvc, "passing storage threshold")).To(Succeed())
+				Expect(runner.resizePVC(newCtx, pvca, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold")).To(Succeed())
 
 				wantLog = `"resizing persistent volume claim","pvc":"test-pvc","from":"2Gi","to":"3Gi"}`
 				Expect(buf.String()).To(ContainSubstring(wantLog))
@@ -944,7 +944,7 @@ var _ = Describe("Periodic Runner", func() {
 
 				By("Expecting third attempt to fail with max capacity reached")
 				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
-				Expect(runner.resizePVC(newCtx, pvca, &resizedPvc, "passing storage threshold")).To(Succeed())
+				Expect(runner.resizePVC(newCtx, pvca, &resizedPvc, volumePolicyForPVC(pvca, &resizedPvc), "passing storage threshold")).To(Succeed())
 				Expect(buf.String()).To(ContainSubstring("max capacity reached"))
 
 				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), pvca)).To(Succeed())
@@ -981,7 +981,7 @@ var _ = Describe("Periodic Runner", func() {
 					newCtx := log.IntoContext(parentCtx, logger)
 
 					beforeResize := time.Now()
-					Expect(runner.resizePVC(newCtx, pvca, pvc, "passing storage threshold")).To(Succeed())
+					Expect(runner.resizePVC(newCtx, pvca, pvc, volumePolicyForPVC(pvca, pvc), "passing storage threshold")).To(Succeed())
 					Expect(buf.String()).To(ContainSubstring(expectedLog))
 
 					var pvcObj corev1.PersistentVolumeClaim

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -46,6 +47,33 @@ func newRunner() (*Runner, error) {
 	)
 
 	return runner, err
+}
+
+// createPodWithPVC creates a Pod in the "default" namespace with the given
+// labels and a single PVC volume referencing claimName. The Pod is registered
+// for cleanup via DeferCleanup.
+func createPodWithPVC(ctx context.Context, name string, labels map[string]string, claimName string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main", Image: "busybox"}},
+			Volumes: []corev1.Volume{{
+				Name: "data",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: claimName},
+				},
+			}},
+		},
+	}
+	Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+	DeferCleanup(func() {
+		Expect(testutils.CleanupObject(ctx, k8sClient, pod)).To(Succeed())
+	})
+	return pod
 }
 
 var _ = Describe("Periodic Runner", func() {
@@ -702,6 +730,390 @@ var _ = Describe("Periodic Runner", func() {
 				for _, cond := range updatedPVCA.Status.Conditions {
 					Expect(cond.Type).NotTo(Equal(string(v1alpha1.ConditionTypeResizing)))
 				}
+			})
+
+			It("should aggregate recommendations for multiple PVCs when targeting a Deployment", func() {
+				selectorLabels := map[string]string{"app": "deployment-target"}
+
+				By("Creating PVCs referenced by the Deployment's pods")
+				pvcA, err := testutils.CreatePVC(parentCtx, k8sClient, "deploy-pvc-a", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcA)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvcA), pvcA)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				pvcB, err := testutils.CreatePVC(parentCtx, k8sClient, "deploy-pvc-b", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcB)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvcB), pvcB)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				By("Creating a Deployment with a label selector")
+				deployment := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "deployment-target", Namespace: "default"},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: ptr.To(int32(2)),
+						Selector: &metav1.LabelSelector{MatchLabels: selectorLabels},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: selectorLabels},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "main", Image: "busybox"}},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(parentCtx, deployment)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, deployment)).To(Succeed())
+				})
+
+				By("Creating Pods with PVC volumes that match the Deployment selector")
+				createPodWithPVC(parentCtx, "deploy-pod-a", selectorLabels, pvcA.Name)
+				createPodWithPVC(parentCtx, "deploy-pod-b", selectorLabels, pvcB.Name)
+
+				By("Patching the PVCA to target the Deployment")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.TargetRef = autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       deployment.Name,
+				}
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				By("Registering metrics for both PVCs")
+				metricsSource := fake.New(fake.WithInterval(10 * time.Millisecond))
+				for _, p := range []*corev1.PersistentVolumeClaim{pvcA, pvcB} {
+					metricsSource.Register(&fake.Item{
+						NamespacedName:         client.ObjectKeyFromObject(p),
+						CapacityBytes:          1073741824,
+						AvailableBytes:         1073741824,
+						CapacityInodes:         10000,
+						AvailableInodes:        10000,
+						ConsumeBytesIncrement:  1000,
+						ConsumeInodesIncrement: 1000,
+					})
+				}
+				metricsCtx, metricsCancel := context.WithCancel(parentCtx)
+				go func() {
+					<-time.After(500 * time.Millisecond)
+					metricsCancel()
+				}()
+				metricsSource.Start(metricsCtx)
+				WithMetricsSource(metricsSource)(runner)
+
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+
+				By("Verifying aggregated RecommendationAvailable condition and per-PVC recommendations")
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
+					HaveField("Status", metav1.ConditionTrue),
+					HaveField("Reason", ReasonRecommendationsProvided),
+					HaveField("Message", Equal("Recommendations have been provided")),
+				)))
+				names := make([]string, 0, len(updatedPVCA.Status.VolumeRecommendations))
+				for _, vr := range updatedPVCA.Status.VolumeRecommendations {
+					names = append(names, vr.Name)
+				}
+				Expect(names).To(ConsistOf(pvcA.Name, pvcB.Name))
+			})
+
+			It("should aggregate recommendations for multiple PVCs when targeting a StatefulSet", func() {
+				selectorLabels := map[string]string{"app": "statefulset-target"}
+
+				By("Creating PVCs referenced by the StatefulSet's pods")
+				pvcA, err := testutils.CreatePVC(parentCtx, k8sClient, "sts-pvc-a", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcA)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvcA), pvcA)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				pvcB, err := testutils.CreatePVC(parentCtx, k8sClient, "sts-pvc-b", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcB)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvcB), pvcB)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				By("Creating a StatefulSet with a label selector")
+				statefulSet := &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: "statefulset-target", Namespace: "default"},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas:    ptr.To(int32(2)),
+						ServiceName: "statefulset-target",
+						Selector:    &metav1.LabelSelector{MatchLabels: selectorLabels},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: selectorLabels},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "main", Image: "busybox"}},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(parentCtx, statefulSet)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, statefulSet)).To(Succeed())
+				})
+
+				By("Creating Pods with PVC volumes that match the StatefulSet selector")
+				createPodWithPVC(parentCtx, "sts-pod-a", selectorLabels, pvcA.Name)
+				createPodWithPVC(parentCtx, "sts-pod-b", selectorLabels, pvcB.Name)
+
+				By("Patching the PVCA to target the StatefulSet")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.TargetRef = autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       statefulSet.Name,
+				}
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				By("Registering metrics for both PVCs")
+				metricsSource := fake.New(fake.WithInterval(10 * time.Millisecond))
+				for _, p := range []*corev1.PersistentVolumeClaim{pvcA, pvcB} {
+					metricsSource.Register(&fake.Item{
+						NamespacedName:         client.ObjectKeyFromObject(p),
+						CapacityBytes:          1073741824,
+						AvailableBytes:         1073741824,
+						CapacityInodes:         10000,
+						AvailableInodes:        10000,
+						ConsumeBytesIncrement:  1000,
+						ConsumeInodesIncrement: 1000,
+					})
+				}
+				metricsCtx, metricsCancel := context.WithCancel(parentCtx)
+				go func() {
+					<-time.After(500 * time.Millisecond)
+					metricsCancel()
+				}()
+				metricsSource.Start(metricsCtx)
+				WithMetricsSource(metricsSource)(runner)
+
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+
+				By("Verifying aggregated RecommendationAvailable condition and per-PVC recommendations")
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
+					HaveField("Status", metav1.ConditionTrue),
+					HaveField("Reason", ReasonRecommendationsProvided),
+					HaveField("Message", Equal("Recommendations have been provided")),
+				)))
+				names := make([]string, 0, len(updatedPVCA.Status.VolumeRecommendations))
+				for _, vr := range updatedPVCA.Status.VolumeRecommendations {
+					names = append(names, vr.Name)
+				}
+				Expect(names).To(ConsistOf(pvcA.Name, pvcB.Name))
+			})
+
+			It("should set PVCFetchError when targeting a Deployment with no matching pods", func() {
+				selectorLabels := map[string]string{"app": "no-matching-pods"}
+
+				By("Creating a Deployment with a selector that matches no pods")
+				deployment := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "deployment-no-pods", Namespace: "default"},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: ptr.To(int32(2)),
+						Selector: &metav1.LabelSelector{MatchLabels: selectorLabels},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: selectorLabels},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "main", Image: "busybox"}},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(parentCtx, deployment)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, deployment)).To(Succeed())
+				})
+
+				By("Patching the PVCA to target the Deployment")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.TargetRef = autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       deployment.Name,
+				}
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
+					HaveField("Status", metav1.ConditionFalse),
+					HaveField("Reason", ReasonPVCFetchError),
+					HaveField("Message", ContainSubstring("no pods found")),
+				)))
+			})
+
+			It("should set PVCFetchError when matching pods reference a non-existent PVC", func() {
+				selectorLabels := map[string]string{"app": "missing-pvc-target"}
+
+				By("Creating a Deployment with a label selector")
+				deployment := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "deployment-missing-pvc", Namespace: "default"},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: ptr.To(int32(1)),
+						Selector: &metav1.LabelSelector{MatchLabels: selectorLabels},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: selectorLabels},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "main", Image: "busybox"}},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(parentCtx, deployment)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, deployment)).To(Succeed())
+				})
+
+				By("Creating a Pod that references a PVC which does not exist")
+				createPodWithPVC(parentCtx, "missing-pvc-pod", selectorLabels, "non-existent-pvc")
+
+				By("Patching the PVCA to target the Deployment")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.TargetRef = autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       deployment.Name,
+				}
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
+					HaveField("Status", metav1.ConditionFalse),
+					HaveField("Reason", ReasonPVCFetchError),
+				)))
+			})
+
+			It("should set PVCFetchError when targeting a non-existent Deployment", func() {
+				By("Patching the PVCA to target a Deployment that does not exist")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.TargetRef = autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "non-existent-deployment",
+				}
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
+					HaveField("Status", metav1.ConditionFalse),
+					HaveField("Reason", ReasonPVCFetchError),
+				)))
+			})
+
+			It("should aggregate to False listing only the failing PVC when one of multiple PVCs has no metrics", func() {
+				selectorLabels := map[string]string{"app": "partial-metrics"}
+
+				By("Creating two PVCs referenced by the Deployment's pods")
+				pvcA, err := testutils.CreatePVC(parentCtx, k8sClient, "partial-pvc-a", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcA)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvcA), pvcA)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				pvcB, err := testutils.CreatePVC(parentCtx, k8sClient, "partial-pvc-b", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcB)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvcB), pvcB)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				By("Creating a Deployment with a label selector")
+				deployment := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "deployment-partial-metrics", Namespace: "default"},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: ptr.To(int32(2)),
+						Selector: &metav1.LabelSelector{MatchLabels: selectorLabels},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: selectorLabels},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "main", Image: "busybox"}},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(parentCtx, deployment)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, deployment)).To(Succeed())
+				})
+
+				By("Creating Pods with PVC volumes that match the Deployment selector")
+				createPodWithPVC(parentCtx, "partial-pod-a", selectorLabels, pvcA.Name)
+				createPodWithPVC(parentCtx, "partial-pod-b", selectorLabels, pvcB.Name)
+
+				By("Patching the PVCA to target the Deployment")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.TargetRef = autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       deployment.Name,
+				}
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				By("Registering metrics for only one of the two PVCs")
+				metricsSource := fake.New(fake.WithInterval(10 * time.Millisecond))
+				metricsSource.Register(&fake.Item{
+					NamespacedName:         client.ObjectKeyFromObject(pvcA),
+					CapacityBytes:          1073741824,
+					AvailableBytes:         1073741824,
+					CapacityInodes:         10000,
+					AvailableInodes:        10000,
+					ConsumeBytesIncrement:  1000,
+					ConsumeInodesIncrement: 1000,
+				})
+				metricsCtx, metricsCancel := context.WithCancel(parentCtx)
+				go func() {
+					<-time.After(500 * time.Millisecond)
+					metricsCancel()
+				}()
+				metricsSource.Start(metricsCtx)
+				WithMetricsSource(metricsSource)(runner)
+
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
+					HaveField("Status", metav1.ConditionFalse),
+					HaveField("Reason", ReasonMetricsFetchError),
+					HaveField("Message", And(
+						ContainSubstring(pvcB.Name),
+						Not(ContainSubstring(pvcA.Name+":")),
+					)),
+				)))
 			})
 		})
 

--- a/internal/target/pvcfetcher/pvcfetcher.go
+++ b/internal/target/pvcfetcher/pvcfetcher.go
@@ -82,7 +82,7 @@ func (f *pvcFetcher) Fetch(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 		}
 
 		if err := f.client.Get(ctx, client.ObjectKeyFromObject(pvc), pvc); err != nil {
-			return nil, fmt.Errorf("failed to get PersistentVolumeClaim %s under PersistentVolumeClaimAutoscaler %s: %w", client.ObjectKeyFromObject(pvc), client.ObjectKeyFromObject(pvca), err)
+			return nil, fmt.Errorf("failed to get PersistentVolumeClaim %s: %w", client.ObjectKeyFromObject(pvc), err)
 		}
 
 		return []*corev1.PersistentVolumeClaim{pvc}, nil
@@ -95,20 +95,20 @@ func (f *pvcFetcher) Fetch(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 
 	podList := &corev1.PodList{}
 	if err := f.client.List(ctx, podList, &client.ListOptions{LabelSelector: selector, Namespace: pvca.Namespace}); err != nil {
-		return nil, fmt.Errorf("failed to list Pods for PersistentVolumeClaimAutoscaler %s: %w", client.ObjectKeyFromObject(pvca), err)
+		return nil, fmt.Errorf("failed to list Pods: %w", err)
 	}
 
 	if len(podList.Items) == 0 {
-		return nil, fmt.Errorf("no pods found for selector '%s' used by PersistentVolumeClaimAutoscaler %s", selector, client.ObjectKeyFromObject(pvca))
+		return nil, fmt.Errorf("no pods found for selector %s", selector)
 	}
 
 	pvcs, err := f.getPVCsFromPods(ctx, podList.Items)
 	if err != nil {
-		return nil, fmt.Errorf("could not get all PersistentVolumeClaims for PersistentVolumeClaimAutoscaler %s: %w", client.ObjectKeyFromObject(pvca), err)
+		return nil, fmt.Errorf("could not get all PersistentVolumeClaims: %w", err)
 	}
 
 	if len(pvcs) == 0 {
-		return nil, fmt.Errorf("no PersistentVolumeClaims found for selector '%s' used by PersistentVolumeClaimAutoscaler %s", selector, client.ObjectKeyFromObject(pvca))
+		return nil, fmt.Errorf("no PersistentVolumeClaims found for selector %s", selector)
 	}
 
 	return pvcs, nil

--- a/internal/target/pvcfetcher/pvcfetcher_test.go
+++ b/internal/target/pvcfetcher/pvcfetcher_test.go
@@ -112,7 +112,7 @@ var _ = Describe("PVCFetcher", func() {
 			selectorFetcher.selector, _ = labels.Parse("app=test")
 
 			pvcs, err := fetcher.Fetch(ctx, pvca)
-			Expect(err).To(MatchError(ContainSubstring("no pods found for selector 'app=test' used by PersistentVolumeClaimAutoscaler default/test-pvca")))
+			Expect(err).To(MatchError(ContainSubstring("no pods found for selector app=test")))
 			Expect(pvcs).To(BeEmpty())
 		})
 
@@ -146,7 +146,7 @@ var _ = Describe("PVCFetcher", func() {
 			Expect(fakeClient.Create(ctx, pod)).To(Succeed())
 
 			pvcs, err := fetcher.Fetch(ctx, pvca)
-			Expect(err).To(MatchError(ContainSubstring("no PersistentVolumeClaims found for selector 'app=test' used by PersistentVolumeClaimAutoscaler default/test-pvca")))
+			Expect(err).To(MatchError(ContainSubstring("no PersistentVolumeClaims found for selector app=test")))
 			Expect(pvcs).To(BeEmpty())
 		})
 

--- a/test/manifests/pvca-4.yaml
+++ b/test/manifests/pvca-4.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: autoscaling.gardener.cloud/v1alpha1
+kind: PersistentVolumeClaimAutoscaler
+metadata:
+  name: test-pvca-4
+  namespace: pvc-autoscaler-system
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: test-sts-4
+  volumePolicies:
+  - maxCapacity: 3Gi

--- a/test/manifests/sts-4.yaml
+++ b/test/manifests/sts-4.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-sts-4
+  namespace: pvc-autoscaler-system
+spec:
+  serviceName: test-sts-4
+  replicas: 2
+  selector:
+    matchLabels:
+      app: test-sts-4
+  template:
+    metadata:
+      labels:
+        app: test-sts-4
+    spec:
+      containers:
+        - name: app
+          image: alpine:3.23.3
+          command:
+            - sleep
+            - infinity
+          volumeMounts:
+            - mountPath: /app
+              name: data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        storageClassName: standard
+        volumeMode: Filesystem
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR makes it possible to target workload controllers in the PVCA API and to resize multiple PVCs for such controllers. E.g. all PVCs that are created by a `StatefulSet`.
With this, it also merges conditions for each PVC into one `Resizing` or `RecommendationsAvailable` condition so that information for all PVCs is easily available.
Additionally, it collects all volume recommendations for all PVCs

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The `pvc-autoscaler` can now target various workload controllers that manage pods which mount `PersistentVolumeClaims`, for example, `StatefulSets`. Such `PersistentVolumeClaims` are automatically identified and scaled, depending on the provided volume policy. The current volume usage metrics and whether resize is in progress for each `PersistentVolumeClaim`, are aggregated into `RecommendationsAvailable` and `Resizing` conditions on the `PersistentVolumeClaimAutoscalerResource`.
```
