### PR TITLE
chore: Bump MaxCapacityDeviationRatio to 4%

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -51,5 +51,5 @@ const (
 	// MaxCapacityDeviationRatio is the maximum allowed deviation ratio between the PVC size
 	// as reported by the metrics source and the PVC size as indicated by the PVC status.
 	// If the deviation is bigger than this ratio, the metrics are considered stale.
-	MaxCapacityDeviationRatio = 0.02
+	MaxCapacityDeviationRatio = 0.04
 )

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -245,7 +245,7 @@ var _ = Describe("Periodic Runner", func() {
 				),
 			)
 
-			It("should apply 2% tolerance for stale metrics detection (large PVC)", func() {
+			It("should apply 4% tolerance for stale metrics detection (large PVC)", func() {
 				By("Patching PVC to 100Gi and PVCA maxCapacity to 200Gi")
 				specPatch := client.MergeFrom(pvc.DeepCopy())
 				pvc.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("100Gi")
@@ -262,7 +262,7 @@ var _ = Describe("Periodic Runner", func() {
 				By("Calling shouldReconcilePVC with metrics deviating by 3Gi")
 				volInfo := &metricssource.VolumeInfo{
 					AvailableBytes:  9 * 1024 * 1024,
-					CapacityBytes:   97 * 1024 * 1024 * 1024, // delta 3Gi > 2% tolerance
+					CapacityBytes:   95 * 1024 * 1024 * 1024, // delta 5Gi > 4% tolerance
 					AvailableInodes: 1000,
 					CapacityInodes:  1000,
 				}
@@ -273,7 +273,7 @@ var _ = Describe("Periodic Runner", func() {
 				By("Calling shouldReconcilePVC with metrics deviating by 1Gi")
 				volInfo = &metricssource.VolumeInfo{
 					AvailableBytes:  9 * 1024 * 1024,
-					CapacityBytes:   99 * 1024 * 1024 * 1024, // delta 1Gi < 2% tolerance
+					CapacityBytes:   98 * 1024 * 1024 * 1024, // delta 2Gi < 4% tolerance
 					AvailableInodes: 1000,
 					CapacityInodes:  1000,
 				}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR bumps the `MaxCapacityDeviationRatio` to `0.04`. This is a safety measure for large volumes that might have reserved a larger amount of metadata for the filesystem of the `PersistentVolume` which causes a higher difference between the capacity metrics reported by prometheus and the capacity in the PVC's status field.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Stale metrics are found by the formula max(4%*size, 0.5Gi).
```
