### PR TITLE
Use annotation on the PVC to record the capacity before scaling

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -52,4 +52,11 @@ const (
 	// as reported by the metrics source and the PVC size as indicated by the PVC status.
 	// If the deviation is bigger than this ratio, the metrics are considered stale.
 	MaxCapacityDeviationRatio = 0.04
+
+	// AnnotationPreviousSize records the PVC's spec size immediately before the most
+	// recent autoscaler-initiated resize. Used to detect that a resize is in flight
+	// before the PVC controller has set a Resizing condition. The annotation is not
+	// cleared after a successful resize, to indicate that the autoscaler has done
+	// work on this PVC.
+	AnnotationPreviousSize = "pvc.autoscaling.gardener.cloud/prev-size"
 )

--- a/internal/periodic/conditions.go
+++ b/internal/periodic/conditions.go
@@ -84,7 +84,7 @@ func (c *resizingConditionAggregator) addCondition(condition metav1.Condition) {
 
 // getAggregatedCondition aggregates all conditions into one. If there are no conditions, it returns an empty condition with the
 // Resizing type. If there is one condition with status true, the aggregated condition's status is also true to indicate that there
-// is a resize in progress.
+// is a resize in progress. If there are only conditions with Unknown status, the aggregated condition will also have Unknown status.
 func (c *resizingConditionAggregator) getAggregatedCondition() metav1.Condition {
 	// When there are 0 conditions, return a condition with empty fields, except for the Resizing type.
 	// This can be used in calling functions to determine whether the condition can be removed from the status of the PVCA.
@@ -94,7 +94,7 @@ func (c *resizingConditionAggregator) getAggregatedCondition() metav1.Condition 
 
 	var (
 		message           = "PersistentVolumeClaims cannot be resized:"
-		status            = metav1.ConditionFalse
+		status            = metav1.ConditionUnknown
 		reasons           = sets.New[string]()
 		conditionMessages = make([]string, 0, len(c.conditions))
 	)
@@ -105,6 +105,9 @@ func (c *resizingConditionAggregator) getAggregatedCondition() metav1.Condition 
 		if condition.Status == metav1.ConditionTrue {
 			message = "PersistentVolumeClaims are being resized:"
 			status = metav1.ConditionTrue
+		} else if status == metav1.ConditionUnknown && condition.Status == metav1.ConditionFalse {
+			// Only set aggregated condition to False if it was previously Unknown and not yet set to True
+			status = metav1.ConditionFalse
 		}
 	}
 

--- a/internal/periodic/conditions_test.go
+++ b/internal/periodic/conditions_test.go
@@ -119,15 +119,20 @@ var _ = Describe("resizingConditionAggregator", func() {
 			Reason:  ReasonReconcile,
 			Message: "pvc-b: resizing from 1Gi to 2Gi",
 		})
+		aggregator.addCondition(metav1.Condition{
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonReconcile,
+			Message: "pvc-d: cannot resize due to unknown error",
+		})
 
 		got := aggregator.getAggregatedCondition()
 		Expect(got.Type).To(Equal(string(v1alpha1.ConditionTypeResizing)))
 		Expect(got.Reason).To(Equal(ReasonReconcile))
 		Expect(got.Status).To(Equal(metav1.ConditionTrue))
-		Expect(got.Message).To(Equal("PersistentVolumeClaims are being resized:\n- pvc-a: max capacity reached\n- pvc-b: resizing from 1Gi to 2Gi"))
+		Expect(got.Message).To(Equal("PersistentVolumeClaims are being resized:\n- pvc-a: max capacity reached\n- pvc-b: resizing from 1Gi to 2Gi\n- pvc-d: cannot resize due to unknown error"))
 	})
 
-	It("should aggregate to False when all conditions are False", func() {
+	It("should aggregate to False when there are no True conditions", func() {
 		aggregator.addCondition(metav1.Condition{
 			Status:  metav1.ConditionFalse,
 			Reason:  ReasonPVCResizeCooldown,
@@ -138,12 +143,36 @@ var _ = Describe("resizingConditionAggregator", func() {
 			Reason:  ReasonReconcile,
 			Message: "pvc-b: max capacity reached",
 		})
+		aggregator.addCondition(metav1.Condition{
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonReconcile,
+			Message: "pvc-d: cannot resize due to unknown error",
+		})
 
 		got := aggregator.getAggregatedCondition()
 		Expect(got.Type).To(Equal(string(v1alpha1.ConditionTypeResizing)))
 		Expect(got.Reason).To(Equal(ReasonReconcile))
 		Expect(got.Status).To(Equal(metav1.ConditionFalse))
-		Expect(got.Message).To(Equal("PersistentVolumeClaims cannot be resized:\n- pvc-a: cooldown duration has not elapsed yet\n- pvc-b: max capacity reached"))
+		Expect(got.Message).To(Equal("PersistentVolumeClaims cannot be resized:\n- pvc-a: cooldown duration has not elapsed yet\n- pvc-b: max capacity reached\n- pvc-d: cannot resize due to unknown error"))
+	})
+
+	It("should aggregate to Unknown when there are only Unknpwn conditions", func() {
+		aggregator.addCondition(metav1.Condition{
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonReconcile,
+			Message: "pvc-a: cannot resize due to unknown error",
+		})
+		aggregator.addCondition(metav1.Condition{
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonReconcile,
+			Message: "pvc-b: cannot resize due to unknown error",
+		})
+
+		got := aggregator.getAggregatedCondition()
+		Expect(got.Type).To(Equal(string(v1alpha1.ConditionTypeResizing)))
+		Expect(got.Reason).To(Equal(ReasonReconcile))
+		Expect(got.Status).To(Equal(metav1.ConditionUnknown))
+		Expect(got.Message).To(Equal("PersistentVolumeClaims cannot be resized:\n- pvc-a: cannot resize due to unknown error\n- pvc-b: cannot resize due to unknown error"))
 	})
 
 	It("should sort messages deterministically regardless of insertion order", func() {

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -362,7 +362,7 @@ func (r *Runner) reconcilePVCA(
 		}
 
 		shouldResize, scalingReason := r.shouldResizePVC(pvc, policy, volumeRecommendation)
-		inProgress := r.isResizeInProgress(logger, pvc, scalingReason, volumeRecommendation, resizingConditions)
+		inProgress := r.isResizeInProgress(logger, pvc, scalingReason, resizingConditions)
 
 		if shouldResize && !inProgress {
 			volumeRecommendation, err = r.resizePVC(ctx, logger, pvc, policy, scalingReason, volumeRecommendation, resizingConditions)
@@ -403,6 +403,13 @@ func (r *Runner) updateVolumeRecommendationForPVC(volumeRecommendations []v1alph
 	volumeRecommendation.Current.UsedInodesPercent = &usedInodes
 
 	currStatusSize := pvc.Status.Capacity.Storage()
+	volumeRecommendation.Current.Size = currStatusSize
+
+	// If target size has not yet been recommended by the autoscaler, take the size from spec
+	// so the field is non-nil.
+	if volumeRecommendation.Target.Size == nil {
+		volumeRecommendation.Target.Size = pvc.Spec.Resources.Requests.Storage()
+	}
 
 	// Detect whether the metrics source is reporting stale data. Stale
 	// metrics data would be when the volume info metrics reported by the
@@ -545,7 +552,7 @@ func (r *Runner) shouldResizePVC(pvc *corev1.PersistentVolumeClaim, policy v1alp
 
 // isResizeInProgress checks whether the [corev1.PersistentVolumeClaim] is currently being resized.
 // Returns true if a resize operation is in progress.
-func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVolumeClaim, scalingReason string, volumeRecommendation v1alpha1.VolumeRecommendation, resizingConditions *resizingConditionAggregator) bool {
+func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVolumeClaim, scalingReason string, resizingConditions *resizingConditionAggregator) bool {
 	currStatusSize := pvc.Status.Capacity.Storage()
 
 	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimResizing) {
@@ -584,10 +591,28 @@ func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVo
 		return true
 	}
 
-	// If previously recorded size is equal to the current status it means
-	// we are still waiting for the resize to complete
-	if volumeRecommendation.Current.Size != nil &&
-		volumeRecommendation.Current.Size.Equal(*currStatusSize) {
+	scaledFromAnnotationValue, ok := pvc.Annotations[common.AnnotationPreviousSize]
+	if !ok {
+		// scaled-from annotation is missing from PVC which means it has not been scaled by the pvc-autoscaler.
+		return false
+	}
+
+	scaledFrom, err := resource.ParseQuantity(scaledFromAnnotationValue)
+	if err != nil {
+		resizingConditions.addCondition(metav1.Condition{
+			Type:    string(v1alpha1.ConditionTypeResizing),
+			Status:  metav1.ConditionUnknown,
+			Reason:  ReasonReconcile,
+			Message: fmt.Sprintf("%s: could not parse %s annotation with value %s: %s", pvc.Name, common.AnnotationPreviousSize, scaledFromAnnotationValue, err.Error()),
+		})
+
+		return true
+	}
+
+	// If recorded size in the annotation is equal to the current status it means
+	// we are still waiting for the resize to complete. This is necessary as the controller responsible
+	// to do the resizing might have started it, but not yet updated the PVC's conditions.
+	if scaledFrom.Equal(*currStatusSize) {
 		logger.Info("persistent volume claim is still being resized")
 		resizingConditions.addCondition(metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeResizing),
@@ -681,6 +706,12 @@ func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.
 
 	// Update the PVC resource.
 	pvcPatch := client.MergeFrom(pvc.DeepCopy())
+
+	if pvc.Annotations == nil {
+		pvc.Annotations = map[string]string{}
+	}
+	pvc.Annotations[common.AnnotationPreviousSize] = currSpecSize.String()
+
 	pvc.Spec.Resources.Requests[corev1.ResourceStorage] = *targetSize
 	if err := r.client.Patch(ctx, pvc, pvcPatch); err != nil {
 		resizingConditions.addCondition(metav1.Condition{
@@ -692,8 +723,6 @@ func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.
 
 		return volumeRecommendation, err
 	}
-
-	volumeRecommendation.Current.Size = pvc.Status.Capacity.Storage()
 	volumeRecommendation.Target.Size = targetSize
 	volumeRecommendation.LastResizeTime = ptr.To(metav1.Now())
 

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -1259,7 +1259,7 @@ var _ = Describe("Periodic Runner", func() {
 					"",
 					`could not parse pvc.autoscaling.gardener.cloud/prev-size annotation with value not-a-quantity`,
 					true,
-					metav1.ConditionFalse,
+					metav1.ConditionUnknown,
 				),
 			)
 		})

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -261,8 +261,12 @@ var _ = Describe("Periodic Runner", func() {
 				Expect(volumeRecommendation).To(Equal(v1alpha1.VolumeRecommendation{
 					Name: pvc.Name,
 					Current: v1alpha1.CurrentVolumeStatus{
+						Size:              pvc.Status.Capacity.Storage(),
 						UsedSpacePercent:  ptr.To(usedSpace),
 						UsedInodesPercent: ptr.To(usedInodes),
+					},
+					Target: v1alpha1.TargetRecommendation{
+						Size: pvc.Spec.Resources.Requests.Storage(),
 					},
 				}))
 			})
@@ -282,8 +286,12 @@ var _ = Describe("Periodic Runner", func() {
 				Expect(volumeRecommendation).To(Equal(v1alpha1.VolumeRecommendation{
 					Name: pvc.Name,
 					Current: v1alpha1.CurrentVolumeStatus{
+						Size:              pvc.Status.Capacity.Storage(),
 						UsedSpacePercent:  ptr.To(usedSpace),
 						UsedInodesPercent: ptr.To(usedInodes),
+					},
+					Target: v1alpha1.TargetRecommendation{
+						Size: pvc.Spec.Resources.Requests.Storage(),
 					},
 				}))
 			})
@@ -1138,16 +1146,15 @@ var _ = Describe("Periodic Runner", func() {
 		})
 
 		Describe("#isResizeInProgress", func() {
-			DescribeTable("should detect whether resize is in progress based on PVC conditions",
+			DescribeTable("should detect whether resize is in progress",
 				func(
 					pvcConditionType *corev1.PersistentVolumeClaimConditionType,
-					recommendedSize string,
-					usedSpacePercent *int,
-					usedInodesPercent *int,
+					prevSizeAnnotation *string,
 					reason string,
 					expectedLogSubstring string,
 					expectedMessageRegex string,
 					expectInProgress bool,
+					expectedConditionStatus metav1.ConditionStatus,
 				) {
 					if pvcConditionType != nil {
 						By("Patching shared pvc with condition")
@@ -1157,14 +1164,14 @@ var _ = Describe("Periodic Runner", func() {
 						}
 						Expect(k8sClient.Status().Patch(parentCtx, pvc, patch)).To(Succeed())
 					}
-
-					volumeRecommendation := v1alpha1.VolumeRecommendation{
-						Name: "test-pvc",
-						Current: v1alpha1.CurrentVolumeStatus{
-							Size:              ptr.To(resource.MustParse(recommendedSize)),
-							UsedSpacePercent:  usedSpacePercent,
-							UsedInodesPercent: usedInodesPercent,
-						},
+					if prevSizeAnnotation != nil {
+						By("Patching shared pvc with annotation")
+						annotationPatch := client.MergeFrom(pvc.DeepCopy())
+						if pvc.Annotations == nil {
+							pvc.Annotations = map[string]string{}
+						}
+						pvc.Annotations[common.AnnotationPreviousSize] = *prevSizeAnnotation
+						Expect(k8sClient.Patch(parentCtx, pvc, annotationPatch)).To(Succeed())
 					}
 
 					var buf strings.Builder
@@ -1172,73 +1179,87 @@ var _ = Describe("Periodic Runner", func() {
 					logger := zap.New(zap.WriteTo(w))
 
 					aggregator := &resizingConditionAggregator{}
-					inProgress := runner.isResizeInProgress(logger, pvc, reason, volumeRecommendation, aggregator)
+					inProgress := runner.isResizeInProgress(logger, pvc, reason, aggregator)
 					Expect(inProgress).To(Equal(expectInProgress))
 
-					if expectInProgress {
-						if expectedLogSubstring != "" {
-							Expect(buf.String()).To(ContainSubstring(expectedLogSubstring))
-						}
-
-						Expect(aggregator.getAggregatedCondition()).To(And(
-							HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
-							HaveField("Status", metav1.ConditionTrue),
-							HaveField("Reason", ReasonReconcile),
-							HaveField("Message", MatchRegexp(expectedMessageRegex)),
-						))
-					} else {
+					if !expectInProgress {
 						Expect(aggregator.getAggregatedCondition().Message).To(BeEmpty())
+
+						return
 					}
+
+					if expectedLogSubstring != "" {
+						Expect(buf.String()).To(ContainSubstring(expectedLogSubstring))
+					}
+					Expect(aggregator.getAggregatedCondition()).To(And(
+						HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
+						HaveField("Status", expectedConditionStatus),
+						HaveField("Reason", ReasonReconcile),
+						HaveField("Message", MatchRegexp(expectedMessageRegex)),
+					))
 				},
 				Entry("should detect resize has been started",
 					ptr.To(corev1.PersistentVolumeClaimResizing),
-					"1Gi",
-					ptr.To(95),
 					nil,
 					"passing storage threshold",
 					"resize has been started",
 					`storage threshold.*resize has been started`,
 					true,
+					metav1.ConditionTrue,
 				),
 				Entry("should detect filesystem resize is pending",
 					ptr.To(corev1.PersistentVolumeClaimFileSystemResizePending),
-					"1Gi",
 					nil,
-					ptr.To(95),
 					"passing inodes threshold",
 					"filesystem resize is pending",
 					`passing inodes threshold.*file system resize is pending`,
 					true,
+					metav1.ConditionTrue,
 				),
 				Entry("should detect volume is being modified",
 					ptr.To(corev1.PersistentVolumeClaimVolumeModifyingVolume),
-					"1Gi",
-					ptr.To(95),
 					nil,
 					"passing storage threshold",
 					"volume is being modified",
 					`storage threshold.*volume is being modified`,
 					true,
+					metav1.ConditionTrue,
 				),
-				Entry("should detect pvc is still being resized",
+				Entry("should detect pvc is still being resized when annotation matches status",
 					nil,
-					"1Gi",
-					nil,
-					ptr.To(95),
+					ptr.To("1Gi"),
 					"passing inodes threshold",
 					"persistent volume claim is still being resized",
 					`passing inodes threshold.*persistent volume claim is still being resized`,
 					true,
+					metav1.ConditionTrue,
 				),
-				Entry("should return false when no resize is in progress",
+				Entry("should return false when annotation is missing",
 					nil,
-					"2Gi",
-					ptr.To(95),
 					nil,
 					"passing storage threshold",
 					"",
 					"",
 					false,
+					metav1.ConditionTrue,
+				),
+				Entry("should return false when annotation no longer matches status (resize completed)",
+					nil,
+					ptr.To("512Mi"),
+					"passing storage threshold",
+					"",
+					"",
+					false,
+					metav1.ConditionTrue,
+				),
+				Entry("should return true on unparseable annotation and surface the parse error in the aggregated condition",
+					nil,
+					ptr.To("not-a-quantity"),
+					"passing storage threshold",
+					"",
+					`could not parse pvc.autoscaling.gardener.cloud/prev-size annotation with value not-a-quantity`,
+					true,
+					metav1.ConditionFalse,
 				),
 			)
 		})
@@ -1274,6 +1295,7 @@ var _ = Describe("Periodic Runner", func() {
 					var resizedPvc corev1.PersistentVolumeClaim
 					Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &resizedPvc)).To(Succeed())
 					Expect(resizedPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse(recommendedSize)))
+					Expect(resizedPvc.Annotations).To(HaveKeyWithValue(common.AnnotationPreviousSize, "1Gi"))
 
 					Expect(updatedRecommendation.Target.Size).NotTo(BeNil())
 					Expect(*updatedRecommendation.Target.Size).To(Equal(resource.MustParse(recommendedSize)))
@@ -1327,6 +1349,7 @@ var _ = Describe("Periodic Runner", func() {
 				firstIncreaseCap := resource.MustParse("2Gi")
 				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &resizedPvc)).To(Succeed())
 				Expect(resizedPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(firstIncreaseCap))
+				Expect(resizedPvc.Annotations).To(HaveKeyWithValue(common.AnnotationPreviousSize, "1Gi"))
 
 				By("Updating PVC status to simulate actual resize")
 				patch := client.MergeFrom(resizedPvc.DeepCopy())
@@ -1344,6 +1367,7 @@ var _ = Describe("Periodic Runner", func() {
 				secondIncreaseCap := resource.MustParse("3Gi")
 				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &resizedPvc)).To(Succeed())
 				Expect(resizedPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(secondIncreaseCap))
+				Expect(resizedPvc.Annotations).To(HaveKeyWithValue(common.AnnotationPreviousSize, "2Gi"))
 
 				By("Updating PVC status again to simulate actual resize")
 				patch = client.MergeFrom(resizedPvc.DeepCopy())


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
With this PR the previous size is recorded in an annotation `pvc.autoscaling.gardener.cloud/prev-size` on the PVC when the autoscaler increases the size of the PVC.
This is necessary because previously the previous size was only recorded in the `volumeRecommendations[].current.size` in the PVCA after resizing the PVC. However, the patch that updates the volumeRecommendations on the PVCA could fail, or the pvc-autoscaler could be restarted before that. This would cause the check here to fail and incorrectly return that resize is no longer in progress if there are no conditions set on the PVC yet:
https://github.com/gardener/pvc-autoscaler/blob/af8bb864befd1ef3c52223d949988158af01fb0c/internal/periodic/periodic.go#L581-L594

With this we can now also properly set the current size in the volume recommendations on each reconciliation, without having to only wait for a scale event to set it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
When the `pvc-autoscaler` resizes a `PersistentVolumeClaim` it will annotate it with `pvc.autoscaling.gardener.cloud/prev-size` to indicate what was the size before the resize was triggered.
In cases where there are no conditions set on the `PersistentVolumeClaim` yet, the value of this annotation is compared to the `.status.capacity.storage` field of the `PersistentVolumeClaim` and a resize is considered to be still in progress if the values are equal.
```