### PR TITLE
Fix `sast-lint` job for release builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,6 @@ jobs:
           # tests are run using prow for non-release-runs, so early-exit
           echo "dummy" > gosec-report.sarif
         fi
-      go-version: '1.25.5'
 
   verify:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -362,8 +362,8 @@ $(SKAFFOLD): $(call gen-tool-version,$(SKAFFOLD),$(SKAFFOLD_VERSION))
 		$(call download-tool,skaffold,https://storage.googleapis.com/skaffold/releases/$(SKAFFOLD_VERSION)/skaffold-$(GOOS)-$(GOARCH))
 
 .PHONY: gosec
-gosec: $(GOSEC) | $(LOCALHACK)
-$(GOSEC): $(call tool_version_file,$(GOSEC),$(GOSEC_VERSION))
+gosec: $(GOSEC) | $(LOCALBIN) ## Download gosec locally if necessary.
+$(GOSEC): $(call gen-tool-version,$(GOSEC),$(GOSEC_VERSION))
 	@GOSEC_VERSION=$(GOSEC_VERSION) TOOLS_BIN_DIR=$(LOCALBIN) bash $(LOCALHACK)/install-gosec.sh
 
 .PHONY: kubectl


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area dev-productivity
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
This PR fixes the `sast-lint` job for release actions. Previously the `gosec` rule was using an non-existnet call to determine the version - `tool_version_file`. The correct call should have been `gen-tool-version` 

The job was failing with: 
```
Run set -eu
> Installing gosec
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

  0 20.5M    0  175k    0     0   339k      0  0:01:01 --:--:--  0:01:01  339k
100 20.5M  100 20.5M    0     0  26.2M      0 --:--:-- --:--:-- --:--:-- 76.8M
chmod: cannot access '/home/runner/work/pvc-autoscaler/pvc-autoscaler/bin/gosec': Not a directory
make: *** [Makefile:367: /home/runner/work/pvc-autoscaler/pvc-autoscaler/bin/gosec] Error 1
Error: Process completed with exit code 2.
```

Ref: https://github.com/gardener/pvc-autoscaler/actions/runs/26453407360/job/77880392937

The issue was happening because the `/home/runner/work/pvc-autoscaler/pvc-autoscaler/bin` referred to by $(LOCALBIN) does not get created.

Additionally, the PR drops the `go-version: '1.25.5'` input parameter from the `sast-lint` job. With this, the greatest go version will be used. We already do this in other repositories.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
