### PR TITLE
Introduce heartbeat for `/healthz`

### DIFF
--- a/cmd/pvc-autoscaler/main.go
+++ b/cmd/pvc-autoscaler/main.go
@@ -20,6 +20,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	scaleclient "k8s.io/client-go/scale"
+	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -159,7 +160,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	heartbeat := healthcheck.NewHeartbeat(interval * 5)
+	heartbeat := healthcheck.NewHeartbeat(interval*5, clock.RealClock{})
 
 	// Add the periodic runner
 	runner, err := periodic.New(

--- a/cmd/pvc-autoscaler/main.go
+++ b/cmd/pvc-autoscaler/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 	"github.com/gardener/pvc-autoscaler/internal/common"
+	"github.com/gardener/pvc-autoscaler/internal/healthcheck"
 	_ "github.com/gardener/pvc-autoscaler/internal/metrics"
 	"github.com/gardener/pvc-autoscaler/internal/metrics/source"
 	"github.com/gardener/pvc-autoscaler/internal/metrics/source/prometheus"
@@ -158,6 +159,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	heartbeat := healthcheck.NewHeartbeat(interval * 5)
+
 	// Add the periodic runner
 	runner, err := periodic.New(
 		periodic.WithClient(mgr.GetClient()),
@@ -165,6 +168,7 @@ func main() {
 		periodic.WithMetricsSource(metricsSource),
 		periodic.WithEventRecorder(mgr.GetEventRecorderFor(common.ControllerName)),
 		periodic.WithPVCFetcher(pvcFetcher),
+		periodic.WithHeartbeat(heartbeat),
 	)
 	if err != nil {
 		setupLog.Error(err, "unable to create periodic runner", "controller", common.ControllerName)
@@ -184,7 +188,7 @@ func main() {
 	}
 	//+kubebuilder:scaffold:builder
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+	if err := mgr.AddHealthzCheck("healthz", heartbeat.Check); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}

--- a/internal/healthcheck/healthcheck_suite_test.go
+++ b/internal/healthcheck/healthcheck_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcheck_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHealthcheck(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Healthcheck Suite")
+}

--- a/internal/healthcheck/heartbeat.go
+++ b/internal/healthcheck/heartbeat.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcheck
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Heartbeat tracks periodic component activity and exposes a controller-runtime health checker.
+type Heartbeat struct {
+	activityTimeout time.Duration
+	checkTimeout    bool
+	lastActivity    time.Time
+	mutex           sync.Mutex
+}
+
+// NewHeartbeat creates a heartbeat checker with the given inactivity timeout.
+func NewHeartbeat(activityTimeout time.Duration) *Heartbeat {
+	return &Heartbeat{
+		activityTimeout: activityTimeout,
+		lastActivity:    time.Now(),
+	}
+}
+
+// StartMonitoring enables timeout checks and resets last activity to now.
+func (h *Heartbeat) StartMonitoring() {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	h.checkTimeout = true
+	h.lastActivity = time.Now()
+}
+
+// UpdateLastActivity marks component activity at the current time.
+func (h *Heartbeat) UpdateLastActivity() {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	h.lastActivity = time.Now()
+}
+
+// Check implements controller-runtime healthz checker interface.
+func (h *Heartbeat) Check(_ *http.Request) error {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	if !h.checkTimeout {
+		return nil
+	}
+
+	now := time.Now()
+	ago := now.Sub(h.lastActivity)
+	if now.After(h.lastActivity.Add(h.activityTimeout)) {
+		return fmt.Errorf("last activity more than %s ago", ago)
+	}
+
+	return nil
+}

--- a/internal/healthcheck/heartbeat.go
+++ b/internal/healthcheck/heartbeat.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"k8s.io/utils/clock"
 )
 
 // Heartbeat tracks periodic component activity and exposes a controller-runtime health checker.
@@ -16,14 +18,16 @@ type Heartbeat struct {
 	activityTimeout time.Duration
 	checkTimeout    bool
 	lastActivity    time.Time
+	clock           clock.Clock
 	mutex           sync.Mutex
 }
 
 // NewHeartbeat creates a heartbeat checker with the given inactivity timeout.
-func NewHeartbeat(activityTimeout time.Duration) *Heartbeat {
+func NewHeartbeat(activityTimeout time.Duration, clk clock.Clock) *Heartbeat {
 	return &Heartbeat{
 		activityTimeout: activityTimeout,
-		lastActivity:    time.Now(),
+		lastActivity:    clk.Now(),
+		clock:           clk,
 	}
 }
 
@@ -33,7 +37,7 @@ func (h *Heartbeat) StartMonitoring() {
 	defer h.mutex.Unlock()
 
 	h.checkTimeout = true
-	h.lastActivity = time.Now()
+	h.lastActivity = h.clock.Now()
 }
 
 // UpdateLastActivity marks component activity at the current time.
@@ -41,7 +45,7 @@ func (h *Heartbeat) UpdateLastActivity() {
 	h.mutex.Lock()
 	defer h.mutex.Unlock()
 
-	h.lastActivity = time.Now()
+	h.lastActivity = h.clock.Now()
 }
 
 // Check implements controller-runtime healthz checker interface.
@@ -53,7 +57,7 @@ func (h *Heartbeat) Check(_ *http.Request) error {
 		return nil
 	}
 
-	now := time.Now()
+	now := h.clock.Now()
 	ago := now.Sub(h.lastActivity)
 	if now.After(h.lastActivity.Add(h.activityTimeout)) {
 		return fmt.Errorf("last activity more than %s ago", ago)

--- a/internal/healthcheck/heartbeat_test.go
+++ b/internal/healthcheck/heartbeat_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcheck_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/pvc-autoscaler/internal/healthcheck"
+)
+
+var _ = Describe("Heartbeat", func() {
+	It("returns nil before monitoring starts", func() {
+		heartbeat := healthcheck.NewHeartbeat(1 * time.Nanosecond)
+		time.Sleep(1 * time.Millisecond)
+
+		Expect(heartbeat.Check(nil)).To(Succeed())
+	})
+
+	It("returns an error after timeout", func() {
+		heartbeat := healthcheck.NewHeartbeat(5 * time.Millisecond)
+		heartbeat.StartMonitoring()
+		time.Sleep(15 * time.Millisecond)
+
+		Expect(heartbeat.Check(nil)).To(HaveOccurred())
+	})
+
+	It("does not timeout after activity update", func() {
+		heartbeat := healthcheck.NewHeartbeat(20 * time.Millisecond)
+		heartbeat.StartMonitoring()
+		time.Sleep(5 * time.Millisecond)
+		heartbeat.UpdateLastActivity()
+		time.Sleep(5 * time.Millisecond)
+
+		Expect(heartbeat.Check(nil)).To(Succeed())
+	})
+})

--- a/internal/healthcheck/heartbeat_test.go
+++ b/internal/healthcheck/heartbeat_test.go
@@ -23,14 +23,14 @@ var _ = Describe("Heartbeat", func() {
 		fakeClock = clocktesting.NewFakeClock(time.Now())
 	})
 
-	It("returns nil before monitoring starts", func() {
+	It("should return nil before monitoring starts", func() {
 		heartbeat := healthcheck.NewHeartbeat(1*time.Nanosecond, fakeClock)
 		fakeClock.Step(1 * time.Millisecond)
 
 		Expect(heartbeat.Check(nil)).To(Succeed())
 	})
 
-	It("returns an error after timeout", func() {
+	It("should return an error after timeout", func() {
 		heartbeat := healthcheck.NewHeartbeat(5*time.Millisecond, fakeClock)
 		heartbeat.StartMonitoring()
 		fakeClock.Step(15 * time.Millisecond)
@@ -38,7 +38,7 @@ var _ = Describe("Heartbeat", func() {
 		Expect(heartbeat.Check(nil)).To(HaveOccurred())
 	})
 
-	It("does not timeout after activity update", func() {
+	It("should not timeout after activity update", func() {
 		heartbeat := healthcheck.NewHeartbeat(20*time.Millisecond, fakeClock)
 		heartbeat.StartMonitoring()
 		fakeClock.Step(5 * time.Millisecond)

--- a/internal/healthcheck/heartbeat_test.go
+++ b/internal/healthcheck/heartbeat_test.go
@@ -9,32 +9,41 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	clocktesting "k8s.io/utils/clock/testing"
 
 	"github.com/gardener/pvc-autoscaler/internal/healthcheck"
 )
 
 var _ = Describe("Heartbeat", func() {
+	var (
+		fakeClock *clocktesting.FakeClock
+	)
+
+	BeforeEach(func() {
+		fakeClock = clocktesting.NewFakeClock(time.Now())
+	})
+
 	It("returns nil before monitoring starts", func() {
-		heartbeat := healthcheck.NewHeartbeat(1 * time.Nanosecond)
-		time.Sleep(1 * time.Millisecond)
+		heartbeat := healthcheck.NewHeartbeat(1*time.Nanosecond, fakeClock)
+		fakeClock.Step(1 * time.Millisecond)
 
 		Expect(heartbeat.Check(nil)).To(Succeed())
 	})
 
 	It("returns an error after timeout", func() {
-		heartbeat := healthcheck.NewHeartbeat(5 * time.Millisecond)
+		heartbeat := healthcheck.NewHeartbeat(5*time.Millisecond, fakeClock)
 		heartbeat.StartMonitoring()
-		time.Sleep(15 * time.Millisecond)
+		fakeClock.Step(15 * time.Millisecond)
 
 		Expect(heartbeat.Check(nil)).To(HaveOccurred())
 	})
 
 	It("does not timeout after activity update", func() {
-		heartbeat := healthcheck.NewHeartbeat(20 * time.Millisecond)
+		heartbeat := healthcheck.NewHeartbeat(20*time.Millisecond, fakeClock)
 		heartbeat.StartMonitoring()
-		time.Sleep(5 * time.Millisecond)
+		fakeClock.Step(5 * time.Millisecond)
 		heartbeat.UpdateLastActivity()
-		time.Sleep(5 * time.Millisecond)
+		fakeClock.Step(5 * time.Millisecond)
 
 		Expect(heartbeat.Check(nil)).To(Succeed())
 	})

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -194,18 +194,17 @@ func (r *Runner) Start(ctx context.Context) error {
 
 	if r.heartbeat != nil {
 		r.heartbeat.StartMonitoring()
-		r.heartbeat.UpdateLastActivity()
 	}
 
 	for {
 		select {
 		case <-ticker.C:
-			if r.heartbeat != nil {
-				r.heartbeat.UpdateLastActivity()
-			}
-
 			if err := r.reconcileAll(ctx); err != nil {
 				logger.Error(err, "failed to reconcile persistentvolumeclaimautoscalers")
+			}
+
+			if r.heartbeat != nil {
+				r.heartbeat.UpdateLastActivity()
 			}
 		case <-ctx.Done():
 			return nil

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 	"github.com/gardener/pvc-autoscaler/internal/common"
+	"github.com/gardener/pvc-autoscaler/internal/healthcheck"
 	"github.com/gardener/pvc-autoscaler/internal/metrics"
 	metricssource "github.com/gardener/pvc-autoscaler/internal/metrics/source"
 	"github.com/gardener/pvc-autoscaler/internal/target/pvcfetcher"
@@ -96,6 +97,7 @@ type Runner struct {
 	metricsSource metricssource.Source
 	eventRecorder record.EventRecorder
 	pvcFetcher    pvcfetcher.Fetcher
+	heartbeat     *healthcheck.Heartbeat
 }
 
 var _ manager.Runnable = &Runner{}
@@ -174,6 +176,15 @@ func WithPVCFetcher(pvcFetcher pvcfetcher.Fetcher) Option {
 	return opt
 }
 
+// WithHeartbeat configures the [Runner] to report activity for health checks.
+func WithHeartbeat(h *healthcheck.Heartbeat) Option {
+	opt := func(r *Runner) {
+		r.heartbeat = h
+	}
+
+	return opt
+}
+
 // Start implements the
 // [sigs.k8s.io/controller-runtime/pkg/manager.Runnable] interface.
 func (r *Runner) Start(ctx context.Context) error {
@@ -181,9 +192,18 @@ func (r *Runner) Start(ctx context.Context) error {
 	logger := log.FromContext(ctx, "controller", common.ControllerName)
 	defer ticker.Stop()
 
+	if r.heartbeat != nil {
+		r.heartbeat.StartMonitoring()
+		r.heartbeat.UpdateLastActivity()
+	}
+
 	for {
 		select {
 		case <-ticker.C:
+			if r.heartbeat != nil {
+				r.heartbeat.UpdateLastActivity()
+			}
+
 			if err := r.reconcileAll(ctx); err != nil {
 				logger.Error(err, "failed to reconcile persistentvolumeclaimautoscalers")
 			}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -40,6 +40,7 @@ build:
             - api/autoscaling/v1alpha1
             - cmd/pvc-autoscaler
             - internal/common
+            - internal/healthcheck
             - internal/metrics
             - internal/metrics/source
             - internal/metrics/source/prometheus


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
Up until now, `/healthz` used a constant ping that stayed healthy even if the periodic loop was stuck. This PR adds a heartbeat implementation, similar to [the one in VPA](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/utils/metrics/healthcheck.go), in the form of a heartbeat. The `/healthz` endpoint now reflects actual controller loop activity instead of a static ping, so if the periodic reconciliation loop stops making progress for longer than 5× the configured interval, the health check fails and Kubernetes restarts the pod automatically.

**Which issue(s) this PR fixes**:
Part of #162 

**Special notes for your reviewer**:
/cc @plkokanov @Kostov6 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Added heartbeat activity tracker that implements the controller-runtime healthz.Checker interface.
The periodic runner reports activity on every tick via UpdateLastActivity(), which prevents missed health check fails.
```
