### PR TITLE
Run `make generate` after `config/**` files or `kustomize` version is changed

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -94,7 +94,22 @@
         executionMode: 'branch',
       },
       matchPackageNames: [
+        '/kubernetes-sigs/kustomize',
         '/kubernetes-sigs/controller-tools',
+      ],
+    },
+    {
+      // Run make generate when an image referenced from `config/` is bumped, so the
+      // regenerated dist/install.yaml picks up the new image tag. Tool-version bumps
+      // that affect generation (controller-tools, kustomize) are handled separately.
+      postUpgradeTasks: {
+        commands: [
+          'make generate',
+        ],
+        executionMode: 'branch',
+      },
+      matchFileNames: [
+        'config/**',
       ],
     },
     {

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: generate
-generate: controller-gen ## Generate DeepCopy, DeepCopyInto, and DeepCopyObject method implementations. Also generates WebhookConfiguration, ClusterRole and CRD objects.
+generate: controller-gen build-installer ## Generate DeepCopy, DeepCopyInto, and DeepCopyObject method implementations. Also generates WebhookConfiguration, ClusterRole and CRD objects.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	$(MAKE) format

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -98,6 +98,21 @@ spec:
                   description: VolumePolicy defines the autoscaling policy for a specific
                     PVC
                   properties:
+                    match:
+                      default: {}
+                      description: Match specifies the matching criteria for selecting
+                        PVCs to which this policy applies.
+                      properties:
+                        name:
+                          default: '*'
+                          description: |-
+                            Name specifies the name of the PVC.
+                            It supports exact and glob pattern matching (e.g., "data-*" matches "data-pvc").
+                            Policies are evaluated in list order and the first matching policy is used.
+                            "*" can be used as a match-all policy.
+                          minLength: 1
+                          type: string
+                      type: object
                     maxCapacity:
                       anyOf:
                       - type: integer
@@ -108,9 +123,6 @@ spec:
                         [k8s.io/apimachinery/pkg/api/resource.Quantity] value.
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                      x-kubernetes-validations:
-                      - message: maxCapacity must be > 0
-                        rule: quantity(self).isGreaterThan(quantity('0'))
                     scaleUp:
                       default: {}
                       description: ScaleUp defines the rules for scaling up the PVC.
@@ -120,9 +132,6 @@ spec:
                             CooldownDuration specifies the minimum time that must elapse after a scaling
                             operation before another scaling operation can be triggered for the targeted PVC objects.
                           type: string
-                          x-kubernetes-validations:
-                          - message: cooldownDuration must be > 0s
-                            rule: duration(self) > duration('0s')
                         minStepAbsolute:
                           anyOf:
                           - type: integer
@@ -133,10 +142,6 @@ spec:
                             This ensures that the change in capacity is at least this amount, regardless of the percentage.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                          x-kubernetes-validations:
-                          - message: minStepAbsolute must be > 1 if specified
-                            rule: self == null || quantity(self).compareTo(quantity('1Gi'))
-                              >= 0
                         stepPercent:
                           default: 10
                           description: StepPercent specifies the percentage by which
@@ -156,7 +161,6 @@ spec:
                   required:
                   - maxCapacity
                   type: object
-                maxItems: 1
                 minItems: 1
                 type: array
             required:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR configures renovate to call `make generate` after a file under the `config/` directory is changed or if the `kustomize` version is updated.
This helps us to keep the `dist/install.yaml` file up-to-date after the corresponding dependencies are bumped by renovate.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
