### PR TITLE
Clamp PVC resize to max capacity instead of skipping it

### DIFF
--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -706,23 +706,29 @@ func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.
 
 	// We don't want to exceed the max capacity
 	if targetSize.Value() > policy.MaxCapacity.Value() {
-		r.eventRecorder.Eventf(
-			pvc,
-			corev1.EventTypeWarning,
-			"MaxCapacityReached",
-			"max capacity (%s) has been reached, will not resize",
-			policy.MaxCapacity.String(),
-		)
-		logger.Info("max capacity reached")
-		metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
-		resizingConditions.addCondition(metav1.Condition{
-			Type:    string(v1alpha1.ConditionTypeResizing),
-			Status:  metav1.ConditionFalse,
-			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf("%s: max capacity reached", pvc.Name),
-		})
+		// Only clamp to max capacity if the increase is at least one scaling resolution,
+		// otherwise the increase is too small to be meaningful
+		if policy.MaxCapacity.Value()-currSpecSize.Value() < common.ScalingResolutionBytes {
+			r.eventRecorder.Eventf(
+				pvc,
+				corev1.EventTypeWarning,
+				"MaxCapacityReached",
+				"max capacity (%s) has been reached, will not resize",
+				policy.MaxCapacity.String(),
+			)
+			logger.Info("max capacity reached")
+			metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
+			resizingConditions.addCondition(metav1.Condition{
+				Type:    string(v1alpha1.ConditionTypeResizing),
+				Status:  metav1.ConditionFalse,
+				Reason:  ReasonReconcile,
+				Message: fmt.Sprintf("%s: max capacity reached", pvc.Name),
+			})
 
-		return volumeRecommendation, nil
+			return volumeRecommendation, nil
+		}
+		// Clamp to max capacity instead of skipping the resize entirely
+		targetSize = &policy.MaxCapacity
 	}
 
 	if policy.ScaleUp.CooldownDuration != nil {

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -1591,7 +1591,7 @@ var _ = Describe("Periodic Runner", func() {
 				resizedPvc.Status.Capacity[corev1.ResourceStorage] = secondIncreaseCap
 				Expect(k8sClient.Status().Patch(parentCtx, &resizedPvc, patch)).To(Succeed())
 
-				By("Expecting third attempt to fail with max capacity reached")
+				By("Expecting third attempt to fail with max capacity reached (already at max)")
 				aggregator = &resizingConditionAggregator{}
 				volumePolicy, errPolicy = getVolumePolicy(resizedPvc.Name, pvca.Spec.VolumePolicies)
 				Expect(errPolicy).NotTo(HaveOccurred())
@@ -1606,6 +1606,53 @@ var _ = Describe("Periodic Runner", func() {
 					HaveField("Message", ContainSubstring("max capacity reached")),
 				))
 			})
+
+			DescribeTable("clamp resize to max capacity",
+				func(maxCapacity resource.Quantity, minStep resource.Quantity, expectResize bool, expectedSize resource.Quantity) {
+					volumeRecommendation := v1alpha1.VolumeRecommendation{
+						Name: pvc.Name,
+						Current: v1alpha1.CurrentVolumeStatus{
+							UsedSpacePercent: ptr.To(95),
+						},
+					}
+
+					var buf strings.Builder
+					logger := zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &buf))).WithValues("pvc", "test-pvc")
+
+					pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+					pvca.Spec.VolumePolicies[0].MaxCapacity = maxCapacity
+					pvca.Spec.VolumePolicies[0].ScaleUp.MinStepAbsolute = ptr.To(minStep)
+					Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+					aggregator := &resizingConditionAggregator{}
+					volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
+					Expect(errPolicy).NotTo(HaveOccurred())
+					_, err := runner.resizePVC(parentCtx, logger, pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+					Expect(err).NotTo(HaveOccurred())
+
+					var updatedPvc corev1.PersistentVolumeClaim
+					Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &updatedPvc)).To(Succeed())
+					Expect(updatedPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(expectedSize))
+
+					if expectResize {
+						Expect(buf.String()).To(ContainSubstring("resizing persistent volume claim"))
+					} else {
+						Expect(buf.String()).To(ContainSubstring("max capacity reached"))
+						Expect(aggregator.getAggregatedCondition()).To(And(
+							HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
+							HaveField("Status", metav1.ConditionFalse),
+							HaveField("Reason", ReasonReconcile),
+							HaveField("Message", ContainSubstring("max capacity reached")),
+						))
+					}
+				},
+				Entry("should not resize when headroom is below scaling resolution",
+					resource.MustParse("1500Mi"), resource.MustParse("1Gi"), false, resource.MustParse("1Gi"),
+				),
+				Entry("should clamp resize to max capacity when step would overshoot",
+					resource.MustParse("2Gi"), resource.MustParse("2Gi"), true, resource.MustParse("2Gi"),
+				),
+			)
 
 			DescribeTable("should handle cooldown duration",
 				func(lastResizeOffset time.Duration, expectResize bool, expectedLog string) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
When a calculated target size would exceed the configured `maxCapacity`, the autoscaler was cancelling the resize entirely. This change clamps the target to `maxCapacity` instead, so a PVC that has room to grow still gets resized up to the limit. The resize is only skipped when the PVC is already at or above `maxCapacity`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bufix operator
PVCs are now resized up to `maxCapacity` when a resize step would overshoot it, instead of being skipped entirely.
```
