### PR TITLE
Add `autoscalerName` field to `PersistentVolumeClaimAutoscaler` for multi-instance sharding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,16 @@ help: ## Display this help.
 
 ##@ Development
 
-.PHONY: generate
-generate: controller-gen build-installer ## Generate DeepCopy, DeepCopyInto, and DeepCopyObject method implementations. Also generates WebhookConfiguration, ClusterRole and CRD objects.
+define run-generate
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	$(MAKE) format
+endef
+
+.PHONY: generate
+generate: controller-gen ## Generate DeepCopy, DeepCopyInto, and DeepCopyObject method implementations. Also generates WebhookConfiguration, ClusterRole and CRD objects.
+	$(call run-generate)
+	$(MAKE) build-installer
 
 .PHONY: sast
 sast: gosec
@@ -205,7 +210,8 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	rm Dockerfile.cross
 
 .PHONY: build-installer
-build-installer: generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
+build-installer: controller-gen kustomize ## Generate a consolidated YAML with CRDs and deployment.
+	$(call run-generate)
 	mkdir -p dist
 	echo "---" > dist/install.yaml  # Add a document separator before appending
 	cd config/overlays/default && $(KUSTOMIZE) edit set image controller=${IMG}:latest

--- a/api/autoscaling/v1alpha1/indexer.go
+++ b/api/autoscaling/v1alpha1/indexer.go
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AutoscalerNameIndexKey is the field index key used to filter PVCAs by their autoscalerName.
+const AutoscalerNameIndexKey = ".spec.autoscalerName"
+
+// AddAutoscalerNameFieldIndexer adds an index for AutoscalerName to the given indexer.
+func AddAutoscalerNameFieldIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := indexer.IndexField(ctx, &PersistentVolumeClaimAutoscaler{}, AutoscalerNameIndexKey, func(obj client.Object) []string {
+		pvca := obj.(*PersistentVolumeClaimAutoscaler)
+		return []string{pvca.Spec.AutoscalerName}
+	}); err != nil {
+		return fmt.Errorf("failed to add indexer for %s to PersistentVolumeClaimAutoscaler Informer: %w", AutoscalerNameIndexKey, err)
+	}
+
+	return nil
+}

--- a/api/autoscaling/v1alpha1/indexer.go
+++ b/api/autoscaling/v1alpha1/indexer.go
@@ -17,7 +17,11 @@ const AutoscalerNameIndexKey = ".spec.autoscalerName"
 // AddAutoscalerNameFieldIndexer adds an index for AutoscalerName to the given indexer.
 func AddAutoscalerNameFieldIndexer(ctx context.Context, indexer client.FieldIndexer) error {
 	if err := indexer.IndexField(ctx, &PersistentVolumeClaimAutoscaler{}, AutoscalerNameIndexKey, func(obj client.Object) []string {
-		pvca := obj.(*PersistentVolumeClaimAutoscaler)
+		pvca, ok := obj.(*PersistentVolumeClaimAutoscaler)
+		if !ok {
+			return nil
+		}
+
 		return []string{pvca.Spec.AutoscalerName}
 	}); err != nil {
 		return fmt.Errorf("failed to add indexer for %s to PersistentVolumeClaimAutoscaler Informer: %w", AutoscalerNameIndexKey, err)

--- a/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
+++ b/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
@@ -17,6 +17,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=pvca
+// +kubebuilder:printcolumn:name="AutoscalerName",type=string,JSONPath=`.spec.autoscalerName`
 // +kubebuilder:printcolumn:name="Target",type=string,JSONPath=`.spec.targetRef.name`
 
 // PersistentVolumeClaimAutoscaler is the Schema for the
@@ -45,6 +46,14 @@ func init() {
 
 // PersistentVolumeClaimAutoscalerSpec defines the desired state of the PersistentVolumeClaimAutoscaler.
 type PersistentVolumeClaimAutoscalerSpec struct {
+	// AutoscalerName optionally assigns this PVCA to a named autoscaler instance.
+	// An autoscaler started with --autoscaler-name=<name> reconciles only PVCAs whose
+	// autoscalerName matches. An autoscaler started without --autoscaler-name reconciles
+	// only PVCAs with an empty autoscalerName. Defaults to "".
+	// +kubebuilder:default=""
+	// +optional
+	AutoscalerName string `json:"autoscalerName,omitempty"`
+
 	// TargetRef specifies the reference to the workload controller (e.g., StatefulSet)
 	// whose PVCs will be managed by the autoscaler.
 	TargetRef autoscalingv1.CrossVersionObjectReference `json:"targetRef"`

--- a/cmd/pvc-autoscaler/main.go
+++ b/cmd/pvc-autoscaler/main.go
@@ -64,6 +64,7 @@ func main() {
 	var metricsCapacityBytesQuery string
 	var metricsAvailableInodesQuery string
 	var metricsCapacityInodesQuery string
+	var autoscalerName string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -84,6 +85,7 @@ func main() {
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 
 	flag.DurationVar(&interval, "interval", 5*time.Minute, "The interval at which to run the periodic check")
+	flag.StringVar(&autoscalerName, "autoscaler-name", "", "Only reconcile PVCAs with this autoscalerName value. An empty value (default) reconciles PVCAs with no autoscalerName set.")
 
 	opts := zap.Options{
 		Development: true,
@@ -143,6 +145,11 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
+	if err := v1alpha1.AddAutoscalerNameFieldIndexer(ctx, mgr.GetFieldIndexer()); err != nil {
+		setupLog.Error(err, "unable to set up field indexer", "controller", common.ControllerName)
+		os.Exit(1)
+	}
+
 	prometheusOpts := []prometheus.Option{
 		prometheus.WithAddress(prometheusAddress),
 		prometheus.WithAvailableBytesQuery(metricsAvailableBytesQuery),
@@ -173,6 +180,7 @@ func main() {
 		periodic.WithEventRecorder(mgr.GetEventRecorderFor(common.ControllerName)),
 		periodic.WithPVCFetcher(pvcFetcher),
 		periodic.WithHeartbeat(heartbeat),
+		periodic.WithAutoscalerName(autoscalerName),
 	)
 	if err != nil {
 		setupLog.Error(err, "unable to create periodic runner", "controller", common.ControllerName)

--- a/config/crd/bases/autoscaling.gardener.cloud_persistentvolumeclaimautoscalers.yaml
+++ b/config/crd/bases/autoscaling.gardener.cloud_persistentvolumeclaimautoscalers.yaml
@@ -17,6 +17,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.autoscalerName
+      name: AutoscalerName
+      type: string
     - jsonPath: .spec.targetRef.name
       name: Target
       type: string
@@ -48,6 +51,14 @@ spec:
             description: PersistentVolumeClaimAutoscalerSpec defines the desired state
               of the PersistentVolumeClaimAutoscaler.
             properties:
+              autoscalerName:
+                default: ""
+                description: |-
+                  AutoscalerName optionally assigns this PVCA to a named autoscaler instance.
+                  An autoscaler started with --autoscaler-name=<name> reconciles only PVCAs whose
+                  autoscalerName matches. An autoscaler started without --autoscaler-name reconciles
+                  only PVCAs with an empty autoscalerName. Defaults to "".
+                type: string
               targetRef:
                 description: |-
                   TargetRef specifies the reference to the workload controller (e.g., StatefulSet)

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -41,6 +41,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.autoscalerName
+      name: AutoscalerName
+      type: string
     - jsonPath: .spec.targetRef.name
       name: Target
       type: string
@@ -72,6 +75,14 @@ spec:
             description: PersistentVolumeClaimAutoscalerSpec defines the desired state
               of the PersistentVolumeClaimAutoscaler.
             properties:
+              autoscalerName:
+                default: ""
+                description: |-
+                  AutoscalerName optionally assigns this PVCA to a named autoscaler instance.
+                  An autoscaler started with --autoscaler-name=<name> reconciles only PVCAs whose
+                  autoscalerName matches. An autoscaler started without --autoscaler-name reconciles
+                  only PVCAs with an empty autoscalerName. Defaults to "".
+                type: string
               targetRef:
                 description: |-
                   TargetRef specifies the reference to the workload controller (e.g., StatefulSet)

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -94,12 +94,13 @@ const (
 // processes [v1alpha1.PersistentVolumeClaimAutoscaler] items on a regular basis
 // and performs PVC resizing when thresholds are reached.
 type Runner struct {
-	client        client.Client
-	interval      time.Duration
-	metricsSource metricssource.Source
-	eventRecorder record.EventRecorder
-	pvcFetcher    pvcfetcher.Fetcher
-	heartbeat     *healthcheck.Heartbeat
+	client         client.Client
+	interval       time.Duration
+	metricsSource  metricssource.Source
+	eventRecorder  record.EventRecorder
+	pvcFetcher     pvcfetcher.Fetcher
+	heartbeat      *healthcheck.Heartbeat
+	autoscalerName string
 }
 
 var _ manager.Runnable = &Runner{}
@@ -187,6 +188,18 @@ func WithHeartbeat(h *healthcheck.Heartbeat) Option {
 	return opt
 }
 
+// WithAutoscalerName configures the [Runner] to reconcile only
+// [v1alpha1.PersistentVolumeClaimAutoscaler] objects whose spec.autoscalerName
+// matches the given value. An empty string (the default) reconciles only PVCAs
+// with an empty autoscalerName.
+func WithAutoscalerName(name string) Option {
+	opt := func(r *Runner) {
+		r.autoscalerName = name
+	}
+
+	return opt
+}
+
 // Start implements the
 // [sigs.k8s.io/controller-runtime/pkg/manager.Runnable] interface.
 func (r *Runner) Start(ctx context.Context) error {
@@ -222,7 +235,7 @@ func (r *Runner) reconcileAll(ctx context.Context) error {
 		pvcaList v1alpha1.PersistentVolumeClaimAutoscalerList
 	)
 
-	if err := r.client.List(ctx, &pvcaList); err != nil {
+	if err := r.client.List(ctx, &pvcaList, client.MatchingFields{v1alpha1.AutoscalerNameIndexKey: r.autoscalerName}); err != nil {
 		return err
 	}
 

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -273,6 +273,8 @@ func (r *Runner) fetchPVCsForPVCAs(ctx context.Context, logger logr.Logger, pers
 
 	for _, pvca := range persistentVolumeClaimAutoscalers {
 		pvcaKey := client.ObjectKeyFromObject(&pvca)
+		logger.V(2).Info("fetching persistentvolumeclaims for persistentvolumeclaimautoscaler", "autoscalerName", r.autoscalerName, "pvca", pvcaKey)
+
 		persistentVolumeClaims, err := r.pvcFetcher.Fetch(ctx, &pvca)
 		if err != nil {
 			logger.Error(err, "failed to fetch persistentvolumeclaims for persistentvolumeclaimautoscaler", "pvca", pvcaKey)

--- a/internal/periodic/periodic_suite_test.go
+++ b/internal/periodic/periodic_suite_test.go
@@ -22,10 +22,12 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 	"github.com/gardener/pvc-autoscaler/internal/target/pvcfetcher"
@@ -33,13 +35,16 @@ import (
 	testutils "github.com/gardener/pvc-autoscaler/test/utils"
 )
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var eventRecorder = record.NewFakeRecorder(1024)
-var pvcFetcher pvcfetcher.Fetcher
-var parentCtx context.Context
-var cancelFunc context.CancelFunc
+var (
+	cfg           *rest.Config
+	k8sClient     client.Client
+	mgrClient     client.Client
+	testEnv       *envtest.Environment
+	eventRecorder = record.NewFakeRecorder(1024)
+	pvcFetcher    pvcfetcher.Fetcher
+	parentCtx     context.Context
+	cancelFunc    context.CancelFunc
+)
 
 func TestPeriodic(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -80,10 +85,27 @@ var _ = BeforeSuite(func() {
 	err = v1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	opts := client.Options{Scheme: scheme.Scheme}
-	k8sClient, err = client.New(cfg, opts)
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:  scheme.Scheme,
+		Metrics: metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	mgrClient = mgr.GetClient()
+
+	Expect(v1alpha1.AddAutoscalerNameFieldIndexer(context.Background(), mgr.GetFieldIndexer())).To(Succeed())
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(parentCtx)).To(Succeed())
+	}()
+
+	// Wait for the cache to be synced before running tests.
+	Expect(mgr.GetCache().WaitForCacheSync(parentCtx)).To(BeTrue())
 
 	// Create test storage class
 	Expect(k8sClient.Create(context.Background(), &testutils.StorageClass)).To(Succeed())

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -73,12 +73,12 @@ func createPVCA(ctx context.Context, name, autoscalerName string, targetRef auto
 // ResourceVersion, ensuring a preceding k8sClient.Patch is visible to the runner.
 func waitForPVCACacheSync(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler) {
 	rv := pvca.ResourceVersion
-	Eventually(func() string {
+	Eventually(func(g Gomega) {
 		cached := &v1alpha1.PersistentVolumeClaimAutoscaler{}
-		_ = mgrClient.Get(ctx, client.ObjectKeyFromObject(pvca), cached)
-
-		return cached.ResourceVersion
-	}).Should(Equal(rv))
+		err := mgrClient.Get(ctx, client.ObjectKeyFromObject(pvca), cached)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(cached.ResourceVersion).To(Equal(rv))
+	}).Should(Succeed())
 }
 
 // creates a new test periodic runner

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -35,14 +35,16 @@ import (
 const nonExistentPVCName = "non-existent-pvc"
 
 // createPVC creates a PVC via k8sClient and waits until mgrClient's cache observes it.
-func createPVC(ctx context.Context, name, capacity string, storageClassName *string, volumeMode *corev1.PersistentVolumeMode) *corev1.PersistentVolumeClaim {
-	pvc, err := testutils.CreatePVC(ctx, k8sClient, name, capacity, storageClassName, volumeMode)
+func createPVC(ctx context.Context, name string, storageClassName *string, volumeMode *corev1.PersistentVolumeMode) *corev1.PersistentVolumeClaim {
+	pvc, err := testutils.CreatePVC(ctx, k8sClient, name, "1Gi", storageClassName, volumeMode)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(pvc).NotTo(BeNil())
+
 	cached := &corev1.PersistentVolumeClaim{}
 	Eventually(func() error {
 		return mgrClient.Get(ctx, client.ObjectKeyFromObject(pvc), cached)
 	}).Should(Succeed())
+
 	return pvc
 }
 
@@ -53,6 +55,7 @@ func createPVCA(ctx context.Context, name, autoscalerName string, targetRef auto
 	pvca, err := testutils.CreatePersistentVolumeClaimAutoscaler(ctx, k8sClient, name, targetRef, volumePolicies)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(pvca).NotTo(BeNil())
+
 	if autoscalerName != "" {
 		patch := client.MergeFrom(pvca.DeepCopy())
 		pvca.Spec.AutoscalerName = autoscalerName
@@ -62,6 +65,7 @@ func createPVCA(ctx context.Context, name, autoscalerName string, targetRef auto
 	Eventually(func() error {
 		return mgrClient.Get(ctx, client.ObjectKeyFromObject(pvca), cached)
 	}).Should(Succeed())
+
 	return pvca
 }
 
@@ -72,6 +76,7 @@ func waitForPVCACacheSync(ctx context.Context, pvca *v1alpha1.PersistentVolumeCl
 	Eventually(func() string {
 		cached := &v1alpha1.PersistentVolumeClaimAutoscaler{}
 		_ = mgrClient.Get(ctx, client.ObjectKeyFromObject(pvca), cached)
+
 		return cached.ResourceVersion
 	}).Should(Equal(rv))
 }
@@ -340,7 +345,7 @@ var _ = Describe("Periodic Runner", func() {
 			}
 
 			By("Creating PVC for tests")
-			pvc = createPVC(parentCtx, "test-pvc", "1Gi", ptr.To(testutils.StorageClassName), nil)
+			pvc = createPVC(parentCtx, "test-pvc", ptr.To(testutils.StorageClassName), nil)
 
 			DeferCleanup(func() {
 				By("Deleting PVC")
@@ -467,7 +472,7 @@ var _ = Describe("Periodic Runner", func() {
 		Describe("#validatePVC", func() {
 			It("should return ErrStorageClassNotFound", func() {
 				By("Creating a PVC without a StorageClass")
-				pvc := createPVC(parentCtx, "pvc-without-storageclass", "1Gi", nil, nil)
+				pvc := createPVC(parentCtx, "pvc-without-storageclass", nil, nil)
 				DeferCleanup(func() {
 					By("Deleting PVC without a StorageClass")
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvc)).To(Succeed())
@@ -520,7 +525,7 @@ var _ = Describe("Periodic Runner", func() {
 				})
 
 				By("Creating a test PVC using the StorageClass")
-				pvc := createPVC(parentCtx, "pvc-sc-no-expansion", "1Gi", ptr.To(scName), nil)
+				pvc := createPVC(parentCtx, "pvc-sc-no-expansion", ptr.To(scName), nil)
 				DeferCleanup(func() {
 					By("Deleting the PVC with StorageClass")
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvc)).To(Succeed())
@@ -556,7 +561,7 @@ var _ = Describe("Periodic Runner", func() {
 
 			It("should return ErrVolumeModeIsNotFilesystem", func() {
 				By("Creating PVC with block volume")
-				pvc := createPVC(parentCtx, "pvc-block-mode", "1Gi", ptr.To(testutils.StorageClassName), ptr.To(corev1.PersistentVolumeBlock))
+				pvc := createPVC(parentCtx, "pvc-block-mode", ptr.To(testutils.StorageClassName), ptr.To(corev1.PersistentVolumeBlock))
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvc)).To(Succeed())
 					Eventually(func() error {
@@ -852,7 +857,7 @@ var _ = Describe("Periodic Runner", func() {
 
 			It("should set RecommendationAvailable condition to false when no matching volume policy exists", func() {
 				By("Creating a PVC that has no volumePolicy match")
-				noMatchPVC := createPVC(parentCtx, "no-match-pvc", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				noMatchPVC := createPVC(parentCtx, "no-match-pvc", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					By("Deleting no-match PVC")
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, noMatchPVC)).To(Succeed())
@@ -954,7 +959,7 @@ var _ = Describe("Periodic Runner", func() {
 				selectorLabels := map[string]string{"app": "deployment-target"}
 
 				By("Creating PVCs referenced by the Deployment's pods")
-				pvcA := createPVC(parentCtx, "deploy-pvc-a", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				pvcA := createPVC(parentCtx, "deploy-pvc-a", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcA)).To(Succeed())
 					Eventually(func() error {
@@ -962,7 +967,7 @@ var _ = Describe("Periodic Runner", func() {
 					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 				})
 
-				pvcB := createPVC(parentCtx, "deploy-pvc-b", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				pvcB := createPVC(parentCtx, "deploy-pvc-b", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcB)).To(Succeed())
 					Eventually(func() error {
@@ -1046,7 +1051,7 @@ var _ = Describe("Periodic Runner", func() {
 				selectorLabels := map[string]string{"app": "statefulset-target"}
 
 				By("Creating PVCs referenced by the StatefulSet's pods")
-				pvcA := createPVC(parentCtx, "sts-pvc-a", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				pvcA := createPVC(parentCtx, "sts-pvc-a", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcA)).To(Succeed())
 					Eventually(func() error {
@@ -1054,7 +1059,7 @@ var _ = Describe("Periodic Runner", func() {
 					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 				})
 
-				pvcB := createPVC(parentCtx, "sts-pvc-b", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				pvcB := createPVC(parentCtx, "sts-pvc-b", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcB)).To(Succeed())
 					Eventually(func() error {
@@ -1251,7 +1256,7 @@ var _ = Describe("Periodic Runner", func() {
 				selectorLabels := map[string]string{"app": "partial-metrics"}
 
 				By("Creating two PVCs referenced by the Deployment's pods")
-				pvcA := createPVC(parentCtx, "partial-pvc-a", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				pvcA := createPVC(parentCtx, "partial-pvc-a", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcA)).To(Succeed())
 					Eventually(func() error {
@@ -1259,7 +1264,7 @@ var _ = Describe("Periodic Runner", func() {
 					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 				})
 
-				pvcB := createPVC(parentCtx, "partial-pvc-b", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				pvcB := createPVC(parentCtx, "partial-pvc-b", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcB)).To(Succeed())
 					Eventually(func() error {
@@ -1805,7 +1810,7 @@ var _ = Describe("Periodic Runner", func() {
 		DescribeTable("should only reconcile PVCAs matching the runner's autoscalerName",
 			func(runnerAutoscalerName, matchingAutoscalerName, nonMatchingAutoscalerName string) {
 				By("Creating PVCs for each PVCA")
-				pvcMatching := createPVC(parentCtx, "filter-pvc-matching", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				pvcMatching := createPVC(parentCtx, "filter-pvc-matching", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcMatching)).To(Succeed())
 					Eventually(func() error {
@@ -1813,7 +1818,7 @@ var _ = Describe("Periodic Runner", func() {
 					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 				})
 
-				pvcNonMatching := createPVC(parentCtx, "filter-pvc-nonmatching", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				pvcNonMatching := createPVC(parentCtx, "filter-pvc-nonmatching", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcNonMatching)).To(Succeed())
 					Eventually(func() error {

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -34,6 +34,48 @@ import (
 
 const nonExistentPVCName = "non-existent-pvc"
 
+// createPVC creates a PVC via k8sClient and waits until mgrClient's cache observes it.
+func createPVC(ctx context.Context, name, capacity string, storageClassName *string, volumeMode *corev1.PersistentVolumeMode) *corev1.PersistentVolumeClaim {
+	pvc, err := testutils.CreatePVC(ctx, k8sClient, name, capacity, storageClassName, volumeMode)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(pvc).NotTo(BeNil())
+	cached := &corev1.PersistentVolumeClaim{}
+	Eventually(func() error {
+		return mgrClient.Get(ctx, client.ObjectKeyFromObject(pvc), cached)
+	}).Should(Succeed())
+	return pvc
+}
+
+// createPVCA creates a PVCA via k8sClient and waits until mgrClient's cache observes it,
+// so the field index is populated before the runner runs.
+// autoscalerName is optional — pass "" for an unclassed PVCA.
+func createPVCA(ctx context.Context, name, autoscalerName string, targetRef autoscalingv1.CrossVersionObjectReference, volumePolicies []v1alpha1.VolumePolicy) *v1alpha1.PersistentVolumeClaimAutoscaler {
+	pvca, err := testutils.CreatePersistentVolumeClaimAutoscaler(ctx, k8sClient, name, targetRef, volumePolicies)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(pvca).NotTo(BeNil())
+	if autoscalerName != "" {
+		patch := client.MergeFrom(pvca.DeepCopy())
+		pvca.Spec.AutoscalerName = autoscalerName
+		Expect(k8sClient.Patch(ctx, pvca, patch)).To(Succeed())
+	}
+	cached := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+	Eventually(func() error {
+		return mgrClient.Get(ctx, client.ObjectKeyFromObject(pvca), cached)
+	}).Should(Succeed())
+	return pvca
+}
+
+// waitForPVCACacheSync waits until mgrClient's cache reflects the given PVCA's current
+// ResourceVersion, ensuring a preceding k8sClient.Patch is visible to the runner.
+func waitForPVCACacheSync(ctx context.Context, pvca *v1alpha1.PersistentVolumeClaimAutoscaler) {
+	rv := pvca.ResourceVersion
+	Eventually(func() string {
+		cached := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+		_ = mgrClient.Get(ctx, client.ObjectKeyFromObject(pvca), cached)
+		return cached.ResourceVersion
+	}).Should(Equal(rv))
+}
+
 // creates a new test periodic runner
 func newRunner() (*Runner, error) {
 	metricsSource := fake.New(
@@ -41,11 +83,12 @@ func newRunner() (*Runner, error) {
 	)
 
 	runner, err := New(
-		WithClient(k8sClient),
+		WithClient(mgrClient),
 		WithEventRecorder(eventRecorder),
 		WithInterval(time.Second),
 		WithMetricsSource(metricsSource),
 		WithPVCFetcher(pvcFetcher),
+		WithAutoscalerName(""),
 	)
 
 	return runner, err
@@ -297,9 +340,7 @@ var _ = Describe("Periodic Runner", func() {
 			}
 
 			By("Creating PVC for tests")
-			pvc, err = testutils.CreatePVC(parentCtx, k8sClient, "test-pvc", "1Gi", ptr.To(testutils.StorageClassName), nil)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(pvc).NotTo(BeNil())
+			pvc = createPVC(parentCtx, "test-pvc", "1Gi", ptr.To(testutils.StorageClassName), nil)
 
 			DeferCleanup(func() {
 				By("Deleting PVC")
@@ -315,15 +356,7 @@ var _ = Describe("Periodic Runner", func() {
 				Kind:       "PersistentVolumeClaim",
 				Name:       "test-pvc",
 			}
-			pvca, err = testutils.CreatePersistentVolumeClaimAutoscaler(
-				parentCtx,
-				k8sClient,
-				"test-pvca",
-				targetRef,
-				defaultVolumePolicies,
-			)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(pvca).NotTo(BeNil())
+			pvca = createPVCA(parentCtx, "test-pvca", "", targetRef, defaultVolumePolicies)
 
 			DeferCleanup(func() {
 				By("Deleting PVCA")
@@ -367,6 +400,7 @@ var _ = Describe("Periodic Runner", func() {
 				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
 				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("200Gi")
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
 
 				By("Calling updateVolumeRecommendationForPVC with metrics deviating by 3Gi")
 				volInfo := &metricssource.VolumeInfo{
@@ -433,8 +467,7 @@ var _ = Describe("Periodic Runner", func() {
 		Describe("#validatePVC", func() {
 			It("should return ErrStorageClassNotFound", func() {
 				By("Creating a PVC without a StorageClass")
-				pvc, err := testutils.CreatePVC(parentCtx, k8sClient, "pvc-without-storageclass", "1Gi", nil, nil)
-				Expect(err).NotTo(HaveOccurred())
+				pvc := createPVC(parentCtx, "pvc-without-storageclass", "1Gi", nil, nil)
 				DeferCleanup(func() {
 					By("Deleting PVC without a StorageClass")
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvc)).To(Succeed())
@@ -450,15 +483,9 @@ var _ = Describe("Periodic Runner", func() {
 					Name:       "pvc-without-storageclass",
 				}
 
-				pvca, err := testutils.CreatePersistentVolumeClaimAutoscaler(
-					parentCtx,
-					k8sClient,
-					"pvca-without-storageclass",
+				pvca := createPVCA(parentCtx, "pvca-without-storageclass", "",
 					targetRef,
-					defaultVolumePolicies,
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pvca).NotTo(BeNil())
+					defaultVolumePolicies)
 				DeferCleanup(func() {
 					By("Deleting PVCA targeting the PVC without StorageClass")
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvca)).To(Succeed())
@@ -493,8 +520,7 @@ var _ = Describe("Periodic Runner", func() {
 				})
 
 				By("Creating a test PVC using the StorageClass")
-				pvc, err := testutils.CreatePVC(parentCtx, k8sClient, "pvc-sc-no-expansion", "1Gi", ptr.To(scName), nil)
-				Expect(err).NotTo(HaveOccurred())
+				pvc := createPVC(parentCtx, "pvc-sc-no-expansion", "1Gi", ptr.To(scName), nil)
 				DeferCleanup(func() {
 					By("Deleting the PVC with StorageClass")
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvc)).To(Succeed())
@@ -510,15 +536,9 @@ var _ = Describe("Periodic Runner", func() {
 					Name:       "pvc-sc-no-expansion",
 				}
 
-				pvca, err := testutils.CreatePersistentVolumeClaimAutoscaler(
-					parentCtx,
-					k8sClient,
-					"pvca-sc-no-expansion",
+				pvca := createPVCA(parentCtx, "pvca-sc-no-expansion", "",
 					targetRef,
-					defaultVolumePolicies,
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pvca).NotTo(BeNil())
+					defaultVolumePolicies)
 				DeferCleanup(func() {
 					By("Deleting PVCA targeting the PVC with StorageClass")
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvca)).To(Succeed())
@@ -536,8 +556,7 @@ var _ = Describe("Periodic Runner", func() {
 
 			It("should return ErrVolumeModeIsNotFilesystem", func() {
 				By("Creating PVC with block volume")
-				pvc, err := testutils.CreatePVC(parentCtx, k8sClient, "pvc-block-mode", "1Gi", ptr.To(testutils.StorageClassName), ptr.To(corev1.PersistentVolumeBlock))
-				Expect(err).NotTo(HaveOccurred())
+				pvc := createPVC(parentCtx, "pvc-block-mode", "1Gi", ptr.To(testutils.StorageClassName), ptr.To(corev1.PersistentVolumeBlock))
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvc)).To(Succeed())
 					Eventually(func() error {
@@ -551,15 +570,9 @@ var _ = Describe("Periodic Runner", func() {
 					Kind:       "PersistentVolumeClaim",
 					Name:       "pvc-block-mode",
 				}
-				pvca, err := testutils.CreatePersistentVolumeClaimAutoscaler(
-					parentCtx,
-					k8sClient,
-					"pvca-block-mode",
+				pvca := createPVCA(parentCtx, "pvca-block-mode", "",
 					targetRef,
-					defaultVolumePolicies,
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pvca).NotTo(BeNil())
+					defaultVolumePolicies)
 				DeferCleanup(func() {
 					By("Deleting the PVCA targeting the PVC with block volume")
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvca)).To(Succeed())
@@ -675,6 +688,7 @@ var _ = Describe("Periodic Runner", func() {
 				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
 				pvca.Spec.TargetRef.Name = nonExistentPVCName
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
 
 				By("Registering metrics for the test PVC")
 				metricsSource := fake.New(fake.WithInterval(10 * time.Millisecond))
@@ -775,12 +789,7 @@ var _ = Describe("Periodic Runner", func() {
 
 			It("should set RecommendationAvailable condition to false and not enqueue when two PVCAs manage the same PVC", func() {
 				By("Creating PVCA that points to a PVC already managed by a different PVCA")
-				conflictingPVCA, err := testutils.CreatePersistentVolumeClaimAutoscaler(
-					parentCtx, k8sClient, "pvca-with-conflict", pvca.Spec.TargetRef, pvca.Spec.VolumePolicies,
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(conflictingPVCA).NotTo(BeNil())
-
+				conflictingPVCA := createPVCA(parentCtx, "pvca-with-conflict", "", pvca.Spec.TargetRef, pvca.Spec.VolumePolicies)
 				DeferCleanup(func() {
 					By("Deleting conflicting PVCA")
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, conflictingPVCA)).To(Succeed())
@@ -805,12 +814,7 @@ var _ = Describe("Periodic Runner", func() {
 
 			It("should set RecommendationAvailable condition to true when conflict is resolved", func() {
 				By("Creating PVCA that points to a PVC already managed by a different PVCA")
-				conflictingPVCA, err := testutils.CreatePersistentVolumeClaimAutoscaler(
-					parentCtx, k8sClient, "pvca-with-conflict", pvca.Spec.TargetRef, pvca.Spec.VolumePolicies,
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(conflictingPVCA).NotTo(BeNil())
-
+				conflictingPVCA := createPVCA(parentCtx, "pvca-with-conflict", "", pvca.Spec.TargetRef, pvca.Spec.VolumePolicies)
 				DeferCleanup(func() {
 					By("Deleting conflicting PVCA")
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, conflictingPVCA)).To(Succeed())
@@ -848,10 +852,7 @@ var _ = Describe("Periodic Runner", func() {
 
 			It("should set RecommendationAvailable condition to false when no matching volume policy exists", func() {
 				By("Creating a PVC that has no volumePolicy match")
-				noMatchPVC, err := testutils.CreatePVC(parentCtx, k8sClient, "no-match-pvc", "1Gi", ptr.To(testutils.StorageClassName), nil)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(noMatchPVC).NotTo(BeNil())
-
+				noMatchPVC := createPVC(parentCtx, "no-match-pvc", "1Gi", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					By("Deleting no-match PVC")
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, noMatchPVC)).To(Succeed())
@@ -866,19 +867,14 @@ var _ = Describe("Periodic Runner", func() {
 					Kind:       "PersistentVolumeClaim",
 					Name:       noMatchPVC.Name,
 				}
-				noMatchPVCA, err := testutils.CreatePersistentVolumeClaimAutoscaler(
-					parentCtx, k8sClient, "pvca-no-match", noMatchTargetRef, []v1alpha1.VolumePolicy{
-						{
-							Match: v1alpha1.Match{
-								Name: "non-matching-pvc-name",
-							},
-							MaxCapacity: resource.MustParse("10Gi"),
+				noMatchPVCA := createPVCA(parentCtx, "pvca-no-match", "", noMatchTargetRef, []v1alpha1.VolumePolicy{
+					{
+						Match: v1alpha1.Match{
+							Name: "non-matching-pvc-name",
 						},
+						MaxCapacity: resource.MustParse("10Gi"),
 					},
-				)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(noMatchPVCA).NotTo(BeNil())
-
+				})
 				DeferCleanup(func() {
 					By("Deleting no-match PVCA")
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, noMatchPVCA)).To(Succeed())
@@ -918,6 +914,7 @@ var _ = Describe("Periodic Runner", func() {
 				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
 				pvca.Spec.TargetRef.Name = nonExistentPVCName
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
 
 				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
 
@@ -942,6 +939,7 @@ var _ = Describe("Periodic Runner", func() {
 				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
 				pvca.Spec.TargetRef.Name = nonExistentPVCName
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
 
 				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
 
@@ -956,8 +954,7 @@ var _ = Describe("Periodic Runner", func() {
 				selectorLabels := map[string]string{"app": "deployment-target"}
 
 				By("Creating PVCs referenced by the Deployment's pods")
-				pvcA, err := testutils.CreatePVC(parentCtx, k8sClient, "deploy-pvc-a", "1Gi", ptr.To(testutils.StorageClassName), nil)
-				Expect(err).NotTo(HaveOccurred())
+				pvcA := createPVC(parentCtx, "deploy-pvc-a", "1Gi", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcA)).To(Succeed())
 					Eventually(func() error {
@@ -965,8 +962,7 @@ var _ = Describe("Periodic Runner", func() {
 					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 				})
 
-				pvcB, err := testutils.CreatePVC(parentCtx, k8sClient, "deploy-pvc-b", "1Gi", ptr.To(testutils.StorageClassName), nil)
-				Expect(err).NotTo(HaveOccurred())
+				pvcB := createPVC(parentCtx, "deploy-pvc-b", "1Gi", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcB)).To(Succeed())
 					Eventually(func() error {
@@ -1005,6 +1001,7 @@ var _ = Describe("Periodic Runner", func() {
 					Name:       deployment.Name,
 				}
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
 
 				By("Registering metrics for both PVCs")
 				metricsSource := fake.New(fake.WithInterval(10 * time.Millisecond))
@@ -1049,8 +1046,7 @@ var _ = Describe("Periodic Runner", func() {
 				selectorLabels := map[string]string{"app": "statefulset-target"}
 
 				By("Creating PVCs referenced by the StatefulSet's pods")
-				pvcA, err := testutils.CreatePVC(parentCtx, k8sClient, "sts-pvc-a", "1Gi", ptr.To(testutils.StorageClassName), nil)
-				Expect(err).NotTo(HaveOccurred())
+				pvcA := createPVC(parentCtx, "sts-pvc-a", "1Gi", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcA)).To(Succeed())
 					Eventually(func() error {
@@ -1058,8 +1054,7 @@ var _ = Describe("Periodic Runner", func() {
 					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 				})
 
-				pvcB, err := testutils.CreatePVC(parentCtx, k8sClient, "sts-pvc-b", "1Gi", ptr.To(testutils.StorageClassName), nil)
-				Expect(err).NotTo(HaveOccurred())
+				pvcB := createPVC(parentCtx, "sts-pvc-b", "1Gi", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcB)).To(Succeed())
 					Eventually(func() error {
@@ -1099,6 +1094,7 @@ var _ = Describe("Periodic Runner", func() {
 					Name:       statefulSet.Name,
 				}
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
 
 				By("Registering metrics for both PVCs")
 				metricsSource := fake.New(fake.WithInterval(10 * time.Millisecond))
@@ -1169,6 +1165,7 @@ var _ = Describe("Periodic Runner", func() {
 					Name:       deployment.Name,
 				}
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
 
 				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
 
@@ -1215,6 +1212,7 @@ var _ = Describe("Periodic Runner", func() {
 					Name:       deployment.Name,
 				}
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
 
 				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
 
@@ -1236,6 +1234,7 @@ var _ = Describe("Periodic Runner", func() {
 					Name:       "non-existent-deployment",
 				}
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
 
 				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
 
@@ -1252,8 +1251,7 @@ var _ = Describe("Periodic Runner", func() {
 				selectorLabels := map[string]string{"app": "partial-metrics"}
 
 				By("Creating two PVCs referenced by the Deployment's pods")
-				pvcA, err := testutils.CreatePVC(parentCtx, k8sClient, "partial-pvc-a", "1Gi", ptr.To(testutils.StorageClassName), nil)
-				Expect(err).NotTo(HaveOccurred())
+				pvcA := createPVC(parentCtx, "partial-pvc-a", "1Gi", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcA)).To(Succeed())
 					Eventually(func() error {
@@ -1261,8 +1259,7 @@ var _ = Describe("Periodic Runner", func() {
 					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 				})
 
-				pvcB, err := testutils.CreatePVC(parentCtx, k8sClient, "partial-pvc-b", "1Gi", ptr.To(testutils.StorageClassName), nil)
-				Expect(err).NotTo(HaveOccurred())
+				pvcB := createPVC(parentCtx, "partial-pvc-b", "1Gi", ptr.To(testutils.StorageClassName), nil)
 				DeferCleanup(func() {
 					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcB)).To(Succeed())
 					Eventually(func() error {
@@ -1301,6 +1298,7 @@ var _ = Describe("Periodic Runner", func() {
 					Name:       deployment.Name,
 				}
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
 
 				By("Registering metrics for only one of the two PVCs")
 				metricsSource := fake.New(fake.WithInterval(10 * time.Millisecond))
@@ -1668,6 +1666,7 @@ var _ = Describe("Periodic Runner", func() {
 					pvcaPatch := client.MergeFrom(pvca.DeepCopy())
 					pvca.Spec.VolumePolicies[0].ScaleUp.CooldownDuration = &metav1.Duration{Duration: time.Hour}
 					Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+					waitForPVCACacheSync(parentCtx, pvca)
 
 					var buf strings.Builder
 					logger := zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &buf)))
@@ -1800,5 +1799,96 @@ var _ = Describe("Periodic Runner", func() {
 				Expect(names).To(Equal([]string{"pvc-a", "pvc-b", "pvc-c"}))
 			})
 		})
+	})
+
+	Context("autoscalerName filtering", func() {
+		DescribeTable("should only reconcile PVCAs matching the runner's autoscalerName",
+			func(runnerAutoscalerName, matchingAutoscalerName, nonMatchingAutoscalerName string) {
+				By("Creating PVCs for each PVCA")
+				pvcMatching := createPVC(parentCtx, "filter-pvc-matching", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcMatching)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvcMatching), pvcMatching)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				pvcNonMatching := createPVC(parentCtx, "filter-pvc-nonmatching", "1Gi", ptr.To(testutils.StorageClassName), nil)
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcNonMatching)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvcNonMatching), pvcNonMatching)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				By("Creating the PVCA that should be reconciled")
+				pvcaMatching := createPVCA(parentCtx, "filter-pvca-matching", matchingAutoscalerName, autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "v1",
+					Kind:       "PersistentVolumeClaim",
+					Name:       pvcMatching.Name,
+				}, []v1alpha1.VolumePolicy{{MaxCapacity: resource.MustParse("10Gi")}})
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcaMatching)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvcaMatching), pvcaMatching)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				By("Creating the PVCA that should NOT be reconciled")
+				pvcaNonMatching := createPVCA(parentCtx, "filter-pvca-nonmatching", nonMatchingAutoscalerName, autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "v1",
+					Kind:       "PersistentVolumeClaim",
+					Name:       pvcNonMatching.Name,
+				}, []v1alpha1.VolumePolicy{{MaxCapacity: resource.MustParse("10Gi")}})
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pvcaNonMatching)).To(Succeed())
+					Eventually(func() error {
+						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvcaNonMatching), pvcaNonMatching)
+					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+				})
+
+				By("Registering metrics for both PVCs and running the metrics source briefly")
+				ms := fake.New(fake.WithInterval(10 * time.Millisecond))
+				for _, p := range []*corev1.PersistentVolumeClaim{pvcMatching, pvcNonMatching} {
+					ms.Register(&fake.Item{
+						NamespacedName:  client.ObjectKeyFromObject(p),
+						CapacityBytes:   1073741824,
+						AvailableBytes:  1073741824,
+						CapacityInodes:  10000,
+						AvailableInodes: 10000,
+					})
+				}
+				msCtx, msCancel := context.WithCancel(parentCtx)
+				go func() {
+					<-time.After(500 * time.Millisecond)
+					msCancel()
+				}()
+				ms.Start(msCtx)
+
+				By("Running the runner")
+				r, err := New(
+					WithClient(mgrClient),
+					WithEventRecorder(eventRecorder),
+					WithInterval(time.Second),
+					WithMetricsSource(ms),
+					WithPVCFetcher(pvcFetcher),
+					WithAutoscalerName(runnerAutoscalerName),
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(r.reconcileAll(parentCtx)).To(Succeed())
+
+				By("Verifying the matching PVCA has been reconciled (RecommendationAvailable condition set)")
+				updatedMatching := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvcaMatching), updatedMatching)).To(Succeed())
+				Expect(updatedMatching.Status.Conditions).NotTo(BeEmpty(), "matching PVCA should have been reconciled")
+
+				By("Verifying the non-matching PVCA has NOT been reconciled (no conditions)")
+				updatedNonMatching := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvcaNonMatching), updatedNonMatching)).To(Succeed())
+				Expect(updatedNonMatching.Status.Conditions).To(BeEmpty(), "non-matching PVCA should not have been reconciled")
+			},
+			Entry("named runner reconciles only PVCAs with matching autoscalerName", "foo", "foo", ""),
+			Entry("default runner reconciles only PVCAs with empty autoscalerName", "", "", "bar"),
+		)
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:

It is sometimes desirable to run multiple pvc-autoscaler instances in the same cluster with different configurations — for example, two instances each pointing at a different Prometheus endpoint. Without a way to partition the set of `PersistentVolumeClaimAutoscaler` (PVCA) objects, every instance would reconcile every PVCA, causing conflicting resize operations and unpredictable behavior.

This PR introduces an optional `spec.autoscalerName` field on the PVCA resource and a matching `--autoscaler-name` flag on the controller binary. The semantics mirror those of the VPA recommender's `spec.recommenders[].name` (note that VPA has an array of `recommenders[]`, however, validation enforces that it is of length 1):

- A controller started with `--autoscaler-name=<name>` reconciles **only** PVCAs whose `spec.autoscalerName` equals `<name>`.
- A controller started **without** `--autoscaler-name` (or with an empty value) reconciles **only** PVCAs whose `spec.autoscalerName` is empty.
- Existing PVCAs with no `spec.autoscalerName` set continue to be managed by a default (unclassed) instance — no migration required.

Filtering is implemented using a controller-runtime field index (`AutoscalerNameIndexKey = ".spec.autoscalerName"`) registered via `v1alpha1.AddAutoscalerNameFieldIndexer`, so the `List` call is efficient and backed by the informer cache.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- The `spec.autoscalerName` field defaults to `""` via `+kubebuilder:default=""`, so the API change is fully backwards-compatible. No existing PVCA objects need to be updated.
- The field intentionally lives in `spec` rather than as a label, following the gardener-resource-manager pattern. This makes ownership explicit and self-documenting in the spec.
- The test suite has been refactored to use both a raw `k8sClient` (for creates, patches, and status read-backs) and a cached `mgrClient` (for the runner, so the field index works). Helper functions `createPVC`, `createPVCA`, and `waitForPVCACacheSync` ensure the manager cache is synced before `reconcileAll` is called.

**Release note**:
```feature user
Added optional `spec.autoscalerName` field to `PersistentVolumeClaimAutoscaler` and `--autoscaler-name` flag to the controller. This enables running multiple pvc-autoscaler instances in the same cluster, each managing a distinct subset of PVCAs.
```
