### PR TITLE
Use correct port in webhook network policy

### DIFF
--- a/config/components/network-policy/allow-webhook-traffic.yaml
+++ b/config/components/network-policy/allow-webhook-traffic.yaml
@@ -22,5 +22,5 @@ spec:
           matchLabels:
             webhook: enabled # Only from namespaces with this label
       ports:
-        - port: 443
+        - port: 9443
           protocol: TCP

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -813,7 +813,7 @@ spec:
         matchLabels:
           webhook: enabled
     ports:
-    - port: 443
+    - port: 9443
       protocol: TCP
   podSelector:
     matchLabels:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug

**What this PR does / why we need it**:
This PR fixes the allowed port of the network policy for the validating webhook so that the actual container port is used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a context timeout issue for the `PersistentVolumeClaimAutoscaler` validating webhook that was caused by an incorrect port in the `allow-webhook-traffic` network policy in the `kustomize` manifests. 
```
