### PR TITLE
Do not treat empty PVC fetch results as errors

### DIFF
--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -76,6 +76,8 @@ const (
 	ReasonMetricsFetchError = "MetricsFetchError"
 	// ReasonPVCFetchError indicates an error occurred during fetching of PVCs.
 	ReasonPVCFetchError = "PersistentVolumeClaimFetchError"
+	// ReasonNoPVCsMatched indicates that pods were found but none had PVC volumes matching the policy.
+	ReasonNoPVCsMatched = "NoPersistentVolumeClaimsMatched"
 	// ReasonAmbiguousPVCA indicates that a PVC is autoscaled by multiple PVCAs.
 	ReasonAmbiguousPVCA = "AmbiguousPersistentVolumeClaimAutoscaler"
 	// ReasonRecommendationError indicates an error occurred during recommendation computation.
@@ -278,29 +280,22 @@ func (r *Runner) fetchPVCsForPVCAs(ctx context.Context, logger logr.Logger, pers
 		persistentVolumeClaims, err := r.pvcFetcher.Fetch(ctx, &pvca)
 		if err != nil {
 			logger.Error(err, "failed to fetch persistentvolumeclaims for persistentvolumeclaimautoscaler", "pvca", pvcaKey)
+			r.setPVCAStatusWhenNoPVCsFetched(ctx, logger, &pvca, pvcaKey,
+				ReasonPVCFetchError,
+				fmt.Sprintf("Failed to fetch PersistentVolumeClaims for PersistentVolumeClaimAutoscaler: %s", err.Error()),
+				"Resizing state is unknown: failed to fetch PersistentVolumeClaims",
+			)
 
-			recommendationsCondition := metav1.Condition{
-				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
-				Status:  metav1.ConditionFalse,
-				Reason:  ReasonPVCFetchError,
-				Message: fmt.Sprintf("Failed to fetch PersistentVolumeClaims for PersistentVolumeClaimAutoscaler: %s", err.Error()),
-			}
+			continue
+		}
 
-			// If the resizing condition is already set on the PVCA resource due to an ongoing resize, set it to Unknown here as
-			// it is not possible to check the actual resizing status of the PVCs, if they cannot be fetched.
-			resizingCondition := metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}
-			if existing := meta.FindStatusCondition(pvca.Status.Conditions, resizingCondition.Type); existing != nil {
-				resizingCondition = metav1.Condition{
-					Type:    string(v1alpha1.ConditionTypeResizing),
-					Status:  metav1.ConditionUnknown,
-					Reason:  ReasonPVCFetchError,
-					Message: "Resizing state is unknown: failed to fetch PersistentVolumeClaims",
-				}
-			}
-
-			if err := r.setStatus(ctx, &pvca, recommendationsCondition, resizingCondition, []v1alpha1.VolumeRecommendation{}); err != nil {
-				logger.Error(err, "failed to update PVCA status", "pvca", pvcaKey)
-			}
+		if len(persistentVolumeClaims) == 0 {
+			logger.V(2).Info("no persistentvolumeclaims found for persistentvolumeclaimautoscaler", "pvca", pvcaKey)
+			r.setPVCAStatusWhenNoPVCsFetched(ctx, logger, &pvca, pvcaKey,
+				ReasonNoPVCsMatched,
+				"No PersistentVolumeClaims match this PersistentVolumeClaimAutoscaler object",
+				"Resizing state is unknown: no matching PersistentVolumeClaims for this PersistentVolumeClaimAutoscaler",
+			)
 
 			continue
 		}
@@ -314,6 +309,32 @@ func (r *Runner) fetchPVCsForPVCAs(ctx context.Context, logger logr.Logger, pers
 	}
 
 	return pvcaToPVCsMap, pvcToOwnersMap
+}
+
+// setPVCAStatusWhenNoPVCsFetched sets the RecommendationAvailable condition to False and, if a Resizing
+// condition already exists, sets it to Unknown. Used when PVC fetching is skipped due to
+// an error or because no PVCs were found.
+func (r *Runner) setPVCAStatusWhenNoPVCsFetched(ctx context.Context, logger logr.Logger, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvcaKey types.NamespacedName, reason, recommendationMessage, resizingMessage string) {
+	recommendationsCondition := metav1.Condition{
+		Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+		Status:  metav1.ConditionFalse,
+		Reason:  reason,
+		Message: recommendationMessage,
+	}
+
+	resizingCondition := metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}
+	if existing := meta.FindStatusCondition(pvca.Status.Conditions, resizingCondition.Type); existing != nil {
+		resizingCondition = metav1.Condition{
+			Type:    string(v1alpha1.ConditionTypeResizing),
+			Status:  metav1.ConditionUnknown,
+			Reason:  reason,
+			Message: resizingMessage,
+		}
+	}
+
+	if err := r.setStatus(ctx, pvca, recommendationsCondition, resizingCondition, []v1alpha1.VolumeRecommendation{}); err != nil {
+		logger.Error(err, "failed to update PVCA status", "pvca", pvcaKey)
+	}
 }
 
 // reconcilePVCA reconciles one [v1alpha1.PersistentVolumeClaimAutoscaler]

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -285,7 +285,7 @@ func (r *Runner) fetchPVCsForPVCAs(ctx context.Context, logger logr.Logger, pers
 			if errors.Is(err, pvcfetcher.ErrNoPodsFound) || errors.Is(err, pvcfetcher.ErrNoPVCsFound) {
 				logger.V(2).Info("no persistentvolumeclaims found for persistentvolumeclaimautoscaler", "pvca", pvcaKey, "reason", err.Error())
 				reason = ReasonNoPVCsMatched
-				message = fmt.Sprintf("Failed to fetch PersistentVolumeClaims: %s", err.Error())
+				message = fmt.Sprintf("No PersistentVolumeClaims found for PersistentVolumeClaimAutoscaler: %s", err.Error())
 			} else {
 				logger.Error(err, "failed to fetch persistentvolumeclaims for persistentvolumeclaimautoscaler", "pvca", pvcaKey)
 			}

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -279,23 +279,41 @@ func (r *Runner) fetchPVCsForPVCAs(ctx context.Context, logger logr.Logger, pers
 
 		persistentVolumeClaims, err := r.pvcFetcher.Fetch(ctx, &pvca)
 		if err != nil {
-			logger.Error(err, "failed to fetch persistentvolumeclaims for persistentvolumeclaimautoscaler", "pvca", pvcaKey)
-			r.setPVCAStatusWhenNoPVCsFetched(ctx, logger, &pvca, pvcaKey,
-				ReasonPVCFetchError,
-				fmt.Sprintf("Failed to fetch PersistentVolumeClaims for PersistentVolumeClaimAutoscaler: %s", err.Error()),
-				"Resizing state is unknown: failed to fetch PersistentVolumeClaims",
-			)
+			reason := ReasonPVCFetchError
+			message := fmt.Sprintf("Failed to fetch PersistentVolumeClaims for PersistentVolumeClaimAutoscaler: %s", err.Error())
 
-			continue
-		}
+			if errors.Is(err, pvcfetcher.ErrNoPodsFound) || errors.Is(err, pvcfetcher.ErrNoPVCsFound) {
+				// Log at low verbosity because there are expected conditions in which no pods could be
+				// matched or no PVCs could be found, e.g. workload scaled to zero. These should not be considered
+				// as operational errors
+				logger.V(2).Info("no persistentvolumeclaims found for persistentvolumeclaimautoscaler", "pvca", pvcaKey, "reason", err.Error())
 
-		if len(persistentVolumeClaims) == 0 {
-			logger.V(2).Info("no persistentvolumeclaims found for persistentvolumeclaimautoscaler", "pvca", pvcaKey)
-			r.setPVCAStatusWhenNoPVCsFetched(ctx, logger, &pvca, pvcaKey,
-				ReasonNoPVCsMatched,
-				"No PersistentVolumeClaims match this PersistentVolumeClaimAutoscaler object",
-				"Resizing state is unknown: no matching PersistentVolumeClaims for this PersistentVolumeClaimAutoscaler",
-			)
+				reason = ReasonNoPVCsMatched
+				message = fmt.Sprintf("Failed to fetch PersistentVolumeClaims: %s", err.Error())
+			} else {
+				logger.Error(err, "failed to fetch persistentvolumeclaims for persistentvolumeclaimautoscaler", "pvca", pvcaKey)
+			}
+
+			recommendationsCondition := metav1.Condition{
+				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
+				Status:  metav1.ConditionFalse,
+				Reason:  reason,
+				Message: message,
+			}
+
+			resizingCondition := metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}
+			if existing := meta.FindStatusCondition(pvca.Status.Conditions, resizingCondition.Type); existing != nil {
+				resizingCondition = metav1.Condition{
+					Type:    string(v1alpha1.ConditionTypeResizing),
+					Status:  metav1.ConditionUnknown,
+					Reason:  reason,
+					Message: fmt.Sprintf("Resizing state is unknown: %s", message),
+				}
+			}
+
+			if err := r.setStatus(ctx, &pvca, recommendationsCondition, resizingCondition, []v1alpha1.VolumeRecommendation{}); err != nil {
+				logger.Error(err, "failed to update PVCA status", "pvca", pvcaKey)
+			}
 
 			continue
 		}
@@ -309,32 +327,6 @@ func (r *Runner) fetchPVCsForPVCAs(ctx context.Context, logger logr.Logger, pers
 	}
 
 	return pvcaToPVCsMap, pvcToOwnersMap
-}
-
-// setPVCAStatusWhenNoPVCsFetched sets the RecommendationAvailable condition to False and, if a Resizing
-// condition already exists, sets it to Unknown. Used when PVC fetching is skipped due to
-// an error or because no PVCs were found.
-func (r *Runner) setPVCAStatusWhenNoPVCsFetched(ctx context.Context, logger logr.Logger, pvca *v1alpha1.PersistentVolumeClaimAutoscaler, pvcaKey types.NamespacedName, reason, recommendationMessage, resizingMessage string) {
-	recommendationsCondition := metav1.Condition{
-		Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
-		Status:  metav1.ConditionFalse,
-		Reason:  reason,
-		Message: recommendationMessage,
-	}
-
-	resizingCondition := metav1.Condition{Type: string(v1alpha1.ConditionTypeResizing)}
-	if existing := meta.FindStatusCondition(pvca.Status.Conditions, resizingCondition.Type); existing != nil {
-		resizingCondition = metav1.Condition{
-			Type:    string(v1alpha1.ConditionTypeResizing),
-			Status:  metav1.ConditionUnknown,
-			Reason:  reason,
-			Message: resizingMessage,
-		}
-	}
-
-	if err := r.setStatus(ctx, pvca, recommendationsCondition, resizingCondition, []v1alpha1.VolumeRecommendation{}); err != nil {
-		logger.Error(err, "failed to update PVCA status", "pvca", pvcaKey)
-	}
 }
 
 // reconcilePVCA reconciles one [v1alpha1.PersistentVolumeClaimAutoscaler]

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -283,11 +283,7 @@ func (r *Runner) fetchPVCsForPVCAs(ctx context.Context, logger logr.Logger, pers
 			message := fmt.Sprintf("Failed to fetch PersistentVolumeClaims for PersistentVolumeClaimAutoscaler: %s", err.Error())
 
 			if errors.Is(err, pvcfetcher.ErrNoPodsFound) || errors.Is(err, pvcfetcher.ErrNoPVCsFound) {
-				// Log at low verbosity because there are expected conditions in which no pods could be
-				// matched or no PVCs could be found, e.g. workload scaled to zero. These should not be considered
-				// as operational errors
 				logger.V(2).Info("no persistentvolumeclaims found for persistentvolumeclaimautoscaler", "pvca", pvcaKey, "reason", err.Error())
-
 				reason = ReasonNoPVCsMatched
 				message = fmt.Sprintf("Failed to fetch PersistentVolumeClaims: %s", err.Error())
 			} else {

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -1140,7 +1140,7 @@ var _ = Describe("Periodic Runner", func() {
 				Expect(names).To(ConsistOf(pvcA.Name, pvcB.Name))
 			})
 
-			It("should set PVCFetchError when targeting a Deployment with no matching pods", func() {
+			It("should set NoPVCsMatched when targeting a Deployment with no matching pods", func() {
 				selectorLabels := map[string]string{"app": "no-matching-pods"}
 
 				By("Creating a Deployment with a selector that matches no pods")
@@ -1179,8 +1179,66 @@ var _ = Describe("Periodic Runner", func() {
 				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
 					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
 					HaveField("Status", metav1.ConditionFalse),
-					HaveField("Reason", ReasonPVCFetchError),
-					HaveField("Message", ContainSubstring("no pods found")),
+					HaveField("Reason", ReasonNoPVCsMatched),
+				)))
+			})
+
+			It("should set NoPVCsMatched when targeting a Deployment whose pods have no PVC volumes", func() {
+				selectorLabels := map[string]string{"app": "no-pvc-volumes"}
+
+				By("Creating a Deployment with a label selector")
+				deployment := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: "deployment-no-pvc-volumes", Namespace: "default"},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: ptr.To(int32(1)),
+						Selector: &metav1.LabelSelector{MatchLabels: selectorLabels},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: selectorLabels},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "main", Image: "busybox"}},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(parentCtx, deployment)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, deployment)).To(Succeed())
+				})
+
+				By("Creating a Pod matching the selector but with no PVC volumes")
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "no-pvc-pod",
+						Namespace: "default",
+						Labels:    selectorLabels,
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "main", Image: "busybox"}},
+					},
+				}
+				Expect(k8sClient.Create(parentCtx, pod)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(testutils.CleanupObject(parentCtx, k8sClient, pod)).To(Succeed())
+				})
+
+				By("Patching the PVCA to target the Deployment")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.TargetRef = autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       deployment.Name,
+				}
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
+
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
+					HaveField("Status", metav1.ConditionFalse),
+					HaveField("Reason", ReasonNoPVCsMatched),
 				)))
 			})
 

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -1180,7 +1180,7 @@ var _ = Describe("Periodic Runner", func() {
 					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
 					HaveField("Status", metav1.ConditionFalse),
 					HaveField("Reason", ReasonNoPVCsMatched),
-					HaveField("Message", "Failed to fetch PersistentVolumeClaims: no matching pods found for PersistentVolumeClaimAutoscaler"),
+					HaveField("Message", "No PersistentVolumeClaims found for PersistentVolumeClaimAutoscaler: no matching pods found for PersistentVolumeClaimAutoscaler"),
 				)))
 			})
 
@@ -1240,7 +1240,7 @@ var _ = Describe("Periodic Runner", func() {
 					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
 					HaveField("Status", metav1.ConditionFalse),
 					HaveField("Reason", ReasonNoPVCsMatched),
-					HaveField("Message", "Failed to fetch PersistentVolumeClaims: no PersistentVolumeClaims found for matched pods"),
+					HaveField("Message", "No PersistentVolumeClaims found for PersistentVolumeClaimAutoscaler: matched pods do not reference any PersistentVolumeClaims"),
 				)))
 			})
 

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -930,7 +930,7 @@ var _ = Describe("Periodic Runner", func() {
 					HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
 					HaveField("Status", metav1.ConditionUnknown),
 					HaveField("Reason", ReasonPVCFetchError),
-					HaveField("Message", Equal("Resizing state is unknown: failed to fetch PersistentVolumeClaims")),
+					HaveField("Message", ContainSubstring("Resizing state is unknown: Failed to fetch PersistentVolumeClaims for PersistentVolumeClaimAutoscaler")),
 				)))
 				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
 					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
@@ -1180,6 +1180,7 @@ var _ = Describe("Periodic Runner", func() {
 					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
 					HaveField("Status", metav1.ConditionFalse),
 					HaveField("Reason", ReasonNoPVCsMatched),
+					HaveField("Message", "Failed to fetch PersistentVolumeClaims: no matching pods found for PersistentVolumeClaimAutoscaler"),
 				)))
 			})
 
@@ -1239,6 +1240,7 @@ var _ = Describe("Periodic Runner", func() {
 					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
 					HaveField("Status", metav1.ConditionFalse),
 					HaveField("Reason", ReasonNoPVCsMatched),
+					HaveField("Message", "Failed to fetch PersistentVolumeClaims: no PersistentVolumeClaims found for matched pods"),
 				)))
 			})
 

--- a/internal/target/pvcfetcher/pvcfetcher.go
+++ b/internal/target/pvcfetcher/pvcfetcher.go
@@ -99,7 +99,7 @@ func (f *pvcFetcher) Fetch(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 	}
 
 	if len(podList.Items) == 0 {
-		return nil, fmt.Errorf("no pods found for selector %s", selector)
+		return nil, nil
 	}
 
 	pvcs, err := f.getPVCsFromPods(ctx, podList.Items)
@@ -108,7 +108,7 @@ func (f *pvcFetcher) Fetch(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 	}
 
 	if len(pvcs) == 0 {
-		return nil, fmt.Errorf("no PersistentVolumeClaims found for selector %s", selector)
+		return nil, nil
 	}
 
 	return pvcs, nil

--- a/internal/target/pvcfetcher/pvcfetcher.go
+++ b/internal/target/pvcfetcher/pvcfetcher.go
@@ -28,7 +28,7 @@ var (
 	ErrNoPodsFound = errors.New("no matching pods found for PersistentVolumeClaimAutoscaler")
 
 	// ErrNoPVCsFound is returned when pods are found but none of them have PVC volumes.
-	ErrNoPVCsFound = errors.New("no PersistentVolumeClaims found for matched pods")
+	ErrNoPVCsFound = errors.New("matched pods do not reference any PersistentVolumeClaims")
 )
 
 // Fetcher is an interface that can be used to fetch all PersistentVolumeClaims

--- a/internal/target/pvcfetcher/pvcfetcher.go
+++ b/internal/target/pvcfetcher/pvcfetcher.go
@@ -23,6 +23,12 @@ var (
 
 	// ErrNoSelectorFetcher is returned when the [Fetcher] is configured without a selector fetcher.
 	ErrNoSelectorFetcher = errors.New("no selector fetcher provided")
+
+	// ErrNoPodsFound is returned when no pods match the target's selector.
+	ErrNoPodsFound = errors.New("no matching pods found for PersistentVolumeClaimAutoscaler")
+
+	// ErrNoPVCsFound is returned when pods are found but none of them have PVC volumes.
+	ErrNoPVCsFound = errors.New("no PersistentVolumeClaims found for matched pods")
 )
 
 // Fetcher is an interface that can be used to fetch all PersistentVolumeClaims
@@ -99,7 +105,7 @@ func (f *pvcFetcher) Fetch(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 	}
 
 	if len(podList.Items) == 0 {
-		return nil, nil
+		return nil, ErrNoPodsFound
 	}
 
 	pvcs, err := f.getPVCsFromPods(ctx, podList.Items)
@@ -108,7 +114,7 @@ func (f *pvcFetcher) Fetch(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 	}
 
 	if len(pvcs) == 0 {
-		return nil, nil
+		return nil, ErrNoPVCsFound
 	}
 
 	return pvcs, nil

--- a/internal/target/pvcfetcher/pvcfetcher_test.go
+++ b/internal/target/pvcfetcher/pvcfetcher_test.go
@@ -108,15 +108,15 @@ var _ = Describe("PVCFetcher", func() {
 			Expect(err.Error()).To(ContainSubstring("failed to fetch selector"))
 		})
 
-		It("should return error when no pods match the selector", func() {
+		It("should return nil when no pods match the selector", func() {
 			selectorFetcher.selector, _ = labels.Parse("app=test")
 
 			pvcs, err := fetcher.Fetch(ctx, pvca)
-			Expect(err).To(MatchError(ContainSubstring("no pods found for selector app=test")))
-			Expect(pvcs).To(BeEmpty())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvcs).To(BeNil())
 		})
 
-		It("should return error when pods have no PVC volumes", func() {
+		It("should return nil when pods have no PVC volumes", func() {
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod",
@@ -146,8 +146,8 @@ var _ = Describe("PVCFetcher", func() {
 			Expect(fakeClient.Create(ctx, pod)).To(Succeed())
 
 			pvcs, err := fetcher.Fetch(ctx, pvca)
-			Expect(err).To(MatchError(ContainSubstring("no PersistentVolumeClaims found for selector app=test")))
-			Expect(pvcs).To(BeEmpty())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pvcs).To(BeNil())
 		})
 
 		It("should return PVCs from pods with PVC volumes", func() {

--- a/internal/target/pvcfetcher/pvcfetcher_test.go
+++ b/internal/target/pvcfetcher/pvcfetcher_test.go
@@ -108,15 +108,15 @@ var _ = Describe("PVCFetcher", func() {
 			Expect(err.Error()).To(ContainSubstring("failed to fetch selector"))
 		})
 
-		It("should return nil when no pods match the selector", func() {
+		It("should return ErrNoPodsFound when no pods match the selector", func() {
 			selectorFetcher.selector, _ = labels.Parse("app=test")
 
 			pvcs, err := fetcher.Fetch(ctx, pvca)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pvcs).To(BeNil())
+			Expect(err).To(MatchError(pvcfetcher.ErrNoPodsFound))
+			Expect(pvcs).To(BeEmpty())
 		})
 
-		It("should return nil when pods have no PVC volumes", func() {
+		It("should return ErrNoPVCsFound when pods have no PVC volumes", func() {
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod",
@@ -146,8 +146,8 @@ var _ = Describe("PVCFetcher", func() {
 			Expect(fakeClient.Create(ctx, pod)).To(Succeed())
 
 			pvcs, err := fetcher.Fetch(ctx, pvca)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pvcs).To(BeNil())
+			Expect(err).To(MatchError(pvcfetcher.ErrNoPVCsFound))
+			Expect(pvcs).To(BeEmpty())
 		})
 
 		It("should return PVCs from pods with PVC volumes", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area ops-productivity
/kind cleanup

**What this PR does / why we need it**:
Previously, `internal/target/pvcfetcher.Fetch` funciton returned errors when no pods matched a selector or when matching pods had no PVC volumes. This caused the runner to set the `ReasonPVCFetchError` condition for situations that are not errors, e.g. when a workload is scaled down to 0.

With this PR the `internal/target/pvcfetcher.Fetch` no longer returns errors in such cases, and just an empty/nil list of PVCs
In such cases the runner will just print a debug log and set the `RecommendationAvailable` and `Resizing` conditions appropriately, to indicate that no PVCs were matched.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `internal/target/pvcfetcher.Fetch` no longer returns errors when no pods matched a selector or when matching pods had no PVC volumes. Such cases are now logged at debug level and represented in the `RecommendationAvailable` and `Resizing` conditions.
```
