### PR TITLE
Enhance max capacity metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -59,4 +59,16 @@ const (
 	// cleared after a successful resize, to indicate that the autoscaler has done
 	// work on this PVC.
 	AnnotationPreviousSize = "pvc.autoscaling.gardener.cloud/prev-size"
+
+	// ScalingReasonMaxCapacity is the scaling reason reported when a PVC is at (or
+	// within one scaling resolution of) its configured max capacity.
+	ScalingReasonMaxCapacity = "max capacity reached"
+
+	// ScalingReasonStorageThreshold is the scaling reason reported when a PVC's
+	// used space exceeds the configured utilization threshold.
+	ScalingReasonStorageThreshold = "passing storage threshold"
+
+	// ScalingReasonInodesThreshold is the scaling reason reported when a PVC's
+	// used inodes exceed the configured utilization threshold.
+	ScalingReasonInodesThreshold = "passing inodes threshold"
 )

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -47,6 +47,17 @@ var (
 		[]string{"namespace", "persistentvolumeclaim"},
 	)
 
+	// MaxCapacityReached reports how many currently targeted PVCs are at their
+	// configured max capacity. Unlike MaxCapacityReachedTotal it is a snapshot
+	// that rises and falls as PVCs enter and leave the max-capacity state.
+	MaxCapacityReached = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "max_capacity_reached",
+			Help:      "Number of targeted PVCs currently at their max capacity",
+		},
+	)
+
 	// SkippedTotal is a metric which increments each time a PVC is skipped
 	// from being reconciled.
 	SkippedTotal = prometheus.NewCounterVec(
@@ -60,5 +71,5 @@ var (
 )
 
 func init() {
-	ctrlmetrics.Registry.MustRegister(ResizedTotal, ThresholdReachedTotal, SkippedTotal, MaxCapacityReachedTotal)
+	ctrlmetrics.Registry.MustRegister(ResizedTotal, ThresholdReachedTotal, SkippedTotal, MaxCapacityReachedTotal, MaxCapacityReached)
 }

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -104,6 +104,21 @@ type Runner struct {
 	atMaxCapacity  int
 }
 
+// recommendation is the outcome of [Runner.recommendResize]. It captures both
+// whether a resize is warranted and, when it is, the fully computed target size
+// so [Runner.resizePVC] only has to perform the patch.
+type recommendation struct {
+	// targetSize is the size the PVC should be resized to. It is nil when no
+	// resize is warranted.
+	targetSize *resource.Quantity
+	// alreadyAtMaxCapacity reports that the PVC is already at (or within one
+	// scaling resolution of) its max capacity and cannot be resized further.
+	alreadyAtMaxCapacity bool
+	// clampedToMaxCapacity reports that targetSize was clamped down to the
+	// policy's max capacity.
+	clampedToMaxCapacity bool
+}
+
 var _ manager.Runnable = &Runner{}
 
 // Option is a function which configures the [Runner].
@@ -425,28 +440,20 @@ func (r *Runner) reconcilePVCA(
 			continue
 		}
 
-		shouldResize, scalingReason := r.shouldResizePVC(pvc, *policy, volumeRecommendation)
-		if !shouldResize && scalingReason == "max capacity reached" {
-			r.atMaxCapacity++
-			if !r.isResizeInProgress(logger, pvc, scalingReason, resizingConditions) {
-				resizingConditions.addCondition(metav1.Condition{
-					Type:    string(v1alpha1.ConditionTypeResizing),
-					Status:  metav1.ConditionFalse,
-					Reason:  ReasonReconcile,
-					Message: fmt.Sprintf("%s: max capacity reached", pvc.Name),
-				})
+		scalingReason := scalingReason(pvc, *policy, volumeRecommendation)
+		if !r.isResizeInProgress(logger, pvc, scalingReason, resizingConditions) {
+			decision := r.recommendResize(logger, pvc, scalingReason, *policy, volumeRecommendation, resizingConditions)
+			if decision.alreadyAtMaxCapacity {
+				setVolumeRecommendationForPVC(&volumeRecommendations, pvc.Name, volumeRecommendation)
+
+				continue
 			}
-			setVolumeRecommendationForPVC(&volumeRecommendations, pvc.Name, volumeRecommendation)
 
-			continue
-		}
-
-		inProgress := r.isResizeInProgress(logger, pvc, scalingReason, resizingConditions)
-
-		if shouldResize && !inProgress {
-			volumeRecommendation, err = r.resizePVC(ctx, logger, pvc, *policy, scalingReason, volumeRecommendation, resizingConditions)
-			if err != nil {
-				logger.Error(err, "failed to resize pvc")
+			if decision.targetSize != nil {
+				volumeRecommendation, err = r.resizePVC(ctx, logger, pvc, scalingReason, decision.targetSize, decision.clampedToMaxCapacity, volumeRecommendation, resizingConditions)
+				if err != nil {
+					logger.Error(err, "failed to resize pvc")
+				}
 			}
 		}
 
@@ -593,11 +600,10 @@ func (r *Runner) validatePVC(ctx context.Context, pvc *corev1.PersistentVolumeCl
 	return nil
 }
 
-// shouldResizePVC is a predicate which checks whether the
-// [corev1.PersistentVolumeClaim] object targeted by the
-// [v1alpha1.PersistentVolumeClaimAutoscaler] should be considered for
-// resize. When it returns true, it also returns the scaling reason.
-func (r *Runner) shouldResizePVC(pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, volumeRecommendation v1alpha1.VolumeRecommendation) (bool, string) {
+// recommendResize decides whether the [corev1.PersistentVolumeClaim] should be
+// resized for the given scalingReason and, when it should, computes the target
+// size. It does not mutate the PVC, it only provides recommendations.
+func (r *Runner) recommendResize(logger logr.Logger, pvc *corev1.PersistentVolumeClaim, scalingReason string, policy v1alpha1.VolumePolicy, volumeRecommendation v1alpha1.VolumeRecommendation, resizingConditions *resizingConditionAggregator) recommendation {
 	var (
 		threshold         = *policy.ScaleUp.UtilizationThresholdPercent
 		usedSpacePercent  = ptr.Deref(volumeRecommendation.Current.UsedSpacePercent, 0)
@@ -605,9 +611,9 @@ func (r *Runner) shouldResizePVC(pvc *corev1.PersistentVolumeClaim, policy v1alp
 		specSize          = pvc.Spec.Resources.Requests.Storage()
 	)
 
-	switch {
+	switch scalingReason {
 	// Already at max capacity, so do not resize
-	case policy.MaxCapacity.Value()-specSize.Value() < common.ScalingResolutionBytes:
+	case common.ScalingReasonMaxCapacity:
 		r.eventRecorder.Eventf(
 			pvc,
 			corev1.EventTypeWarning,
@@ -616,10 +622,18 @@ func (r *Runner) shouldResizePVC(pvc *corev1.PersistentVolumeClaim, policy v1alp
 			policy.MaxCapacity.String(),
 		)
 
-		return false, "max capacity reached"
+		r.atMaxCapacity++
+		resizingConditions.addCondition(metav1.Condition{
+			Type:    string(v1alpha1.ConditionTypeResizing),
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonReconcile,
+			Message: fmt.Sprintf("%s: max capacity reached", pvc.Name),
+		})
+
+		return recommendation{alreadyAtMaxCapacity: true}
 
 	// Used space reached threshold
-	case usedSpacePercent > threshold:
+	case common.ScalingReasonStorageThreshold:
 		r.eventRecorder.Eventf(
 			pvc,
 			corev1.EventTypeWarning,
@@ -630,10 +644,8 @@ func (r *Runner) shouldResizePVC(pvc *corev1.PersistentVolumeClaim, policy v1alp
 		)
 		metrics.ThresholdReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name, "space").Inc()
 
-		return true, "passing storage threshold"
-
 	// Used inodes reached threshold
-	case usedInodesPercent > threshold:
+	case common.ScalingReasonInodesThreshold:
 		r.eventRecorder.Eventf(
 			pvc,
 			corev1.EventTypeWarning,
@@ -644,11 +656,60 @@ func (r *Runner) shouldResizePVC(pvc *corev1.PersistentVolumeClaim, policy v1alp
 		)
 		metrics.ThresholdReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name, "inodes").Inc()
 
-		return true, "passing inodes threshold"
-
 	// No need to reconcile the PVC for now
 	default:
-		return false, ""
+		return recommendation{}
+	}
+
+	// Compute the target size for the resize
+	stepPercent := float64(*policy.ScaleUp.StepPercent)
+	increment := math.Max(float64(specSize.Value())*(stepPercent/100.0), float64(policy.ScaleUp.MinStepAbsolute.Value()))
+	targetSizeBytes := int64(math.Ceil((float64(specSize.Value())+increment)/1073741824)) * 1073741824
+	targetSize := resource.NewQuantity(targetSizeBytes, resource.BinarySI)
+
+	// Check that we've got a valid new size
+	switch targetSize.Cmp(*specSize) {
+	case 0:
+		logger.Info("new and current size are the same")
+
+		return recommendation{}
+	case -1:
+		logger.Info("new size is less than current")
+
+		return recommendation{}
+	}
+
+	// We don't want to exceed the max capacity
+	clampedToMaxCapacity := false
+	if targetSize.Value() >= policy.MaxCapacity.Value() {
+		// Clamp to max capacity instead of overshooting it
+		targetSize = &policy.MaxCapacity
+		clampedToMaxCapacity = true
+	}
+
+	if policy.ScaleUp.CooldownDuration != nil {
+		lastResizeTime := volumeRecommendation.LastResizeTime
+		if lastResizeTime != nil {
+			elapsed := time.Since(lastResizeTime.Time)
+			cooldown := policy.ScaleUp.CooldownDuration.Duration
+			if elapsed < cooldown {
+				remaining := cooldown - elapsed
+				logger.Info("cooldown period not elapsed", "remaining", remaining.String())
+				resizingConditions.addCondition(metav1.Condition{
+					Type:    string(v1alpha1.ConditionTypeResizing),
+					Status:  metav1.ConditionFalse,
+					Reason:  ReasonPVCResizeCooldown,
+					Message: fmt.Sprintf("%s: cooldown duration has not elapsed yet", pvc.Name),
+				})
+
+				return recommendation{}
+			}
+		}
+	}
+
+	return recommendation{
+		targetSize:           targetSize,
+		clampedToMaxCapacity: clampedToMaxCapacity,
 	}
 }
 
@@ -730,60 +791,11 @@ func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVo
 	return false
 }
 
-// resizePVC performs the actual resize of the [corev1.PersistentVolumeClaim] targeted by the given
-// [v1alpha1.PersistentVolumeClaimAutoscaler].
-func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, scalingReason string, volumeRecommendation v1alpha1.VolumeRecommendation, resizingConditions *resizingConditionAggregator) (v1alpha1.VolumeRecommendation, error) {
+// resizePVC performs the actual resize of the [corev1.PersistentVolumeClaim] to
+// the target size computed by [Runner.recommendResize].
+func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.PersistentVolumeClaim, scalingReason string, targetSize *resource.Quantity, clampedToMaxCapacity bool, volumeRecommendation v1alpha1.VolumeRecommendation, resizingConditions *resizingConditionAggregator) (v1alpha1.VolumeRecommendation, error) {
 	currSpecSize := pvc.Spec.Resources.Requests.Storage()
 
-	// Calculate the new size
-	stepPercent := float64(*policy.ScaleUp.StepPercent)
-	increment := math.Max(float64(currSpecSize.Value())*(stepPercent/100.0), float64(policy.ScaleUp.MinStepAbsolute.Value()))
-	targetSizeBytes := int64(math.Ceil((float64(currSpecSize.Value())+increment)/1073741824)) * 1073741824
-	targetSize := resource.NewQuantity(targetSizeBytes, resource.BinarySI)
-
-	// Check that we've got a valid new size
-	cmp := targetSize.Cmp(*currSpecSize)
-	switch cmp {
-	case 0:
-		logger.Info("new and current size are the same")
-
-		return volumeRecommendation, nil
-	case -1:
-		logger.Info("new size is less than current")
-
-		return volumeRecommendation, nil
-	}
-
-	// We don't want to exceed the max capacity
-	maxReached := false
-	if targetSize.Value() >= policy.MaxCapacity.Value() {
-		// Only clamp to max capacity if the increase is at least one scaling resolution,
-		// otherwise the increase is too small to be meaningful
-		targetSize = &policy.MaxCapacity
-		maxReached = true
-	}
-
-	if policy.ScaleUp.CooldownDuration != nil {
-		lastResizeTime := volumeRecommendation.LastResizeTime
-		if lastResizeTime != nil {
-			elapsed := time.Since(lastResizeTime.Time)
-			cooldown := policy.ScaleUp.CooldownDuration.Duration
-			if elapsed < cooldown {
-				remaining := cooldown - elapsed
-				logger.Info("cooldown period not elapsed", "remaining", remaining.String())
-				resizingConditions.addCondition(metav1.Condition{
-					Type:    string(v1alpha1.ConditionTypeResizing),
-					Status:  metav1.ConditionFalse,
-					Reason:  ReasonPVCResizeCooldown,
-					Message: fmt.Sprintf("%s: cooldown duration has not elapsed yet", pvc.Name),
-				})
-
-				return volumeRecommendation, nil
-			}
-		}
-	}
-
-	// And finally we should be good to resize now
 	logger.Info("resizing persistent volume claim", "from", currSpecSize.String(), "to", targetSize.String())
 	metrics.ResizedTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
 	r.eventRecorder.Eventf(
@@ -815,7 +827,7 @@ func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.
 		return volumeRecommendation, err
 	}
 
-	if maxReached {
+	if clampedToMaxCapacity {
 		metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
 	}
 	volumeRecommendation.Target.Size = targetSize
@@ -864,4 +876,24 @@ func (r *Runner) setStatus(ctx context.Context, pvca *v1alpha1.PersistentVolumeC
 	}
 
 	return r.client.Status().Patch(ctx, pvca, client.MergeFrom(original))
+}
+
+// scalingReason classifies why the given PVC should/should not be scaled,
+// returning an empty string when no resize is warranted.
+func scalingReason(pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, volumeRecommendation v1alpha1.VolumeRecommendation) string {
+	threshold := *policy.ScaleUp.UtilizationThresholdPercent
+	usedSpacePercent := ptr.Deref(volumeRecommendation.Current.UsedSpacePercent, 0)
+	usedInodesPercent := ptr.Deref(volumeRecommendation.Current.UsedInodesPercent, 0)
+	specSize := pvc.Spec.Resources.Requests.Storage()
+
+	switch {
+	case policy.MaxCapacity.Value()-specSize.Value() < common.ScalingResolutionBytes:
+		return common.ScalingReasonMaxCapacity
+	case usedSpacePercent > threshold:
+		return common.ScalingReasonStorageThreshold
+	case usedInodesPercent > threshold:
+		return common.ScalingReasonInodesThreshold
+	default:
+		return ""
+	}
 }

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -101,6 +101,7 @@ type Runner struct {
 	pvcFetcher     pvcfetcher.Fetcher
 	heartbeat      *healthcheck.Heartbeat
 	autoscalerName string
+	atMaxCapacity  int
 }
 
 var _ manager.Runnable = &Runner{}
@@ -253,11 +254,11 @@ func (r *Runner) reconcileAll(ctx context.Context) error {
 
 	pvcaToPVCsMap, pvcToOwnersMap := r.fetchPVCsForPVCAs(ctx, logger, pvcaList.Items)
 
-	atMaxCapacity := 0
+	r.atMaxCapacity = 0
 	for pvca, pvcs := range pvcaToPVCsMap {
-		r.reconcilePVCA(ctx, logger, pvca, pvcs, pvcToOwnersMap, metricsData, &atMaxCapacity)
+		r.reconcilePVCA(ctx, logger, pvca, pvcs, pvcToOwnersMap, metricsData)
 	}
-	metrics.MaxCapacityReached.Set(float64(atMaxCapacity))
+	metrics.MaxCapacityReached.Set(float64(r.atMaxCapacity))
 
 	return nil
 }
@@ -329,7 +330,6 @@ func (r *Runner) reconcilePVCA(
 	pvcs []*corev1.PersistentVolumeClaim,
 	pvcToOwnersMap map[string][]string,
 	metricsData metricssource.Metrics,
-	atMaxCapacity *int,
 ) {
 	logger = logger.WithValues("pvca", client.ObjectKeyFromObject(pvca))
 
@@ -427,8 +427,8 @@ func (r *Runner) reconcilePVCA(
 
 		shouldResize, scalingReason := r.shouldResizePVC(pvc, *policy, volumeRecommendation)
 		if !shouldResize && scalingReason == "max capacity reached" {
-			*atMaxCapacity++
-			if !r.isResizeInProgress(logger, pvc, "", resizingConditions) {
+			r.atMaxCapacity++
+			if !r.isResizeInProgress(logger, pvc, scalingReason, resizingConditions) {
 				resizingConditions.addCondition(metav1.Condition{
 					Type:    string(v1alpha1.ConditionTypeResizing),
 					Status:  metav1.ConditionFalse,

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -241,6 +241,8 @@ func (r *Runner) reconcileAll(ctx context.Context) error {
 
 	// Nothing to do for now
 	if len(pvcaList.Items) == 0 {
+		metrics.MaxCapacityReached.Set(0)
+
 		return nil
 	}
 
@@ -251,9 +253,11 @@ func (r *Runner) reconcileAll(ctx context.Context) error {
 
 	pvcaToPVCsMap, pvcToOwnersMap := r.fetchPVCsForPVCAs(ctx, logger, pvcaList.Items)
 
+	atMaxCapacity := 0
 	for pvca, pvcs := range pvcaToPVCsMap {
-		r.reconcilePVCA(ctx, logger, pvca, pvcs, pvcToOwnersMap, metricsData)
+		r.reconcilePVCA(ctx, logger, pvca, pvcs, pvcToOwnersMap, metricsData, &atMaxCapacity)
 	}
+	metrics.MaxCapacityReached.Set(float64(atMaxCapacity))
 
 	return nil
 }
@@ -325,6 +329,7 @@ func (r *Runner) reconcilePVCA(
 	pvcs []*corev1.PersistentVolumeClaim,
 	pvcToOwnersMap map[string][]string,
 	metricsData metricssource.Metrics,
+	atMaxCapacity *int,
 ) {
 	logger = logger.WithValues("pvca", client.ObjectKeyFromObject(pvca))
 
@@ -421,6 +426,21 @@ func (r *Runner) reconcilePVCA(
 		}
 
 		shouldResize, scalingReason := r.shouldResizePVC(pvc, *policy, volumeRecommendation)
+		if !shouldResize && scalingReason == "max capacity reached" {
+			*atMaxCapacity++
+			if !r.isResizeInProgress(logger, pvc, "", resizingConditions) {
+				resizingConditions.addCondition(metav1.Condition{
+					Type:    string(v1alpha1.ConditionTypeResizing),
+					Status:  metav1.ConditionFalse,
+					Reason:  ReasonReconcile,
+					Message: fmt.Sprintf("%s: max capacity reached", pvc.Name),
+				})
+			}
+			setVolumeRecommendationForPVC(&volumeRecommendations, pvc.Name, volumeRecommendation)
+
+			continue
+		}
+
 		inProgress := r.isResizeInProgress(logger, pvc, scalingReason, resizingConditions)
 
 		if shouldResize && !inProgress {
@@ -582,9 +602,22 @@ func (r *Runner) shouldResizePVC(pvc *corev1.PersistentVolumeClaim, policy v1alp
 		threshold         = *policy.ScaleUp.UtilizationThresholdPercent
 		usedSpacePercent  = ptr.Deref(volumeRecommendation.Current.UsedSpacePercent, 0)
 		usedInodesPercent = ptr.Deref(volumeRecommendation.Current.UsedInodesPercent, 0)
+		specSize          = pvc.Spec.Resources.Requests.Storage()
 	)
 
 	switch {
+	// Already at max capacity, so do not resize
+	case policy.MaxCapacity.Value()-specSize.Value() < common.ScalingResolutionBytes:
+		r.eventRecorder.Eventf(
+			pvc,
+			corev1.EventTypeWarning,
+			"MaxCapacityReached",
+			"max capacity (%s) has been reached, will not resize",
+			policy.MaxCapacity.String(),
+		)
+
+		return false, "max capacity reached"
+
 	// Used space reached threshold
 	case usedSpacePercent > threshold:
 		r.eventRecorder.Eventf(
@@ -623,6 +656,7 @@ func (r *Runner) shouldResizePVC(pvc *corev1.PersistentVolumeClaim, policy v1alp
 // Returns true if a resize operation is in progress.
 func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVolumeClaim, scalingReason string, resizingConditions *resizingConditionAggregator) bool {
 	currStatusSize := pvc.Status.Capacity.Storage()
+	dueTo := utils.ScaledDueToClause(scalingReason)
 
 	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimResizing) {
 		logger.Info("resize has been started")
@@ -630,7 +664,7 @@ func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVo
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf("%s: is being scaled due to %s, resize has been started", pvc.Name, scalingReason),
+			Message: fmt.Sprintf("%s: is being scaled%s, resize has been started", pvc.Name, dueTo),
 		})
 
 		return true
@@ -642,7 +676,7 @@ func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVo
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf("%s: is being scaled due to %s, file system resize is pending", pvc.Name, scalingReason),
+			Message: fmt.Sprintf("%s: is being scaled%s, file system resize is pending", pvc.Name, dueTo),
 		})
 
 		return true
@@ -654,7 +688,7 @@ func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVo
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf("%s: is being scaled due to %s, volume is being modified", pvc.Name, scalingReason),
+			Message: fmt.Sprintf("%s: is being scaled%s, volume is being modified", pvc.Name, dueTo),
 		})
 
 		return true
@@ -687,7 +721,7 @@ func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVo
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf("%s: is being scaled due to %s, persistent volume claim is still being resized", pvc.Name, scalingReason),
+			Message: fmt.Sprintf("%s: is being scaled%s, persistent volume claim is still being resized", pvc.Name, dueTo),
 		})
 
 		return true
@@ -721,30 +755,12 @@ func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.
 	}
 
 	// We don't want to exceed the max capacity
-	if targetSize.Value() > policy.MaxCapacity.Value() {
+	maxReached := false
+	if targetSize.Value() >= policy.MaxCapacity.Value() {
 		// Only clamp to max capacity if the increase is at least one scaling resolution,
 		// otherwise the increase is too small to be meaningful
-		if policy.MaxCapacity.Value()-currSpecSize.Value() < common.ScalingResolutionBytes {
-			r.eventRecorder.Eventf(
-				pvc,
-				corev1.EventTypeWarning,
-				"MaxCapacityReached",
-				"max capacity (%s) has been reached, will not resize",
-				policy.MaxCapacity.String(),
-			)
-			logger.Info("max capacity reached")
-			metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
-			resizingConditions.addCondition(metav1.Condition{
-				Type:    string(v1alpha1.ConditionTypeResizing),
-				Status:  metav1.ConditionFalse,
-				Reason:  ReasonReconcile,
-				Message: fmt.Sprintf("%s: max capacity reached", pvc.Name),
-			})
-
-			return volumeRecommendation, nil
-		}
-		// Clamp to max capacity instead of skipping the resize entirely
 		targetSize = &policy.MaxCapacity
+		maxReached = true
 	}
 
 	if policy.ScaleUp.CooldownDuration != nil {
@@ -797,6 +813,10 @@ func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.
 		})
 
 		return volumeRecommendation, err
+	}
+
+	if maxReached {
+		metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
 	}
 	volumeRecommendation.Target.Size = targetSize
 	volumeRecommendation.LastResizeTime = ptr.To(metav1.Now())

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 	"github.com/gardener/pvc-autoscaler/internal/common"
+	"github.com/gardener/pvc-autoscaler/internal/metrics"
 	metricssource "github.com/gardener/pvc-autoscaler/internal/metrics/source"
 	"github.com/gardener/pvc-autoscaler/internal/metrics/source/fake"
 	testutils "github.com/gardener/pvc-autoscaler/test/utils"
@@ -752,6 +754,59 @@ var _ = Describe("Periodic Runner", func() {
 					HaveField("Status", metav1.ConditionFalse),
 					HaveField("Reason", ReasonMetricsFetchError),
 				)))
+			})
+
+			It("should report the number of PVCs at max capacity via the gauge", func() {
+				By("Registering metrics for the test PVC so it reaches shouldResizePVC")
+				metricsSource := fake.New(fake.WithInterval(10 * time.Millisecond))
+				fakeItem := &fake.Item{
+					NamespacedName:         client.ObjectKeyFromObject(pvc),
+					CapacityBytes:          1073741824,
+					AvailableBytes:         1073741824,
+					CapacityInodes:         10000,
+					AvailableInodes:        10000,
+					ConsumeBytesIncrement:  1000,
+					ConsumeInodesIncrement: 1000,
+				}
+				metricsSource.Register(fakeItem)
+
+				newCtx, cancelFunc := context.WithCancel(parentCtx)
+				go func() {
+					ch := time.After(500 * time.Millisecond)
+					<-ch
+					cancelFunc()
+				}()
+				metricsSource.Start(newCtx)
+				withMetricsSourceOpt := WithMetricsSource(metricsSource)
+				withMetricsSourceOpt(runner)
+
+				By("Setting max capacity so the 1Gi PVC is already at max")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("1Gi")
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
+
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+				Expect(testutil.ToFloat64(metrics.MaxCapacityReached)).To(Equal(float64(1)))
+
+				By("Recording a terminal Resizing=False max-capacity condition on the PVCA")
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
+					HaveField("Status", metav1.ConditionFalse),
+					HaveField("Reason", ReasonReconcile),
+					HaveField("Message", ContainSubstring("max capacity reached")),
+				)))
+
+				By("Raising max capacity so the PVC is no longer at max")
+				pvcaPatch = client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("10Gi")
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
+
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+				Expect(testutil.ToFloat64(metrics.MaxCapacityReached)).To(Equal(float64(0)))
 			})
 
 			It("should reconcile when threshold has been reached", func() {
@@ -1553,6 +1608,9 @@ var _ = Describe("Periodic Runner", func() {
 				w := io.MultiWriter(GinkgoWriter, &buf)
 				logger := zap.New(zap.WriteTo(w)).WithValues("pvc", "test-pvc")
 
+				maxCapCounter := metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name)
+				baselineMaxCap := testutil.ToFloat64(maxCapCounter)
+
 				By("Performing first resize")
 				aggregator := &resizingConditionAggregator{}
 				volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
@@ -1594,24 +1652,86 @@ var _ = Describe("Periodic Runner", func() {
 				resizedPvc.Status.Capacity[corev1.ResourceStorage] = secondIncreaseCap
 				Expect(k8sClient.Status().Patch(parentCtx, &resizedPvc, patch)).To(Succeed())
 
-				By("Expecting third attempt to fail with max capacity reached (already at max)")
-				aggregator = &resizingConditionAggregator{}
+				By("Expecting third attempt to report max capacity reached (already at max)")
 				volumePolicy, errPolicy = getVolumePolicy(resizedPvc.Name, pvca.Spec.VolumePolicies)
 				Expect(errPolicy).NotTo(HaveOccurred())
-				_, err = runner.resizePVC(parentCtx, logger, &resizedPvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(buf.String()).To(ContainSubstring("max capacity reached"))
+				shouldResize, reason := runner.shouldResizePVC(&resizedPvc, *volumePolicy, volumeRecommendation)
+				Expect(shouldResize).To(BeFalse())
+				Expect(reason).To(Equal("max capacity reached"))
 
-				Expect(aggregator.getAggregatedCondition()).To(And(
-					HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
-					HaveField("Status", metav1.ConditionFalse),
-					HaveField("Reason", ReasonReconcile),
-					HaveField("Message", ContainSubstring("max capacity reached")),
-				))
+				By("Expecting the counter to have incremented once, on the resize that landed at max")
+				Expect(testutil.ToFloat64(maxCapCounter)).To(Equal(baselineMaxCap + 1))
+
+				By("Expecting a subsequent check while already at max to not recount")
+				volumePolicy, errPolicy = getVolumePolicy(resizedPvc.Name, pvca.Spec.VolumePolicies)
+				Expect(errPolicy).NotTo(HaveOccurred())
+				shouldResize, _ = runner.shouldResizePVC(&resizedPvc, *volumePolicy, volumeRecommendation)
+				Expect(shouldResize).To(BeFalse())
+				Expect(testutil.ToFloat64(maxCapCounter)).To(Equal(baselineMaxCap + 1))
+			})
+
+			It("should count again when max is raised and the PVC resizes up to the new max", func() {
+				volumeRecommendation := v1alpha1.VolumeRecommendation{
+					Name: pvc.Name,
+					Current: v1alpha1.CurrentVolumeStatus{
+						UsedSpacePercent: ptr.To(95),
+					},
+				}
+
+				var buf strings.Builder
+				logger := zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &buf))).WithValues("pvc", "test-pvc")
+
+				maxCapCounter := metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name)
+				baselineMaxCap := testutil.ToFloat64(maxCapCounter)
+
+				By("Setting max capacity one step above the current 1Gi size")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("2Gi")
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				By("Resizing up to max should count once")
+				aggregator := &resizingConditionAggregator{}
+				volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
+				Expect(errPolicy).NotTo(HaveOccurred())
+				_, err := runner.resizePVC(parentCtx, logger, pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+				Expect(err).NotTo(HaveOccurred())
+
+				var atMaxPvc corev1.PersistentVolumeClaim
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &atMaxPvc)).To(Succeed())
+				Expect(atMaxPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("2Gi")))
+				Expect(testutil.ToFloat64(maxCapCounter)).To(Equal(baselineMaxCap + 1))
+
+				By("Simulating the resize completing")
+				statusPatch := client.MergeFrom(atMaxPvc.DeepCopy())
+				atMaxPvc.Status.Capacity[corev1.ResourceStorage] = resource.MustParse("2Gi")
+				Expect(k8sClient.Status().Patch(parentCtx, &atMaxPvc, statusPatch)).To(Succeed())
+
+				By("A reconcile while still at max should not recount")
+				volumePolicy, errPolicy = getVolumePolicy(atMaxPvc.Name, pvca.Spec.VolumePolicies)
+				Expect(errPolicy).NotTo(HaveOccurred())
+				shouldResize, reason := runner.shouldResizePVC(&atMaxPvc, *volumePolicy, volumeRecommendation)
+				Expect(shouldResize).To(BeFalse())
+				Expect(reason).To(Equal("max capacity reached"))
+				Expect(testutil.ToFloat64(maxCapCounter)).To(Equal(baselineMaxCap + 1))
+
+				By("Raising max by another step so the PVC can resize up to the new max")
+				pvcaPatch = client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("3Gi")
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				volumePolicy, errPolicy = getVolumePolicy(atMaxPvc.Name, pvca.Spec.VolumePolicies)
+				Expect(errPolicy).NotTo(HaveOccurred())
+				aggregator = &resizingConditionAggregator{}
+				_, err = runner.resizePVC(parentCtx, logger, &atMaxPvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Landing on the new max should count a second time")
+				Expect(atMaxPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("3Gi")))
+				Expect(testutil.ToFloat64(maxCapCounter)).To(Equal(baselineMaxCap + 2))
 			})
 
 			DescribeTable("clamp resize to max capacity",
-				func(maxCapacity resource.Quantity, minStep resource.Quantity, expectResize bool, expectedSize resource.Quantity) {
+				func(maxCapacity resource.Quantity, minStep resource.Quantity, expectedSize resource.Quantity) {
 					volumeRecommendation := v1alpha1.VolumeRecommendation{
 						Name: pvc.Name,
 						Current: v1alpha1.CurrentVolumeStatus{
@@ -1636,26 +1756,32 @@ var _ = Describe("Periodic Runner", func() {
 					var updatedPvc corev1.PersistentVolumeClaim
 					Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &updatedPvc)).To(Succeed())
 					Expect(updatedPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(expectedSize))
-
-					if expectResize {
-						Expect(buf.String()).To(ContainSubstring("resizing persistent volume claim"))
-					} else {
-						Expect(buf.String()).To(ContainSubstring("max capacity reached"))
-						Expect(aggregator.getAggregatedCondition()).To(And(
-							HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
-							HaveField("Status", metav1.ConditionFalse),
-							HaveField("Reason", ReasonReconcile),
-							HaveField("Message", ContainSubstring("max capacity reached")),
-						))
-					}
+					Expect(buf.String()).To(ContainSubstring("resizing persistent volume claim"))
 				},
-				Entry("should not resize when headroom is below scaling resolution",
-					resource.MustParse("1500Mi"), resource.MustParse("1Gi"), false, resource.MustParse("1Gi"),
-				),
 				Entry("should clamp resize to max capacity when step would overshoot",
-					resource.MustParse("2Gi"), resource.MustParse("2Gi"), true, resource.MustParse("2Gi"),
+					resource.MustParse("2Gi"), resource.MustParse("2Gi"), resource.MustParse("2Gi"),
 				),
 			)
+
+			It("should not resize when headroom is below scaling resolution", func() {
+				volumeRecommendation := v1alpha1.VolumeRecommendation{
+					Name: pvc.Name,
+					Current: v1alpha1.CurrentVolumeStatus{
+						UsedSpacePercent: ptr.To(95),
+					},
+				}
+
+				By("Setting max capacity within one scaling resolution of the current 1Gi size")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("1500Mi")
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
+				Expect(errPolicy).NotTo(HaveOccurred())
+				shouldResize, reason := runner.shouldResizePVC(pvc, *volumePolicy, volumeRecommendation)
+				Expect(shouldResize).To(BeFalse())
+				Expect(reason).To(Equal("max capacity reached"))
+			})
 
 			DescribeTable("should handle cooldown duration",
 				func(lastResizeOffset time.Duration, expectResize bool, expectedLog string) {

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -99,6 +100,18 @@ func newRunner() (*Runner, error) {
 	)
 
 	return runner, err
+}
+
+// calculateAndResize chains recommendResize and resizePVC the same way
+// reconcilePVCA does, so tests can exercise the full "decide then resize" flow.
+func (r *Runner) calculateAndResize(ctx context.Context, logger logr.Logger, pvc *corev1.PersistentVolumeClaim, policy v1alpha1.VolumePolicy, volumeRecommendation v1alpha1.VolumeRecommendation, resizingConditions *resizingConditionAggregator) (v1alpha1.VolumeRecommendation, error) {
+	reason := scalingReason(pvc, policy, volumeRecommendation)
+	decision := r.recommendResize(logger, pvc, reason, policy, volumeRecommendation, resizingConditions)
+	if decision.targetSize == nil {
+		return volumeRecommendation, nil
+	}
+
+	return r.resizePVC(ctx, logger, pvc, reason, decision.targetSize, decision.clampedToMaxCapacity, volumeRecommendation, resizingConditions)
 }
 
 // createPodWithPVC creates a Pod in the "default" namespace with the given
@@ -609,7 +622,7 @@ var _ = Describe("Periodic Runner", func() {
 			})
 		})
 
-		Describe("#shouldResizePVC", func() {
+		Describe("#recommendResize", func() {
 			It("should not reconcile when threshold is not reached", func() {
 				volumeRecommendation := v1alpha1.VolumeRecommendation{
 					Name: pvc.Name,
@@ -623,9 +636,9 @@ var _ = Describe("Periodic Runner", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(volumePolicy).NotTo(BeNil())
 
-				ok, reason := runner.shouldResizePVC(pvc, *volumePolicy, volumeRecommendation)
-				Expect(ok).To(BeFalse())
-				Expect(reason).To(BeEmpty())
+				decision := runner.recommendResize(logr.Discard(), pvc, scalingReason(pvc, *volumePolicy, volumeRecommendation), *volumePolicy, volumeRecommendation, &resizingConditionAggregator{})
+				Expect(decision.targetSize).To(BeNil())
+				Expect(scalingReason(pvc, *volumePolicy, volumeRecommendation)).To(BeEmpty())
 			})
 
 			Context("Should reconcile when thresholds are reached", func() {
@@ -656,9 +669,9 @@ var _ = Describe("Periodic Runner", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(volumePolicy).NotTo(BeNil())
 
-					ok, reason := testRunner.shouldResizePVC(pvc, *volumePolicy, volumeRecommendation)
-					Expect(ok).To(BeTrue())
-					Expect(reason).To(Equal("passing storage threshold"))
+					decision := testRunner.recommendResize(logr.Discard(), pvc, scalingReason(pvc, *volumePolicy, volumeRecommendation), *volumePolicy, volumeRecommendation, &resizingConditionAggregator{})
+					Expect(decision.targetSize).NotTo(BeNil())
+					Expect(scalingReason(pvc, *volumePolicy, volumeRecommendation)).To(Equal(common.ScalingReasonStorageThreshold))
 
 					event := <-eventRecorder.Events
 					wantEvent := `Warning UsedSpaceThresholdReached used space (92%) exceeds the configured threshold (80%)`
@@ -678,9 +691,9 @@ var _ = Describe("Periodic Runner", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(volumePolicy).NotTo(BeNil())
 
-					ok, reason := testRunner.shouldResizePVC(pvc, *volumePolicy, volumeRecommendation)
-					Expect(ok).To(BeTrue())
-					Expect(reason).To(Equal("passing inodes threshold"))
+					decision := testRunner.recommendResize(logr.Discard(), pvc, scalingReason(pvc, *volumePolicy, volumeRecommendation), *volumePolicy, volumeRecommendation, &resizingConditionAggregator{})
+					Expect(decision.targetSize).NotTo(BeNil())
+					Expect(scalingReason(pvc, *volumePolicy, volumeRecommendation)).To(Equal(common.ScalingReasonInodesThreshold))
 
 					event := <-eventRecorder.Events
 					wantEvent := `Warning UsedInodesThresholdReached used inodes (91%) exceeds the configured threshold (80%)`
@@ -757,7 +770,7 @@ var _ = Describe("Periodic Runner", func() {
 			})
 
 			It("should report the number of PVCs at max capacity via the gauge", func() {
-				By("Registering metrics for the test PVC so it reaches shouldResizePVC")
+				By("Registering metrics for the test PVC so it reaches recommendResize")
 				metricsSource := fake.New(fake.WithInterval(10 * time.Millisecond))
 				fakeItem := &fake.Item{
 					NamespacedName:         client.ObjectKeyFromObject(pvc),
@@ -1470,7 +1483,7 @@ var _ = Describe("Periodic Runner", func() {
 				Entry("should detect resize has been started",
 					ptr.To(corev1.PersistentVolumeClaimResizing),
 					nil,
-					"passing storage threshold",
+					common.ScalingReasonStorageThreshold,
 					"resize has been started",
 					`storage threshold.*resize has been started`,
 					true,
@@ -1479,7 +1492,7 @@ var _ = Describe("Periodic Runner", func() {
 				Entry("should detect filesystem resize is pending",
 					ptr.To(corev1.PersistentVolumeClaimFileSystemResizePending),
 					nil,
-					"passing inodes threshold",
+					common.ScalingReasonInodesThreshold,
 					"filesystem resize is pending",
 					`passing inodes threshold.*file system resize is pending`,
 					true,
@@ -1488,7 +1501,7 @@ var _ = Describe("Periodic Runner", func() {
 				Entry("should detect volume is being modified",
 					ptr.To(corev1.PersistentVolumeClaimVolumeModifyingVolume),
 					nil,
-					"passing storage threshold",
+					common.ScalingReasonStorageThreshold,
 					"volume is being modified",
 					`storage threshold.*volume is being modified`,
 					true,
@@ -1497,7 +1510,7 @@ var _ = Describe("Periodic Runner", func() {
 				Entry("should detect pvc is still being resized when annotation matches status",
 					nil,
 					ptr.To("1Gi"),
-					"passing inodes threshold",
+					common.ScalingReasonInodesThreshold,
 					"persistent volume claim is still being resized",
 					`passing inodes threshold.*persistent volume claim is still being resized`,
 					true,
@@ -1506,7 +1519,7 @@ var _ = Describe("Periodic Runner", func() {
 				Entry("should return false when annotation is missing",
 					nil,
 					nil,
-					"passing storage threshold",
+					common.ScalingReasonStorageThreshold,
 					"",
 					"",
 					false,
@@ -1515,7 +1528,7 @@ var _ = Describe("Periodic Runner", func() {
 				Entry("should return false when annotation no longer matches status (resize completed)",
 					nil,
 					ptr.To("512Mi"),
-					"passing storage threshold",
+					common.ScalingReasonStorageThreshold,
 					"",
 					"",
 					false,
@@ -1524,7 +1537,7 @@ var _ = Describe("Periodic Runner", func() {
 				Entry("should return true on unparseable annotation and surface the parse error in the aggregated condition",
 					nil,
 					ptr.To("not-a-quantity"),
-					"passing storage threshold",
+					common.ScalingReasonStorageThreshold,
 					"",
 					`could not parse pvc.autoscaling.gardener.cloud/prev-size annotation with value not-a-quantity`,
 					true,
@@ -1558,7 +1571,7 @@ var _ = Describe("Periodic Runner", func() {
 					aggregator := &resizingConditionAggregator{}
 					volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
 					Expect(errPolicy).NotTo(HaveOccurred())
-					updatedRecommendation, err := runner.resizePVC(parentCtx, logger, pvc, *volumePolicy, reason, volumeRecommendation, aggregator)
+					updatedRecommendation, err := runner.calculateAndResize(parentCtx, logger, pvc, *volumePolicy, volumeRecommendation, aggregator)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(buf.String()).To(ContainSubstring(expectedLogSubstring))
 
@@ -1582,7 +1595,7 @@ var _ = Describe("Periodic Runner", func() {
 					"2Gi",
 					ptr.To(95),
 					nil,
-					"passing storage threshold",
+					common.ScalingReasonStorageThreshold,
 					"resizing persistent volume claim",
 					`resizing from 1Gi to 2Gi.*passing storage threshold`,
 				),
@@ -1590,7 +1603,7 @@ var _ = Describe("Periodic Runner", func() {
 					"2Gi",
 					nil,
 					ptr.To(95),
-					"passing inodes threshold",
+					common.ScalingReasonInodesThreshold,
 					"resizing persistent volume claim",
 					`resizing from 1Gi to 2Gi.*passing inodes threshold`,
 				),
@@ -1615,7 +1628,7 @@ var _ = Describe("Periodic Runner", func() {
 				aggregator := &resizingConditionAggregator{}
 				volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
 				Expect(errPolicy).NotTo(HaveOccurred())
-				volumeRecommendation, err := runner.resizePVC(parentCtx, logger, pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+				volumeRecommendation, err := runner.calculateAndResize(parentCtx, logger, pvc, *volumePolicy, volumeRecommendation, aggregator)
 				Expect(err).NotTo(HaveOccurred())
 
 				wantLog := `"resizing persistent volume claim","pvc":"test-pvc","from":"1Gi","to":"2Gi"}`
@@ -1636,7 +1649,7 @@ var _ = Describe("Periodic Runner", func() {
 				aggregator = &resizingConditionAggregator{}
 				volumePolicy, errPolicy = getVolumePolicy(resizedPvc.Name, pvca.Spec.VolumePolicies)
 				Expect(errPolicy).NotTo(HaveOccurred())
-				volumeRecommendation, err = runner.resizePVC(parentCtx, logger, &resizedPvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+				volumeRecommendation, err = runner.calculateAndResize(parentCtx, logger, &resizedPvc, *volumePolicy, volumeRecommendation, aggregator)
 				Expect(err).NotTo(HaveOccurred())
 
 				wantLog = `"resizing persistent volume claim","pvc":"test-pvc","from":"2Gi","to":"3Gi"}`
@@ -1655,9 +1668,10 @@ var _ = Describe("Periodic Runner", func() {
 				By("Expecting third attempt to report max capacity reached (already at max)")
 				volumePolicy, errPolicy = getVolumePolicy(resizedPvc.Name, pvca.Spec.VolumePolicies)
 				Expect(errPolicy).NotTo(HaveOccurred())
-				shouldResize, reason := runner.shouldResizePVC(&resizedPvc, *volumePolicy, volumeRecommendation)
-				Expect(shouldResize).To(BeFalse())
-				Expect(reason).To(Equal("max capacity reached"))
+				decision := runner.recommendResize(logr.Discard(), &resizedPvc, scalingReason(&resizedPvc, *volumePolicy, volumeRecommendation), *volumePolicy, volumeRecommendation, &resizingConditionAggregator{})
+				Expect(decision.targetSize).To(BeNil())
+				Expect(decision.alreadyAtMaxCapacity).To(BeTrue())
+				Expect(scalingReason(&resizedPvc, *volumePolicy, volumeRecommendation)).To(Equal(common.ScalingReasonMaxCapacity))
 
 				By("Expecting the counter to have incremented once, on the resize that landed at max")
 				Expect(testutil.ToFloat64(maxCapCounter)).To(Equal(baselineMaxCap + 1))
@@ -1665,8 +1679,8 @@ var _ = Describe("Periodic Runner", func() {
 				By("Expecting a subsequent check while already at max to not recount")
 				volumePolicy, errPolicy = getVolumePolicy(resizedPvc.Name, pvca.Spec.VolumePolicies)
 				Expect(errPolicy).NotTo(HaveOccurred())
-				shouldResize, _ = runner.shouldResizePVC(&resizedPvc, *volumePolicy, volumeRecommendation)
-				Expect(shouldResize).To(BeFalse())
+				decision = runner.recommendResize(logr.Discard(), &resizedPvc, scalingReason(&resizedPvc, *volumePolicy, volumeRecommendation), *volumePolicy, volumeRecommendation, &resizingConditionAggregator{})
+				Expect(decision.targetSize).To(BeNil())
 				Expect(testutil.ToFloat64(maxCapCounter)).To(Equal(baselineMaxCap + 1))
 			})
 
@@ -1693,7 +1707,7 @@ var _ = Describe("Periodic Runner", func() {
 				aggregator := &resizingConditionAggregator{}
 				volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
 				Expect(errPolicy).NotTo(HaveOccurred())
-				_, err := runner.resizePVC(parentCtx, logger, pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+				_, err := runner.calculateAndResize(parentCtx, logger, pvc, *volumePolicy, volumeRecommendation, aggregator)
 				Expect(err).NotTo(HaveOccurred())
 
 				var atMaxPvc corev1.PersistentVolumeClaim
@@ -1709,9 +1723,10 @@ var _ = Describe("Periodic Runner", func() {
 				By("A reconcile while still at max should not recount")
 				volumePolicy, errPolicy = getVolumePolicy(atMaxPvc.Name, pvca.Spec.VolumePolicies)
 				Expect(errPolicy).NotTo(HaveOccurred())
-				shouldResize, reason := runner.shouldResizePVC(&atMaxPvc, *volumePolicy, volumeRecommendation)
-				Expect(shouldResize).To(BeFalse())
-				Expect(reason).To(Equal("max capacity reached"))
+				decision := runner.recommendResize(logr.Discard(), &atMaxPvc, scalingReason(&atMaxPvc, *volumePolicy, volumeRecommendation), *volumePolicy, volumeRecommendation, &resizingConditionAggregator{})
+				Expect(decision.targetSize).To(BeNil())
+				Expect(decision.alreadyAtMaxCapacity).To(BeTrue())
+				Expect(scalingReason(&atMaxPvc, *volumePolicy, volumeRecommendation)).To(Equal(common.ScalingReasonMaxCapacity))
 				Expect(testutil.ToFloat64(maxCapCounter)).To(Equal(baselineMaxCap + 1))
 
 				By("Raising max by another step so the PVC can resize up to the new max")
@@ -1722,7 +1737,7 @@ var _ = Describe("Periodic Runner", func() {
 				volumePolicy, errPolicy = getVolumePolicy(atMaxPvc.Name, pvca.Spec.VolumePolicies)
 				Expect(errPolicy).NotTo(HaveOccurred())
 				aggregator = &resizingConditionAggregator{}
-				_, err = runner.resizePVC(parentCtx, logger, &atMaxPvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+				_, err = runner.calculateAndResize(parentCtx, logger, &atMaxPvc, *volumePolicy, volumeRecommendation, aggregator)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Landing on the new max should count a second time")
@@ -1750,7 +1765,7 @@ var _ = Describe("Periodic Runner", func() {
 					aggregator := &resizingConditionAggregator{}
 					volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
 					Expect(errPolicy).NotTo(HaveOccurred())
-					_, err := runner.resizePVC(parentCtx, logger, pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+					_, err := runner.calculateAndResize(parentCtx, logger, pvc, *volumePolicy, volumeRecommendation, aggregator)
 					Expect(err).NotTo(HaveOccurred())
 
 					var updatedPvc corev1.PersistentVolumeClaim
@@ -1778,9 +1793,10 @@ var _ = Describe("Periodic Runner", func() {
 
 				volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
 				Expect(errPolicy).NotTo(HaveOccurred())
-				shouldResize, reason := runner.shouldResizePVC(pvc, *volumePolicy, volumeRecommendation)
-				Expect(shouldResize).To(BeFalse())
-				Expect(reason).To(Equal("max capacity reached"))
+				decision := runner.recommendResize(logr.Discard(), pvc, scalingReason(pvc, *volumePolicy, volumeRecommendation), *volumePolicy, volumeRecommendation, &resizingConditionAggregator{})
+				Expect(decision.targetSize).To(BeNil())
+				Expect(decision.alreadyAtMaxCapacity).To(BeTrue())
+				Expect(scalingReason(pvc, *volumePolicy, volumeRecommendation)).To(Equal(common.ScalingReasonMaxCapacity))
 			})
 
 			DescribeTable("should handle cooldown duration",
@@ -1806,7 +1822,7 @@ var _ = Describe("Periodic Runner", func() {
 					aggregator := &resizingConditionAggregator{}
 					volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
 					Expect(errPolicy).NotTo(HaveOccurred())
-					updatedRecommendation, err := runner.resizePVC(parentCtx, logger, pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+					updatedRecommendation, err := runner.calculateAndResize(parentCtx, logger, pvc, *volumePolicy, volumeRecommendation, aggregator)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(buf.String()).To(ContainSubstring(expectedLog))
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/pvc-autoscaler/internal/common"
 )
 
 // ErrBadPercentageValue is an error which is returned when attempting to parse
@@ -40,7 +42,7 @@ func ParsePercentage(s string) (float64, error) {
 // ScaledDueToClause renders the ", due to <reason>" fragment used in the in-progress
 // resize messages, so a PVC whose resize is observed without a scaling reason looks neat.
 func ScaledDueToClause(scalingReason string) string {
-	if scalingReason == "max capacity reached" {
+	if scalingReason == common.ScalingReasonMaxCapacity {
 		return ""
 	}
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -34,6 +35,16 @@ func ParsePercentage(s string) (float64, error) {
 	}
 
 	return val, nil
+}
+
+// ScaledDueToClause renders the ", due to <reason>" fragment used in the in-progress
+// resize messages, so a PVC whose resize is observed without a scaling reason looks neat.
+func ScaledDueToClause(scalingReason string) string {
+	if scalingReason == "" {
+		return ""
+	}
+
+	return fmt.Sprintf(" due to %s", scalingReason)
 }
 
 // IsPersistentVolumeClaimConditionTrue is a predicate which tests whether the

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -40,7 +40,7 @@ func ParsePercentage(s string) (float64, error) {
 // ScaledDueToClause renders the ", due to <reason>" fragment used in the in-progress
 // resize messages, so a PVC whose resize is observed without a scaling reason looks neat.
 func ScaledDueToClause(scalingReason string) string {
-	if scalingReason == "" {
+	if scalingReason == "max capacity reached" {
 		return ""
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Improves the max-capacity metrics and consolidates the "max capacity reached" logic:

- Adds a new `max_capacity_reached` Gauge that reports how many currently targeted PVCs sit at their configured max capacity. Unlike the existing `max_capacity_reached_total` counter, this is a live snapshot that rises and falls as PVCs enter and leave the max-capacity state. It is reset to `0` when there are no PVCAs to reconcile.
- Moves the "already at max capacity" check into `shouldResizePVC`, so a PVC at max is detected up front and skipped cleanly (with the `MaxCapacityReached` warning event and resizing condition) instead of being handled inside `resizePVC`, where only actually resizable PVCs should be able to enter.
- Fixes the semantics of the `max_capacity_reached_total` counter so it increments once when a resize of a PVC leads to it reaching max capacity, rather than on every reconcile while the PVC continues to sit at max. Now it only increases if the max capacity is reached or if the max capacity was augmented and was reached again.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/15611

**Special notes for your reviewer**:
`go.mod` picks up `github.com/kylelemons/godebug` as an indirect dependency.
/cc @Kostov6 @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add a new `max_capacity_reached` Gauge reporting how many targeted PVCs are currently at their configured max capacity. The `max_capacity_reached_total` counter now increments only once per resize-to-max instead of on every reconcile.
```
