### PR TITLE
Add metrics to monitor PVCs stuck in resize

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -47,6 +47,17 @@ var (
 		[]string{"namespace", "persistentvolumeclaim"},
 	)
 
+	// MaxCapacityReached reports how many currently targeted PVCs are at their
+	// configured max capacity. Unlike MaxCapacityReachedTotal it is a snapshot
+	// that rises and falls as PVCs enter and leave the max-capacity state.
+	MaxCapacityReached = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "max_capacity_reached",
+			Help:      "Number of targeted PVCs currently at their max capacity",
+		},
+	)
+
 	// SkippedTotal is a metric which increments each time a PVC is skipped
 	// from being reconciled.
 	SkippedTotal = prometheus.NewCounterVec(
@@ -60,5 +71,5 @@ var (
 )
 
 func init() {
-	ctrlmetrics.Registry.MustRegister(ResizedTotal, ThresholdReachedTotal, SkippedTotal, MaxCapacityReachedTotal)
+	ctrlmetrics.Registry.MustRegister(ResizedTotal, ThresholdReachedTotal, SkippedTotal, MaxCapacityReachedTotal, MaxCapacityReached)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -68,8 +68,20 @@ var (
 		},
 		[]string{"namespace", "persistentvolumeclaim", "reason"},
 	)
+
+	// ResizeStartedTimestampSeconds reports, per PVC currently being resized, the
+	// unix timestamp at which the in-flight resize started. It is unset for PVCs
+	// that are not mid-resize.
+	ResizeStartedTimestampSeconds = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "resize_started_timestamp_seconds",
+			Help:      "Unix timestamp at which an in-progress PVC resize started; unset when no resize is in progress",
+		},
+		[]string{"namespace", "persistentvolumeclaim"},
+	)
 )
 
 func init() {
-	ctrlmetrics.Registry.MustRegister(ResizedTotal, ThresholdReachedTotal, SkippedTotal, MaxCapacityReachedTotal, MaxCapacityReached)
+	ctrlmetrics.Registry.MustRegister(ResizedTotal, ThresholdReachedTotal, SkippedTotal, MaxCapacityReachedTotal, MaxCapacityReached, ResizeStartedTimestampSeconds)
 }

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -242,6 +242,7 @@ func (r *Runner) reconcileAll(ctx context.Context) error {
 	// Nothing to do for now
 	if len(pvcaList.Items) == 0 {
 		metrics.MaxCapacityReached.Set(0)
+		metrics.ResizeStartedTimestampSeconds.Reset()
 
 		return nil
 	}
@@ -252,6 +253,8 @@ func (r *Runner) reconcileAll(ctx context.Context) error {
 	}
 
 	pvcaToPVCsMap, pvcToOwnersMap := r.fetchPVCsForPVCAs(ctx, logger, pvcaList.Items)
+
+	metrics.ResizeStartedTimestampSeconds.Reset()
 
 	atMaxCapacity := 0
 	for pvca, pvcs := range pvcaToPVCsMap {
@@ -428,7 +431,11 @@ func (r *Runner) reconcilePVCA(
 		shouldResize, scalingReason := r.shouldResizePVC(pvc, *policy, volumeRecommendation)
 		if !shouldResize && scalingReason == "max capacity reached" {
 			*atMaxCapacity++
-			if !r.isResizeInProgress(logger, pvc, "", resizingConditions) {
+			if r.isResizeInProgress(logger, pvc, "", resizingConditions) {
+				metrics.ResizeStartedTimestampSeconds.
+					WithLabelValues(pvc.Namespace, pvc.Name).
+					Set(utils.ResizeStartTime(volumeRecommendation))
+			} else {
 				resizingConditions.addCondition(metav1.Condition{
 					Type:    string(v1alpha1.ConditionTypeResizing),
 					Status:  metav1.ConditionFalse,
@@ -442,6 +449,11 @@ func (r *Runner) reconcilePVCA(
 		}
 
 		inProgress := r.isResizeInProgress(logger, pvc, scalingReason, resizingConditions)
+		if inProgress {
+			metrics.ResizeStartedTimestampSeconds.
+				WithLabelValues(pvc.Namespace, pvc.Name).
+				Set(utils.ResizeStartTime(volumeRecommendation))
+		}
 
 		if shouldResize && !inProgress {
 			volumeRecommendation, err = r.resizePVC(ctx, logger, pvc, *policy, scalingReason, volumeRecommendation, resizingConditions)

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -241,6 +241,8 @@ func (r *Runner) reconcileAll(ctx context.Context) error {
 
 	// Nothing to do for now
 	if len(pvcaList.Items) == 0 {
+		metrics.MaxCapacityReached.Set(0)
+
 		return nil
 	}
 
@@ -251,9 +253,11 @@ func (r *Runner) reconcileAll(ctx context.Context) error {
 
 	pvcaToPVCsMap, pvcToOwnersMap := r.fetchPVCsForPVCAs(ctx, logger, pvcaList.Items)
 
+	atMaxCapacity := 0
 	for pvca, pvcs := range pvcaToPVCsMap {
-		r.reconcilePVCA(ctx, logger, pvca, pvcs, pvcToOwnersMap, metricsData)
+		r.reconcilePVCA(ctx, logger, pvca, pvcs, pvcToOwnersMap, metricsData, &atMaxCapacity)
 	}
+	metrics.MaxCapacityReached.Set(float64(atMaxCapacity))
 
 	return nil
 }
@@ -325,6 +329,7 @@ func (r *Runner) reconcilePVCA(
 	pvcs []*corev1.PersistentVolumeClaim,
 	pvcToOwnersMap map[string][]string,
 	metricsData metricssource.Metrics,
+	atMaxCapacity *int,
 ) {
 	logger = logger.WithValues("pvca", client.ObjectKeyFromObject(pvca))
 
@@ -421,6 +426,21 @@ func (r *Runner) reconcilePVCA(
 		}
 
 		shouldResize, scalingReason := r.shouldResizePVC(pvc, *policy, volumeRecommendation)
+		if !shouldResize && scalingReason == "max capacity reached" {
+			*atMaxCapacity++
+			if !r.isResizeInProgress(logger, pvc, "", resizingConditions) {
+				resizingConditions.addCondition(metav1.Condition{
+					Type:    string(v1alpha1.ConditionTypeResizing),
+					Status:  metav1.ConditionFalse,
+					Reason:  ReasonReconcile,
+					Message: fmt.Sprintf("%s: max capacity reached", pvc.Name),
+				})
+			}
+			setVolumeRecommendationForPVC(&volumeRecommendations, pvc.Name, volumeRecommendation)
+
+			continue
+		}
+
 		inProgress := r.isResizeInProgress(logger, pvc, scalingReason, resizingConditions)
 
 		if shouldResize && !inProgress {
@@ -582,9 +602,22 @@ func (r *Runner) shouldResizePVC(pvc *corev1.PersistentVolumeClaim, policy v1alp
 		threshold         = *policy.ScaleUp.UtilizationThresholdPercent
 		usedSpacePercent  = ptr.Deref(volumeRecommendation.Current.UsedSpacePercent, 0)
 		usedInodesPercent = ptr.Deref(volumeRecommendation.Current.UsedInodesPercent, 0)
+		specSize          = pvc.Spec.Resources.Requests.Storage()
 	)
 
 	switch {
+	// Already at max capacity, so do not resize
+	case policy.MaxCapacity.Value()-specSize.Value() < common.ScalingResolutionBytes:
+		r.eventRecorder.Eventf(
+			pvc,
+			corev1.EventTypeWarning,
+			"MaxCapacityReached",
+			"max capacity (%s) has been reached, will not resize",
+			policy.MaxCapacity.String(),
+		)
+
+		return false, "max capacity reached"
+
 	// Used space reached threshold
 	case usedSpacePercent > threshold:
 		r.eventRecorder.Eventf(
@@ -623,6 +656,7 @@ func (r *Runner) shouldResizePVC(pvc *corev1.PersistentVolumeClaim, policy v1alp
 // Returns true if a resize operation is in progress.
 func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVolumeClaim, scalingReason string, resizingConditions *resizingConditionAggregator) bool {
 	currStatusSize := pvc.Status.Capacity.Storage()
+	dueTo := utils.ScaledDueToClause(scalingReason)
 
 	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimResizing) {
 		logger.Info("resize has been started")
@@ -630,7 +664,7 @@ func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVo
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf("%s: is being scaled due to %s, resize has been started", pvc.Name, scalingReason),
+			Message: fmt.Sprintf("%s: is being scaled%s, resize has been started", pvc.Name, dueTo),
 		})
 
 		return true
@@ -642,7 +676,7 @@ func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVo
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf("%s: is being scaled due to %s, file system resize is pending", pvc.Name, scalingReason),
+			Message: fmt.Sprintf("%s: is being scaled%s, file system resize is pending", pvc.Name, dueTo),
 		})
 
 		return true
@@ -654,7 +688,7 @@ func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVo
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf("%s: is being scaled due to %s, volume is being modified", pvc.Name, scalingReason),
+			Message: fmt.Sprintf("%s: is being scaled%s, volume is being modified", pvc.Name, dueTo),
 		})
 
 		return true
@@ -687,7 +721,7 @@ func (r *Runner) isResizeInProgress(logger logr.Logger, pvc *corev1.PersistentVo
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionTrue,
 			Reason:  ReasonReconcile,
-			Message: fmt.Sprintf("%s: is being scaled due to %s, persistent volume claim is still being resized", pvc.Name, scalingReason),
+			Message: fmt.Sprintf("%s: is being scaled%s, persistent volume claim is still being resized", pvc.Name, dueTo),
 		})
 
 		return true
@@ -721,30 +755,12 @@ func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.
 	}
 
 	// We don't want to exceed the max capacity
-	if targetSize.Value() > policy.MaxCapacity.Value() {
+	maxReached := false
+	if targetSize.Value() >= policy.MaxCapacity.Value() {
 		// Only clamp to max capacity if the increase is at least one scaling resolution,
 		// otherwise the increase is too small to be meaningful
-		if policy.MaxCapacity.Value()-currSpecSize.Value() < common.ScalingResolutionBytes {
-			r.eventRecorder.Eventf(
-				pvc,
-				corev1.EventTypeWarning,
-				"MaxCapacityReached",
-				"max capacity (%s) has been reached, will not resize",
-				policy.MaxCapacity.String(),
-			)
-			logger.Info("max capacity reached")
-			metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
-			resizingConditions.addCondition(metav1.Condition{
-				Type:    string(v1alpha1.ConditionTypeResizing),
-				Status:  metav1.ConditionFalse,
-				Reason:  ReasonReconcile,
-				Message: fmt.Sprintf("%s: max capacity reached", pvc.Name),
-			})
-
-			return volumeRecommendation, nil
-		}
-		// Clamp to max capacity instead of skipping the resize entirely
 		targetSize = &policy.MaxCapacity
+		maxReached = true
 	}
 
 	if policy.ScaleUp.CooldownDuration != nil {
@@ -797,6 +813,10 @@ func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.
 		})
 
 		return volumeRecommendation, err
+	}
+
+	if maxReached {
+		metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
 	}
 	volumeRecommendation.Target.Size = targetSize
 	volumeRecommendation.LastResizeTime = ptr.To(metav1.Now())

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 	"github.com/gardener/pvc-autoscaler/internal/common"
+	"github.com/gardener/pvc-autoscaler/internal/metrics"
 	metricssource "github.com/gardener/pvc-autoscaler/internal/metrics/source"
 	"github.com/gardener/pvc-autoscaler/internal/metrics/source/fake"
 	testutils "github.com/gardener/pvc-autoscaler/test/utils"
@@ -752,6 +754,59 @@ var _ = Describe("Periodic Runner", func() {
 					HaveField("Status", metav1.ConditionFalse),
 					HaveField("Reason", ReasonMetricsFetchError),
 				)))
+			})
+
+			It("should report the number of PVCs at max capacity via the gauge", func() {
+				By("Registering metrics for the test PVC so it reaches shouldResizePVC")
+				metricsSource := fake.New(fake.WithInterval(10 * time.Millisecond))
+				fakeItem := &fake.Item{
+					NamespacedName:         client.ObjectKeyFromObject(pvc),
+					CapacityBytes:          1073741824,
+					AvailableBytes:         1073741824,
+					CapacityInodes:         10000,
+					AvailableInodes:        10000,
+					ConsumeBytesIncrement:  1000,
+					ConsumeInodesIncrement: 1000,
+				}
+				metricsSource.Register(fakeItem)
+
+				newCtx, cancelFunc := context.WithCancel(parentCtx)
+				go func() {
+					ch := time.After(500 * time.Millisecond)
+					<-ch
+					cancelFunc()
+				}()
+				metricsSource.Start(newCtx)
+				withMetricsSourceOpt := WithMetricsSource(metricsSource)
+				withMetricsSourceOpt(runner)
+
+				By("Setting max capacity so the 1Gi PVC is already at max")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("1Gi")
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
+
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+				Expect(testutil.ToFloat64(metrics.MaxCapacityReached)).To(Equal(float64(1)))
+
+				By("Recording a terminal Resizing=False max-capacity condition on the PVCA")
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
+					HaveField("Status", metav1.ConditionFalse),
+					HaveField("Reason", ReasonReconcile),
+					HaveField("Message", ContainSubstring("max capacity reached")),
+				)))
+
+				By("Raising max capacity so the PVC is no longer at max")
+				pvcaPatch = client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("10Gi")
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
+
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+				Expect(testutil.ToFloat64(metrics.MaxCapacityReached)).To(Equal(float64(0)))
 			})
 
 			It("should reconcile when threshold has been reached", func() {
@@ -1553,6 +1608,9 @@ var _ = Describe("Periodic Runner", func() {
 				w := io.MultiWriter(GinkgoWriter, &buf)
 				logger := zap.New(zap.WriteTo(w)).WithValues("pvc", "test-pvc")
 
+				maxCapCounter := metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name)
+				baselineMaxCap := testutil.ToFloat64(maxCapCounter)
+
 				By("Performing first resize")
 				aggregator := &resizingConditionAggregator{}
 				volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
@@ -1594,24 +1652,86 @@ var _ = Describe("Periodic Runner", func() {
 				resizedPvc.Status.Capacity[corev1.ResourceStorage] = secondIncreaseCap
 				Expect(k8sClient.Status().Patch(parentCtx, &resizedPvc, patch)).To(Succeed())
 
-				By("Expecting third attempt to fail with max capacity reached (already at max)")
-				aggregator = &resizingConditionAggregator{}
+				By("Expecting third attempt to report max capacity reached (already at max)")
 				volumePolicy, errPolicy = getVolumePolicy(resizedPvc.Name, pvca.Spec.VolumePolicies)
 				Expect(errPolicy).NotTo(HaveOccurred())
-				_, err = runner.resizePVC(parentCtx, logger, &resizedPvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(buf.String()).To(ContainSubstring("max capacity reached"))
+				shouldResize, reason := runner.shouldResizePVC(&resizedPvc, *volumePolicy, volumeRecommendation)
+				Expect(shouldResize).To(BeFalse())
+				Expect(reason).To(Equal("max capacity reached"))
 
-				Expect(aggregator.getAggregatedCondition()).To(And(
-					HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
-					HaveField("Status", metav1.ConditionFalse),
-					HaveField("Reason", ReasonReconcile),
-					HaveField("Message", ContainSubstring("max capacity reached")),
-				))
+				By("Expecting the counter to have incremented once, on the resize that landed at max")
+				Expect(testutil.ToFloat64(maxCapCounter)).To(Equal(baselineMaxCap + 1))
+
+				By("Expecting a subsequent check while already at max to not recount")
+				volumePolicy, errPolicy = getVolumePolicy(resizedPvc.Name, pvca.Spec.VolumePolicies)
+				Expect(errPolicy).NotTo(HaveOccurred())
+				shouldResize, _ = runner.shouldResizePVC(&resizedPvc, *volumePolicy, volumeRecommendation)
+				Expect(shouldResize).To(BeFalse())
+				Expect(testutil.ToFloat64(maxCapCounter)).To(Equal(baselineMaxCap + 1))
+			})
+
+			It("should count again when max is raised and the PVC resizes up to the new max", func() {
+				volumeRecommendation := v1alpha1.VolumeRecommendation{
+					Name: pvc.Name,
+					Current: v1alpha1.CurrentVolumeStatus{
+						UsedSpacePercent: ptr.To(95),
+					},
+				}
+
+				var buf strings.Builder
+				logger := zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &buf))).WithValues("pvc", "test-pvc")
+
+				maxCapCounter := metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name)
+				baselineMaxCap := testutil.ToFloat64(maxCapCounter)
+
+				By("Setting max capacity one step above the current 1Gi size")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("2Gi")
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				By("Resizing up to max should count once")
+				aggregator := &resizingConditionAggregator{}
+				volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
+				Expect(errPolicy).NotTo(HaveOccurred())
+				_, err := runner.resizePVC(parentCtx, logger, pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+				Expect(err).NotTo(HaveOccurred())
+
+				var atMaxPvc corev1.PersistentVolumeClaim
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &atMaxPvc)).To(Succeed())
+				Expect(atMaxPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("2Gi")))
+				Expect(testutil.ToFloat64(maxCapCounter)).To(Equal(baselineMaxCap + 1))
+
+				By("Simulating the resize completing")
+				statusPatch := client.MergeFrom(atMaxPvc.DeepCopy())
+				atMaxPvc.Status.Capacity[corev1.ResourceStorage] = resource.MustParse("2Gi")
+				Expect(k8sClient.Status().Patch(parentCtx, &atMaxPvc, statusPatch)).To(Succeed())
+
+				By("A reconcile while still at max should not recount")
+				volumePolicy, errPolicy = getVolumePolicy(atMaxPvc.Name, pvca.Spec.VolumePolicies)
+				Expect(errPolicy).NotTo(HaveOccurred())
+				shouldResize, reason := runner.shouldResizePVC(&atMaxPvc, *volumePolicy, volumeRecommendation)
+				Expect(shouldResize).To(BeFalse())
+				Expect(reason).To(Equal("max capacity reached"))
+				Expect(testutil.ToFloat64(maxCapCounter)).To(Equal(baselineMaxCap + 1))
+
+				By("Raising max by another step so the PVC can resize up to the new max")
+				pvcaPatch = client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("3Gi")
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				volumePolicy, errPolicy = getVolumePolicy(atMaxPvc.Name, pvca.Spec.VolumePolicies)
+				Expect(errPolicy).NotTo(HaveOccurred())
+				aggregator = &resizingConditionAggregator{}
+				_, err = runner.resizePVC(parentCtx, logger, &atMaxPvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Landing on the new max should count a second time")
+				Expect(atMaxPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("3Gi")))
+				Expect(testutil.ToFloat64(maxCapCounter)).To(Equal(baselineMaxCap + 2))
 			})
 
 			DescribeTable("clamp resize to max capacity",
-				func(maxCapacity resource.Quantity, minStep resource.Quantity, expectResize bool, expectedSize resource.Quantity) {
+				func(maxCapacity resource.Quantity, minStep resource.Quantity, expectedSize resource.Quantity) {
 					volumeRecommendation := v1alpha1.VolumeRecommendation{
 						Name: pvc.Name,
 						Current: v1alpha1.CurrentVolumeStatus{
@@ -1636,26 +1756,32 @@ var _ = Describe("Periodic Runner", func() {
 					var updatedPvc corev1.PersistentVolumeClaim
 					Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &updatedPvc)).To(Succeed())
 					Expect(updatedPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(expectedSize))
-
-					if expectResize {
-						Expect(buf.String()).To(ContainSubstring("resizing persistent volume claim"))
-					} else {
-						Expect(buf.String()).To(ContainSubstring("max capacity reached"))
-						Expect(aggregator.getAggregatedCondition()).To(And(
-							HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
-							HaveField("Status", metav1.ConditionFalse),
-							HaveField("Reason", ReasonReconcile),
-							HaveField("Message", ContainSubstring("max capacity reached")),
-						))
-					}
+					Expect(buf.String()).To(ContainSubstring("resizing persistent volume claim"))
 				},
-				Entry("should not resize when headroom is below scaling resolution",
-					resource.MustParse("1500Mi"), resource.MustParse("1Gi"), false, resource.MustParse("1Gi"),
-				),
 				Entry("should clamp resize to max capacity when step would overshoot",
-					resource.MustParse("2Gi"), resource.MustParse("2Gi"), true, resource.MustParse("2Gi"),
+					resource.MustParse("2Gi"), resource.MustParse("2Gi"), resource.MustParse("2Gi"),
 				),
 			)
+
+			It("should not resize when headroom is below scaling resolution", func() {
+				volumeRecommendation := v1alpha1.VolumeRecommendation{
+					Name: pvc.Name,
+					Current: v1alpha1.CurrentVolumeStatus{
+						UsedSpacePercent: ptr.To(95),
+					},
+				}
+
+				By("Setting max capacity within one scaling resolution of the current 1Gi size")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("1500Mi")
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+
+				volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
+				Expect(errPolicy).NotTo(HaveOccurred())
+				shouldResize, reason := runner.shouldResizePVC(pvc, *volumePolicy, volumeRecommendation)
+				Expect(shouldResize).To(BeFalse())
+				Expect(reason).To(Equal("max capacity reached"))
+			})
 
 			DescribeTable("should handle cooldown duration",
 				func(lastResizeOffset time.Duration, expectResize bool, expectedLog string) {

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -809,6 +809,73 @@ var _ = Describe("Periodic Runner", func() {
 				Expect(testutil.ToFloat64(metrics.MaxCapacityReached)).To(Equal(float64(0)))
 			})
 
+			It("should report the resize-started timestamp gauge while a resize is in flight and clear it once done", func() {
+				By("Registering metrics for the test PVC so its threshold is reached")
+				metricsSource := fake.New(fake.WithInterval(10 * time.Millisecond))
+				fakeItem := &fake.Item{
+					NamespacedName:         client.ObjectKeyFromObject(pvc),
+					CapacityBytes:          1073741824,
+					AvailableBytes:         1073741824,
+					CapacityInodes:         10000,
+					AvailableInodes:        10000,
+					ConsumeBytesIncrement:  1000,
+					ConsumeInodesIncrement: 1000,
+				}
+				metricsSource.Register(fakeItem)
+
+				newCtx, cancelFunc := context.WithCancel(parentCtx)
+				go func() {
+					ch := time.After(500 * time.Millisecond)
+					<-ch
+					cancelFunc()
+				}()
+				metricsSource.Start(newCtx)
+				withMetricsSourceOpt := WithMetricsSource(metricsSource)
+				withMetricsSourceOpt(runner)
+
+				By("Reconciling once to initiate the resize (spec bumped, scaled-from annotation set)")
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+
+				By("Verifying no series is reported on the sweep that initiates the resize")
+				Expect(testutil.CollectAndCount(metrics.ResizeStartedTimestampSeconds)).To(Equal(0))
+
+				By("Waiting for the resize to be observable via the cache: spec > status, scaled-from == status")
+				Eventually(func(g Gomega) {
+					cached := &corev1.PersistentVolumeClaim{}
+					g.Expect(mgrClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), cached)).To(Succeed())
+					g.Expect(cached.Annotations).To(HaveKeyWithValue(common.AnnotationPreviousSize, "1Gi"))
+				}).Should(Succeed())
+
+				By("Reading the persisted LastResizeTime from the PVCA status recommendation")
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.VolumeRecommendations).To(HaveLen(1))
+				lastResizeTime := updatedPVCA.Status.VolumeRecommendations[0].LastResizeTime
+				Expect(lastResizeTime).NotTo(BeNil())
+
+				By("Reconciling again while the resize is still in flight and asserting the gauge is set")
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+				Expect(testutil.CollectAndCount(metrics.ResizeStartedTimestampSeconds)).To(Equal(1))
+				Expect(testutil.ToFloat64(metrics.ResizeStartedTimestampSeconds.WithLabelValues(pvc.Namespace, pvc.Name))).
+					To(BeNumerically("==", float64(lastResizeTime.Unix())))
+
+				By("Simulating resize completion by bumping the PVC status capacity to match spec")
+				refreshed := &corev1.PersistentVolumeClaim{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), refreshed)).To(Succeed())
+				statusPatch := client.MergeFrom(refreshed.DeepCopy())
+				refreshed.Status.Capacity[corev1.ResourceStorage] = *refreshed.Spec.Resources.Requests.Storage()
+				Expect(k8sClient.Status().Patch(parentCtx, refreshed, statusPatch)).To(Succeed())
+				Eventually(func(g Gomega) {
+					cached := &corev1.PersistentVolumeClaim{}
+					g.Expect(mgrClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), cached)).To(Succeed())
+					g.Expect(cached.Status.Capacity.Storage().Cmp(*cached.Spec.Resources.Requests.Storage())).To(Equal(0))
+				}).Should(Succeed())
+
+				By("Reconciling once more and asserting the series is cleared")
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+				Expect(testutil.CollectAndCount(metrics.ResizeStartedTimestampSeconds)).To(Equal(0))
+			})
+
 			It("should reconcile when threshold has been reached", func() {
 				metricsSource := fake.New(fake.WithInterval(10 * time.Millisecond))
 				fakeItem := &fake.Item{

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -9,8 +9,11 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 )
 
 // ErrBadPercentageValue is an error which is returned when attempting to parse
@@ -45,6 +48,16 @@ func ScaledDueToClause(scalingReason string) string {
 	}
 
 	return fmt.Sprintf(" due to %s", scalingReason)
+}
+
+// ResizeStartTime returns the unix time (seconds) the in-flight resize started,
+// taken from the recommendation's LastResizeTime. When unset it falls back to now.
+func ResizeStartTime(vr v1alpha1.VolumeRecommendation) float64 {
+	if vr.LastResizeTime != nil {
+		return float64(vr.LastResizeTime.Unix())
+	}
+
+	return float64(time.Now().Unix())
 }
 
 // IsPersistentVolumeClaimConditionTrue is a predicate which tests whether the

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -34,6 +35,16 @@ func ParsePercentage(s string) (float64, error) {
 	}
 
 	return val, nil
+}
+
+// ScaledDueToClause renders the ", due to <reason>" fragment used in the in-progress
+// resize messages, so a PVC whose resize is observed without a scaling reason looks neat.
+func ScaledDueToClause(scalingReason string) string {
+	if scalingReason == "" {
+		return ""
+	}
+
+	return fmt.Sprintf(" due to %s", scalingReason)
 }
 
 // IsPersistentVolumeClaimConditionTrue is a predicate which tests whether the


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Adds a per-PVC Gauge that exposes when an in-flight resize started, giving operators visibility into stuck or long-running resizes. This way you can set up alerts to signal if a resize gets stuck for a long time, by using the new `resize_started_timestamp_seconds` Gauge labelled by `namespace` and `persistentvolumeclaim`) that reports the unix timestamp at which the current in-progress resize started. It is unset for PVCs that are not mid-resize.

The PVC autoscaler sets the gauge whenever a resize is observed in progress - both for PVCs being actively scaled and for PVCs at max capacity whose resize is still in flight by using the recommendation's `LastResizeTime` and falling back to `now` when unset. It resets the Gauge at the start of each reconcile sweep (and when there are no PVCAs to reconcile), so series are cleared once a resize completes and no longer report the PVC.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This has been developed on top of #308 in a common effort to improve metrics for the pvc-autoscaler. The first commit will be dropped once #308 gets merged.
/cc @Kostov6 @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add a new `resize_started_timestamp_seconds` Gauge reporting, per PVC currently being resized, the unix timestamp at which the in-flight resize started.
```
