### PR TITLE
[GEP-0038] Detect and recover from volume expansion failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 IMAGE_TAG ?= $(EFFECTIVE_VERSION)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.31.0
+ENVTEST_K8S_VERSION = 1.34.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/api/autoscaling/v1alpha1/webhook_suite_test.go
+++ b/api/autoscaling/v1alpha1/webhook_suite_test.go
@@ -56,7 +56,7 @@ var _ = BeforeSuite(func() {
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
 		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s",
-			fmt.Sprintf("1.31.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("1.34.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},

--- a/cmd/pvc-autoscaler/main.go
+++ b/cmd/pvc-autoscaler/main.go
@@ -164,7 +164,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	pvcFetcher, err := newPVCFetcher(mgr.GetRESTMapper(), mgr.GetConfig(), mgr.GetClient())
+	pvcFetcher, kubernetesVersion, err := newPVCFetcher(mgr.GetRESTMapper(), mgr.GetConfig(), mgr.GetClient())
 	if err != nil {
 		setupLog.Error(err, "unable to create PersistentVolumeClaim fetcher", "controller", common.ControllerName)
 		os.Exit(1)
@@ -181,6 +181,7 @@ func main() {
 		periodic.WithPVCFetcher(pvcFetcher),
 		periodic.WithHeartbeat(heartbeat),
 		periodic.WithAutoscalerName(autoscalerName),
+		periodic.WithKubernetesVersion(kubernetesVersion),
 	)
 	if err != nil {
 		setupLog.Error(err, "unable to create periodic runner", "controller", common.ControllerName)
@@ -217,10 +218,10 @@ func main() {
 	}
 }
 
-func newPVCFetcher(restMapper meta.RESTMapper, config *rest.Config, c client.Client) (pvcfetcher.Fetcher, error) {
-	scalesClient, err := newScalesClient(restMapper, config)
+func newPVCFetcher(restMapper meta.RESTMapper, config *rest.Config, c client.Client) (pvcfetcher.Fetcher, string, error) {
+	scalesClient, kubernetesVersion, err := newScalesClient(restMapper, config)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create scales client: %w", err)
+		return nil, "", fmt.Errorf("unable to create scales client: %w", err)
 	}
 
 	selectorFetcher, err := selectorfetcher.New(
@@ -228,19 +229,29 @@ func newPVCFetcher(restMapper meta.RESTMapper, config *rest.Config, c client.Cli
 		selectorfetcher.WithScaleClient(scalesClient),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create selector fetcher: %w", err)
+		return nil, "", fmt.Errorf("unable to create selector fetcher: %w", err)
 	}
 
-	return pvcfetcher.New(
+	fetcher, err := pvcfetcher.New(
 		pvcfetcher.WithClient(c),
 		pvcfetcher.WithSelectorFetcher(selectorFetcher),
 	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return fetcher, kubernetesVersion, nil
 }
 
-func newScalesClient(restMapper meta.RESTMapper, config *rest.Config) (scaleclient.ScalesGetter, error) {
+func newScalesClient(restMapper meta.RESTMapper, config *rest.Config) (scaleclient.ScalesGetter, string, error) {
 	clientSet, err := clientset.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new clientset: %w", err)
+		return nil, "", fmt.Errorf("failed to create new clientset: %w", err)
+	}
+
+	serverVersion, err := clientSet.Discovery().ServerVersion()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to discover Kubernetes server version: %w", err)
 	}
 
 	// we don't use cached discovery because DiscoveryScaleKindResolver does its own caching,
@@ -248,8 +259,8 @@ func newScalesClient(restMapper meta.RESTMapper, config *rest.Config) (scaleclie
 	scaleKindResolver := scaleclient.NewDiscoveryScaleKindResolver(clientSet.Discovery())
 	scaleClient, err := scaleclient.NewForConfig(config, restMapper, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new scale client: %w", err)
+		return nil, "", fmt.Errorf("failed to create new scale client: %w", err)
 	}
 
-	return scaleClient, nil
+	return scaleClient, serverVersion.GitVersion, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gardener/pvc-autoscaler
 go 1.25.5
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/go-logr/logr v1.4.4
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
@@ -17,7 +18,6 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -57,8 +57,19 @@ var (
 		},
 		[]string{"namespace", "persistentvolumeclaim", "reason"},
 	)
+
+	// ResizeFailureRecoveryTotal is a metric which increments each time the
+	// a PVC's requested storage to tries to recover from an infeasible volume expansion.
+	ResizeFailureRecoveryTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "resize_failure_recovery_total",
+			Help:      "Total number of times the autoscaler reduced a PVC's requested storage to recover from an infeasible resize",
+		},
+		[]string{"namespace", "persistentvolumeclaim"},
+	)
 )
 
 func init() {
-	ctrlmetrics.Registry.MustRegister(ResizedTotal, ThresholdReachedTotal, SkippedTotal, MaxCapacityReachedTotal)
+	ctrlmetrics.Registry.MustRegister(ResizedTotal, ThresholdReachedTotal, SkippedTotal, MaxCapacityReachedTotal, ResizeFailureRecoveryTotal)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -59,7 +59,7 @@ var (
 	)
 
 	// ResizeFailureRecoveryTotal is a metric which increments each time the
-	// a PVC's requested storage to tries to recover from an infeasible volume expansion.
+	// autoscaler reduces a PVC's requested storage to recover from an infeasible volume expansion.
 	ResizeFailureRecoveryTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -97,13 +97,14 @@ const (
 // processes [v1alpha1.PersistentVolumeClaimAutoscaler] items on a regular basis
 // and performs PVC resizing when thresholds are reached.
 type Runner struct {
-	client         client.Client
-	interval       time.Duration
-	metricsSource  metricssource.Source
-	eventRecorder  record.EventRecorder
-	pvcFetcher     pvcfetcher.Fetcher
-	heartbeat      *healthcheck.Heartbeat
-	autoscalerName string
+	client            client.Client
+	interval          time.Duration
+	metricsSource     metricssource.Source
+	eventRecorder     record.EventRecorder
+	pvcFetcher        pvcfetcher.Fetcher
+	heartbeat         *healthcheck.Heartbeat
+	autoscalerName    string
+	kubernetesVersion string
 }
 
 var _ manager.Runnable = &Runner{}
@@ -198,6 +199,17 @@ func WithHeartbeat(h *healthcheck.Heartbeat) Option {
 func WithAutoscalerName(name string) Option {
 	opt := func(r *Runner) {
 		r.autoscalerName = name
+	}
+
+	return opt
+}
+
+// WithKubernetesVersion configures the [Runner] with the version of the
+// Kubernetes cluster it runs against. It is used for recovery from infeasible volume
+// expansions (RecoverVolumeExpansionFailure), which is GA as of Kubernetes 1.34.
+func WithKubernetesVersion(version string) Option {
+	opt := func(r *Runner) {
+		r.kubernetesVersion = version
 	}
 
 	return opt
@@ -424,6 +436,13 @@ func (r *Runner) reconcilePVCA(
 		}
 
 		if utils.IsPersistentVolumeClaimResizeInfeasible(pvc) {
+			if !utils.IsKubernetesVersionGreaterEqual134(r.kubernetesVersion) {
+				logger.Info("skipping recovery from infeasible pvc resize, requires Kubernetes >= 1.34", "pvc", pvcObjKey.Name, "kubernetesVersion", r.kubernetesVersion)
+				setVolumeRecommendationForPVC(&volumeRecommendations, pvc.Name, volumeRecommendation)
+
+				continue
+			}
+
 			volumeRecommendation, err = r.recoverFromFailedResize(ctx, logger, pvc, volumeRecommendation, resizingConditions)
 			if err != nil {
 				logger.Error(err, "failed to recover from failed pvc resize")

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -823,15 +824,26 @@ func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.
 	return volumeRecommendation, nil
 }
 
-// recoverFromFailedResize reduces the [corev1.PersistentVolumeClaim]'s requested storage back to the last-known-good capacity when the CSI driver
-// has reported the expansion as infeasible.
+// recoverFromFailedResize reduces the [corev1.PersistentVolumeClaim]'s requested storage when the CSI driver has reported the
+// expansion as infeasible. It retries at half the step (allocated + max(ScalingResolutionBytes, failedStep/2)).
 func (r *Runner) recoverFromFailedResize(ctx context.Context, logger logr.Logger, pvc *corev1.PersistentVolumeClaim, volumeRecommendation v1alpha1.VolumeRecommendation, resizingConditions *resizingConditionAggregator) (v1alpha1.VolumeRecommendation, error) {
 	metrics.ResizeFailureRecoveryTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
 
 	currSpecSize := pvc.Spec.Resources.Requests.Storage()
-	targetSize := pvc.Status.AllocatedResources.Storage()
-	if targetSize.IsZero() || targetSize.Cmp(*currSpecSize) >= 0 {
+	allocated := pvc.Status.AllocatedResources.Storage()
+	if allocated.IsZero() || allocated.Cmp(*currSpecSize) >= 0 {
 		return volumeRecommendation, nil
+	}
+
+	failedStep := currSpecSize.Value() - allocated.Value()
+	recoveryIncrement := int64(math.Max(float64(common.ScalingResolutionBytes), float64(failedStep)/2.0))
+	newTargetBytes := int64(math.Ceil(float64(allocated.Value()+recoveryIncrement)/float64(common.ScalingResolutionBytes))) * common.ScalingResolutionBytes
+	targetSize := resource.NewQuantity(newTargetBytes, resource.BinarySI)
+
+	// If the half-step meets or exceeds the size that just failed, roll back to the last-known-good capacity instead.
+	if targetSize.Cmp(*currSpecSize) >= 0 {
+		rollback := allocated.DeepCopy()
+		targetSize = &rollback
 	}
 
 	infeasibleStatus := pvc.Status.AllocatedResourceStatuses[corev1.ResourceStorage]
@@ -847,14 +859,20 @@ func (r *Runner) recoverFromFailedResize(ctx context.Context, logger logr.Logger
 		string(infeasibleStatus),
 	)
 
-	pvcPatch := client.MergeFrom(pvc.DeepCopy())
+	pvcPatch := client.MergeFromWithOptions(pvc.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	pvc.Spec.Resources.Requests[corev1.ResourceStorage] = *targetSize
 	if err := r.client.Patch(ctx, pvc, pvcPatch); err != nil {
+		if apierrors.IsConflict(err) {
+			logger.Info("skipping recovery, pvc changed concurrently", "from", currSpecSize.String(), "to", targetSize.String())
+
+			return volumeRecommendation, nil
+		}
+
 		resizingConditions.addCondition(metav1.Condition{
 			Type:    string(v1alpha1.ConditionTypeResizing),
 			Status:  metav1.ConditionFalse,
 			Reason:  ReasonResizeFailureRecovery,
-			Message: fmt.Sprintf("%s: failed to roll back requested storage from %s to %s after infeasible resize: %s", pvc.Name, currSpecSize.String(), targetSize.String(), err.Error()),
+			Message: fmt.Sprintf("%s: failed to reduce requested storage from %s to %s after infeasible resize: %s", pvc.Name, currSpecSize.String(), targetSize.String(), err.Error()),
 		})
 
 		return volumeRecommendation, err
@@ -865,7 +883,7 @@ func (r *Runner) recoverFromFailedResize(ctx context.Context, logger logr.Logger
 		Type:    string(v1alpha1.ConditionTypeResizing),
 		Status:  metav1.ConditionFalse,
 		Reason:  ReasonResizeFailureRecovery,
-		Message: fmt.Sprintf("%s: rolled back requested storage from %s to %s after infeasible resize (%s)", pvc.Name, currSpecSize.String(), targetSize.String(), string(infeasibleStatus)),
+		Message: fmt.Sprintf("%s: reduced requested storage from %s to %s after infeasible resize (%s)", pvc.Name, currSpecSize.String(), targetSize.String(), string(infeasibleStatus)),
 	})
 
 	return volumeRecommendation, nil

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -88,6 +88,8 @@ const (
 	ReasonReconcile = "Reconcile"
 	// ReasonPVCResizeCooldown indicates that the PVC resize is in cooldown period.
 	ReasonPVCResizeCooldown = "PersistentVolumeClaimResizeCooldown"
+	// ReasonResizeFailureRecovery indicates that the autoscaler reduced the requested storage on a PVC to recover from an infeasible volume expansion.
+	ReasonResizeFailureRecovery = "ResizeFailureRecovery"
 )
 
 // Runner is a [sigs.k8s.io/controller-runtime/pkg/manager.Runnable], which
@@ -416,6 +418,16 @@ func (r *Runner) reconcilePVCA(
 				Reason:  ReasonMetricsFetchError,
 				Message: fmt.Sprintf("%s: %s", pvcObjKey.Name, err.Error()),
 			})
+
+			continue
+		}
+
+		if utils.IsPersistentVolumeClaimResizeInfeasible(pvc) {
+			volumeRecommendation, err = r.recoverFromFailedResize(ctx, logger, pvc, volumeRecommendation, resizingConditions)
+			if err != nil {
+				logger.Error(err, "failed to recover from failed pvc resize")
+			}
+			setVolumeRecommendationForPVC(&volumeRecommendations, pvc.Name, volumeRecommendation)
 
 			continue
 		}
@@ -806,6 +818,54 @@ func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.
 		Status:  metav1.ConditionTrue,
 		Reason:  ReasonReconcile,
 		Message: fmt.Sprintf("%s: resizing from %s to %s due to %s", pvc.Name, currSpecSize.String(), targetSize.String(), scalingReason),
+	})
+
+	return volumeRecommendation, nil
+}
+
+// recoverFromFailedResize reduces the [corev1.PersistentVolumeClaim]'s requested storage back to the last-known-good capacity when the CSI driver
+// has reported the expansion as infeasible.
+func (r *Runner) recoverFromFailedResize(ctx context.Context, logger logr.Logger, pvc *corev1.PersistentVolumeClaim, volumeRecommendation v1alpha1.VolumeRecommendation, resizingConditions *resizingConditionAggregator) (v1alpha1.VolumeRecommendation, error) {
+	metrics.ResizeFailureRecoveryTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
+
+	currSpecSize := pvc.Spec.Resources.Requests.Storage()
+	targetSize := pvc.Status.AllocatedResources.Storage()
+	if targetSize.IsZero() || targetSize.Cmp(*currSpecSize) >= 0 {
+		return volumeRecommendation, nil
+	}
+
+	infeasibleStatus := pvc.Status.AllocatedResourceStatuses[corev1.ResourceStorage]
+
+	logger.Info("recovering from failed pvc resize", "from", currSpecSize.String(), "to", targetSize.String(), "status", string(infeasibleStatus))
+	r.eventRecorder.Eventf(
+		pvc,
+		corev1.EventTypeWarning,
+		"ResizeFailureRecovery",
+		"reducing requested storage from %s to %s because volume expansion was reported as infeasible: %s",
+		currSpecSize.String(),
+		targetSize.String(),
+		string(infeasibleStatus),
+	)
+
+	pvcPatch := client.MergeFrom(pvc.DeepCopy())
+	pvc.Spec.Resources.Requests[corev1.ResourceStorage] = *targetSize
+	if err := r.client.Patch(ctx, pvc, pvcPatch); err != nil {
+		resizingConditions.addCondition(metav1.Condition{
+			Type:    string(v1alpha1.ConditionTypeResizing),
+			Status:  metav1.ConditionFalse,
+			Reason:  ReasonResizeFailureRecovery,
+			Message: fmt.Sprintf("%s: failed to roll back requested storage from %s to %s after infeasible resize: %s", pvc.Name, currSpecSize.String(), targetSize.String(), err.Error()),
+		})
+
+		return volumeRecommendation, err
+	}
+	volumeRecommendation.Target.Size = targetSize
+
+	resizingConditions.addCondition(metav1.Condition{
+		Type:    string(v1alpha1.ConditionTypeResizing),
+		Status:  metav1.ConditionFalse,
+		Reason:  ReasonResizeFailureRecovery,
+		Message: fmt.Sprintf("%s: rolled back requested storage from %s to %s after infeasible resize (%s)", pvc.Name, currSpecSize.String(), targetSize.String(), string(infeasibleStatus)),
 	})
 
 	return volumeRecommendation, nil

--- a/internal/periodic/periodic_suite_test.go
+++ b/internal/periodic/periodic_suite_test.go
@@ -65,7 +65,7 @@ var _ = BeforeSuite(func() {
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.31.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("1.34.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 
 	parentCtx, cancelFunc = context.WithCancel(context.Background())

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -792,6 +792,60 @@ var _ = Describe("Periodic Runner", func() {
 				)))
 			})
 
+			It("should roll back requested storage and skip scale-up when resize is infeasible", func() {
+				By("Simulating a failed infeasible expansion on the PVC")
+				specPatch := client.MergeFrom(pvc.DeepCopy())
+				pvc.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("2Gi")
+				Expect(k8sClient.Patch(parentCtx, pvc, specPatch)).To(Succeed())
+
+				statusPatch := client.MergeFrom(pvc.DeepCopy())
+				pvc.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("900Mi")}
+				pvc.Status.AllocatedResources = corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")}
+				pvc.Status.AllocatedResourceStatuses = map[corev1.ResourceName]corev1.ClaimResourceStatus{
+					corev1.ResourceStorage: corev1.PersistentVolumeClaimControllerResizeInfeasible,
+				}
+				Expect(k8sClient.Status().Patch(parentCtx, pvc, statusPatch)).To(Succeed())
+
+				By("Registering metrics that would otherwise cross the scale-up threshold")
+				metricsSource := fake.New(fake.WithInterval(10 * time.Millisecond))
+				metricsSource.Register(&fake.Item{
+					NamespacedName:         client.ObjectKeyFromObject(pvc),
+					CapacityBytes:          1073741824,
+					AvailableBytes:         1073741824,
+					CapacityInodes:         10000,
+					AvailableInodes:        10000,
+					ConsumeBytesIncrement:  1000,
+					ConsumeInodesIncrement: 1000,
+				})
+				newCtx, cancelFunc := context.WithCancel(parentCtx)
+				go func() {
+					ch := time.After(500 * time.Millisecond)
+					<-ch
+					cancelFunc()
+				}()
+				metricsSource.Start(newCtx)
+
+				withMetricsSourceOpt := WithMetricsSource(metricsSource)
+				withMetricsSourceOpt(runner)
+
+				By("Running reconcile")
+				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
+
+				By("Verifying the PVC spec was rolled back rather than grown")
+				var updatedPvc corev1.PersistentVolumeClaim
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &updatedPvc)).To(Succeed())
+				Expect(updatedPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
+
+				By("Verifying the Resizing condition reflects the recovery")
+				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
+					HaveField("Status", metav1.ConditionFalse),
+					HaveField("Reason", ReasonResizeFailureRecovery),
+				)))
+			})
+
 			It("should set RecommendationAvailable condition to false and not enqueue when two PVCAs manage the same PVC", func() {
 				By("Creating PVCA that points to a PVC already managed by a different PVCA")
 				conflictingPVCA := createPVCA(parentCtx, "pvca-with-conflict", "", pvca.Spec.TargetRef, pvca.Spec.VolumePolicies)
@@ -1706,6 +1760,83 @@ var _ = Describe("Periodic Runner", func() {
 					"resizing persistent volume claim",
 				),
 			)
+		})
+
+		Describe("#recoverFromFailedResize", func() {
+			// Kubernetes only permits the shrink when newSize > status.capacity, so callers
+			// must keep capacitySize < intended rollback target.
+			setInfeasibleState := func(failedSize, capacitySize, allocatedSize resource.Quantity, status corev1.ClaimResourceStatus, setAllocatedResources bool) {
+				By("Patching PVC spec to the failed size")
+				specPatch := client.MergeFrom(pvc.DeepCopy())
+				pvc.Spec.Resources.Requests[corev1.ResourceStorage] = failedSize
+				Expect(k8sClient.Patch(parentCtx, pvc, specPatch)).To(Succeed())
+
+				By("Patching PVC status to reflect the infeasible expansion")
+				statusPatch := client.MergeFrom(pvc.DeepCopy())
+				pvc.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: capacitySize}
+				pvc.Status.AllocatedResourceStatuses = map[corev1.ResourceName]corev1.ClaimResourceStatus{
+					corev1.ResourceStorage: status,
+				}
+				if setAllocatedResources {
+					pvc.Status.AllocatedResources = corev1.ResourceList{corev1.ResourceStorage: allocatedSize}
+				}
+				Expect(k8sClient.Status().Patch(parentCtx, pvc, statusPatch)).To(Succeed())
+			}
+
+			DescribeTable("should roll back requested storage",
+				func(status corev1.ClaimResourceStatus, setAllocatedResources bool) {
+					// capacity < allocated is required so the shrink target (allocated=1Gi) is strictly greater than status.capacity (900Mi).
+					setInfeasibleState(resource.MustParse("5Gi"), resource.MustParse("900Mi"), resource.MustParse("1Gi"), status, setAllocatedResources)
+
+					var buf strings.Builder
+					logger := zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &buf))).WithValues("pvc", pvc.Name)
+
+					aggregator := &resizingConditionAggregator{}
+					volumeRecommendation := v1alpha1.VolumeRecommendation{Name: pvc.Name}
+					updatedRecommendation, err := runner.recoverFromFailedResize(parentCtx, logger, pvc, volumeRecommendation, aggregator)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(buf.String()).To(ContainSubstring("recovering from failed pvc resize"))
+
+					By("Verifying PVC spec was rolled back")
+					var updatedPvc corev1.PersistentVolumeClaim
+					Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &updatedPvc)).To(Succeed())
+					Expect(updatedPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
+
+					Expect(updatedRecommendation.Target.Size).NotTo(BeNil())
+					Expect(*updatedRecommendation.Target.Size).To(Equal(resource.MustParse("1Gi")))
+					Expect(updatedRecommendation.LastResizeTime).To(BeNil())
+
+					Expect(aggregator.getAggregatedCondition()).To(And(
+						HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
+						HaveField("Status", metav1.ConditionFalse),
+						HaveField("Reason", ReasonResizeFailureRecovery),
+						HaveField("Message", MatchRegexp(`rolled back requested storage from 5Gi to 1Gi after infeasible resize \(`+string(status)+`\)`)),
+					))
+				},
+				Entry("when the storage controller reports ControllerResizeInfeasible with allocatedResources",
+					corev1.PersistentVolumeClaimControllerResizeInfeasible, true,
+				),
+				Entry("when the storage controller reports NodeResizeInfeasible with allocatedResources",
+					corev1.PersistentVolumeClaimNodeResizeInfeasible, true,
+				),
+			)
+
+			It("should be a no-op when target size equals current spec size", func() {
+				setInfeasibleState(resource.MustParse("1Gi"), resource.MustParse("1Gi"), resource.MustParse("1Gi"), corev1.PersistentVolumeClaimControllerResizeInfeasible, true)
+
+				var buf strings.Builder
+				logger := zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &buf))).WithValues("pvc", pvc.Name)
+
+				aggregator := &resizingConditionAggregator{}
+				volumeRecommendation := v1alpha1.VolumeRecommendation{Name: pvc.Name}
+				updatedRecommendation, err := runner.recoverFromFailedResize(parentCtx, logger, pvc, volumeRecommendation, aggregator)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(buf.String()).NotTo(ContainSubstring("recovering from failed pvc resize"))
+				Expect(aggregator.getAggregatedCondition().Message).To(BeEmpty())
+				Expect(updatedRecommendation).To(Equal(volumeRecommendation))
+			})
 		})
 
 		Describe("#SetStatus", func() {

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -94,6 +94,7 @@ func newRunner() (*Runner, error) {
 		WithMetricsSource(metricsSource),
 		WithPVCFetcher(pvcFetcher),
 		WithAutoscalerName(""),
+		WithKubernetesVersion("v1.34.0"),
 	)
 
 	return runner, err

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -1763,30 +1763,21 @@ var _ = Describe("Periodic Runner", func() {
 		})
 
 		Describe("#recoverFromFailedResize", func() {
-			// Kubernetes only permits the shrink when newSize > status.capacity, so callers
-			// must keep capacitySize < intended rollback target.
-			setInfeasibleState := func(failedSize, capacitySize, allocatedSize resource.Quantity, status corev1.ClaimResourceStatus, setAllocatedResources bool) {
-				By("Patching PVC spec to the failed size")
-				specPatch := client.MergeFrom(pvc.DeepCopy())
-				pvc.Spec.Resources.Requests[corev1.ResourceStorage] = failedSize
-				Expect(k8sClient.Patch(parentCtx, pvc, specPatch)).To(Succeed())
+			DescribeTable("should reduce requested storage after an infeasible resize",
+				func(failed, capacity, allocated, expectedTarget string, status corev1.ClaimResourceStatus, expectRecovery bool) {
+					By("Patching PVC spec to the failed size")
+					specPatch := client.MergeFrom(pvc.DeepCopy())
+					pvc.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse(failed)
+					Expect(k8sClient.Patch(parentCtx, pvc, specPatch)).To(Succeed())
 
-				By("Patching PVC status to reflect the infeasible expansion")
-				statusPatch := client.MergeFrom(pvc.DeepCopy())
-				pvc.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: capacitySize}
-				pvc.Status.AllocatedResourceStatuses = map[corev1.ResourceName]corev1.ClaimResourceStatus{
-					corev1.ResourceStorage: status,
-				}
-				if setAllocatedResources {
-					pvc.Status.AllocatedResources = corev1.ResourceList{corev1.ResourceStorage: allocatedSize}
-				}
-				Expect(k8sClient.Status().Patch(parentCtx, pvc, statusPatch)).To(Succeed())
-			}
-
-			DescribeTable("should roll back requested storage",
-				func(status corev1.ClaimResourceStatus, setAllocatedResources bool) {
-					// capacity < allocated is required so the shrink target (allocated=1Gi) is strictly greater than status.capacity (900Mi).
-					setInfeasibleState(resource.MustParse("5Gi"), resource.MustParse("900Mi"), resource.MustParse("1Gi"), status, setAllocatedResources)
+					By("Patching PVC status to reflect the infeasible expansion")
+					statusPatch := client.MergeFrom(pvc.DeepCopy())
+					pvc.Status.Capacity = corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(capacity)}
+					pvc.Status.AllocatedResourceStatuses = map[corev1.ResourceName]corev1.ClaimResourceStatus{
+						corev1.ResourceStorage: status,
+					}
+					pvc.Status.AllocatedResources = corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(allocated)}
+					Expect(k8sClient.Status().Patch(parentCtx, pvc, statusPatch)).To(Succeed())
 
 					var buf strings.Builder
 					logger := zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &buf))).WithValues("pvc", pvc.Name)
@@ -1796,47 +1787,37 @@ var _ = Describe("Periodic Runner", func() {
 					updatedRecommendation, err := runner.recoverFromFailedResize(parentCtx, logger, pvc, volumeRecommendation, aggregator)
 					Expect(err).NotTo(HaveOccurred())
 
+					if !expectRecovery {
+						Expect(buf.String()).NotTo(ContainSubstring("recovering from failed pvc resize"))
+						Expect(aggregator.getAggregatedCondition().Message).To(BeEmpty())
+						Expect(updatedRecommendation).To(Equal(volumeRecommendation))
+
+						return
+					}
+
 					Expect(buf.String()).To(ContainSubstring("recovering from failed pvc resize"))
 
-					By("Verifying PVC spec was rolled back")
+					By("Verifying PVC spec was reduced to the expected target")
 					var updatedPvc corev1.PersistentVolumeClaim
 					Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &updatedPvc)).To(Succeed())
-					Expect(updatedPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
+					Expect(updatedPvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse(expectedTarget)))
 
 					Expect(updatedRecommendation.Target.Size).NotTo(BeNil())
-					Expect(*updatedRecommendation.Target.Size).To(Equal(resource.MustParse("1Gi")))
+					Expect(*updatedRecommendation.Target.Size).To(Equal(resource.MustParse(expectedTarget)))
 					Expect(updatedRecommendation.LastResizeTime).To(BeNil())
 
 					Expect(aggregator.getAggregatedCondition()).To(And(
 						HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
 						HaveField("Status", metav1.ConditionFalse),
 						HaveField("Reason", ReasonResizeFailureRecovery),
-						HaveField("Message", MatchRegexp(`rolled back requested storage from 5Gi to 1Gi after infeasible resize \(`+string(status)+`\)`)),
+						HaveField("Message", MatchRegexp(`reduced requested storage from `+failed+` to `+expectedTarget+` after infeasible resize \(`+string(status)+`\)`)),
 					))
 				},
-				Entry("when the storage controller reports ControllerResizeInfeasible with allocatedResources",
-					corev1.PersistentVolumeClaimControllerResizeInfeasible, true,
-				),
-				Entry("when the storage controller reports NodeResizeInfeasible with allocatedResources",
-					corev1.PersistentVolumeClaimNodeResizeInfeasible, true,
-				),
+				Entry("should retry at a half-step when the storage controller reports ControllerResizeInfeasible", "5Gi", "900Mi", "1Gi", "3Gi", corev1.PersistentVolumeClaimControllerResizeInfeasible, true),
+				Entry("should retry at a half-step when the storage controller reports NodeResizeInfeasible", "5Gi", "900Mi", "1Gi", "3Gi", corev1.PersistentVolumeClaimNodeResizeInfeasible, true),
+				Entry("should fall back to the last-known-good capacity when the half-step would meet or exceed the failed size", "2Gi", "900Mi", "1Gi", "1Gi", corev1.PersistentVolumeClaimControllerResizeInfeasible, true),
+				Entry("should be a no-op when the requested size already equals the last-known-good capacity", "1Gi", "1Gi", "1Gi", "1Gi", corev1.PersistentVolumeClaimControllerResizeInfeasible, false),
 			)
-
-			It("should be a no-op when target size equals current spec size", func() {
-				setInfeasibleState(resource.MustParse("1Gi"), resource.MustParse("1Gi"), resource.MustParse("1Gi"), corev1.PersistentVolumeClaimControllerResizeInfeasible, true)
-
-				var buf strings.Builder
-				logger := zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &buf))).WithValues("pvc", pvc.Name)
-
-				aggregator := &resizingConditionAggregator{}
-				volumeRecommendation := v1alpha1.VolumeRecommendation{Name: pvc.Name}
-				updatedRecommendation, err := runner.recoverFromFailedResize(parentCtx, logger, pvc, volumeRecommendation, aggregator)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(buf.String()).NotTo(ContainSubstring("recovering from failed pvc resize"))
-				Expect(aggregator.getAggregatedCondition().Message).To(BeEmpty())
-				Expect(updatedRecommendation).To(Equal(volumeRecommendation))
-			})
 		})
 
 		Describe("#SetStatus", func() {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -53,3 +53,14 @@ func IsPersistentVolumeClaimConditionPresentAndEqual(obj *corev1.PersistentVolum
 
 	return false
 }
+
+// IsPersistentVolumeClaimResizeInfeasible is a predicate which returns whether the storage resize on
+// the given PersistentVolumeClaim has been rejected by the CSI driver as infeasible.
+func IsPersistentVolumeClaimResizeInfeasible(obj *corev1.PersistentVolumeClaim) bool {
+	status, ok := obj.Status.AllocatedResourceStatuses[corev1.ResourceStorage]
+	if !ok {
+		return false
+	}
+
+	return status == corev1.PersistentVolumeClaimControllerResizeInfeasible || status == corev1.PersistentVolumeClaimNodeResizeInfeasible
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -9,12 +9,47 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
 )
 
 // ErrBadPercentageValue is an error which is returned when attempting to parse
 // a bad percentage value.
 var ErrBadPercentageValue = errors.New("bad percentage value")
+
+// constraintK8sGreaterEqual134 matches Kubernetes versions 1.34.0 and higher.
+var constraintK8sGreaterEqual134 = mustNewConstraint(">= 1.34-0")
+
+func mustNewConstraint(constraint string) *semver.Constraints {
+	c, err := semver.NewConstraint(constraint)
+	if err != nil {
+		panic(err)
+	}
+
+	return c
+}
+
+// normalizeVersion returns the normalized version string by removing the
+// leading 'v' and any suffixes like '-rc1', '+build', etc.
+func normalizeVersion(version string) string {
+	v := strings.ReplaceAll(version, "v", "")
+	if idx := strings.IndexAny(v, "-+"); idx != -1 {
+		v = v[:idx]
+	}
+
+	return v
+}
+
+// IsKubernetesVersionGreaterEqual134 reports whether the given Kubernetes
+// version string is 1.34.0 or newer.
+func IsKubernetesVersionGreaterEqual134(version string) bool {
+	v, err := semver.NewVersion(normalizeVersion(version))
+	if err != nil {
+		return false
+	}
+
+	return constraintK8sGreaterEqual134.Check(v)
+}
 
 // ParsePercentage parses a string value, which represents percentage, e.g. 10%.
 func ParsePercentage(s string) (float64, error) {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -78,4 +78,38 @@ var _ = Describe("Utils", func() {
 			Expect(utils.IsPersistentVolumeClaimConditionPresentAndEqual(pvc, corev1.PersistentVolumeClaimVolumeModifyVolumeError, corev1.ConditionTrue)).To(BeFalse())
 		})
 	})
+
+	Context("# IsPersistentVolumeClaimResizeInfeasible", func() {
+		newPVC := func(status corev1.ClaimResourceStatus) *corev1.PersistentVolumeClaim {
+			return &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "sample-pvc", Namespace: "default"},
+				Status: corev1.PersistentVolumeClaimStatus{
+					AllocatedResourceStatuses: map[corev1.ResourceName]corev1.ClaimResourceStatus{
+						corev1.ResourceStorage: status,
+					},
+				},
+			}
+		}
+
+		It("returns false when the allocated resource statuses map is empty", func() {
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "sample-pvc", Namespace: "default"},
+			}
+			Expect(utils.IsPersistentVolumeClaimResizeInfeasible(pvc)).To(BeFalse())
+		})
+
+		It("returns false when the storage status indicates progress", func() {
+			Expect(utils.IsPersistentVolumeClaimResizeInfeasible(newPVC(corev1.PersistentVolumeClaimControllerResizeInProgress))).To(BeFalse())
+			Expect(utils.IsPersistentVolumeClaimResizeInfeasible(newPVC(corev1.PersistentVolumeClaimNodeResizeInProgress))).To(BeFalse())
+			Expect(utils.IsPersistentVolumeClaimResizeInfeasible(newPVC(corev1.PersistentVolumeClaimNodeResizePending))).To(BeFalse())
+		})
+
+		It("returns true for ControllerResizeInfeasible", func() {
+			Expect(utils.IsPersistentVolumeClaimResizeInfeasible(newPVC(corev1.PersistentVolumeClaimControllerResizeInfeasible))).To(BeTrue())
+		})
+
+		It("returns true for NodeResizeInfeasible", func() {
+			Expect(utils.IsPersistentVolumeClaimResizeInfeasible(newPVC(corev1.PersistentVolumeClaimNodeResizeInfeasible))).To(BeTrue())
+		})
+	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area auto-scaling
/area disaster-recovery
/kind enhancement

**What this PR does / why we need it**:
When a CSI driver rejects a volume expansion as `infeasible` (`ControllerResizeInfeasible` / `NodeResizeInfeasible`), the PVC is stuck and no further scale-up happens. This PR makes the autoscaler detect that state and recover from it by retrying with a progressively smaller step (halved) until it succeeds or stops retrying on the last-known-good size.

This PR also adds a new metric `pvc_autoscaler_resize_failure_recovery_total`, incremented each time the autoscaler reduces a PVC's requested storage to recover from an infeasible resize.

**Which issue(s) this PR fixes**:
Fixes #294 
Part of #159 

**Special notes for your reviewer**:
Recovery relies on the Kubernetes `RecoverVolumeExpansionFailure` feature, which is GA as of Kubernetes 1.34, so the behavior is gated behind a cluster version check.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The autoscaler now recovers PVCs whose volume expansion was rejected as infeasible by the CSI driver. It retries the resize with a progressively smaller step (halving the failed increment down to the last-known-good capacity) instead of leaving the PVC stuck. Recovery requires Kubernetes 1.34 or newer, where the `RecoverVolumeExpansionFailure` feature is GA.
```

```other operator
New metric `pvc_autoscaler_resize_failure_recovery_total` (labels: `namespace`, `persistentvolumeclaim`) counts how often the autoscaler reduced a PVC's requested storage to recover from an infeasible resize.
```
