### PR TITLE
Introduce `InPlace` and `Off` resize strategies when scaling up `PersistentVolumeClaims`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ you configure the `--prometheus-address` option for the
 # Usage
 
 In order to start monitoring and automatically resize a persistent volume, when
-the available space or inodes drop below a certain threshold you need to
+the available space or inodes rise above a certain threshold you need to
 create a new `PersistentVolumeClaimAutoscaler` resource, e.g.
 
 ``` yaml
@@ -82,18 +82,22 @@ spec:
       resizeStrategy: InPlace
 ```
 
-The following properties must be specified when creating a new
+The following properties can be specified when creating a new
 `PersistentVolumeClaimAutoscaler` resource.
 
-| Property                                                     | Description                                                                                                                                                                          | Default    |
-|:-------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------:|
-| `.spec.targetRef.name`                                       | Name of the controller or PVC to monitor and autoscale                                                                                                                               | N/A        |
-| `.spec.volumePolicies[].maxCapacity`                         | Max capacity up to which a PVC can be resized                                                                                                                                        | N/A        |
-| `.spec.volumePolicies[].scaleUp.utilizationThresholdPercent` | Threshold percentage for used space/inodes that triggers a resize                                                                                                                    | `80`       |
-| `.spec.volumePolicies[].scaleUp.stepPercent`                 | Percentage by which to increase the PVC during resize                                                                                                                                | `10`       |
-| `.spec.volumePolicies[].scaleUp.minStepAbsolute`             | Minimum absolute increase in capacity during scale-up                                                                                                                                | `1Gi`      |
-| `.spec.volumePolicies[].scaleUp.cooldownDuration`            | Duration to wait before another scale-up operation for the targeted PVC objects                                                                                                      | N/A        |
-| `.spec.volumePolicies[].scaleUp.resizeStrategy`              | The strategy to use when resizing PersistentVolumeClaims. `InPlace` resizes the PVC directly; `Off` turns of resizing and only target recommendations continue to be calculated      | `InPlace`  |
+| Property                                                     | Description                                                                     | Default    |
+|:-------------------------------------------------------------|:--------------------------------------------------------------------------------|:----------:|
+| `.spec.targetRef.name`                                       | Name of the controller or PVC to monitor and autoscaler                         | N/A        |
+| `.spec.volumePolicies[].maxCapacity`                         | Max capacity up to which a PVC can be resized                                   | N/A        |
+| `.spec.volumePolicies[].scaleUp.utilizationThresholdPercent` | Threshold percentage for used space/inodes that triggers a resize               | `80`       |
+| `.spec.volumePolicies[].scaleUp.stepPercent`                 | Percentage by which to increase the PVC during resize                           | `10`       |
+| `.spec.volumePolicies[].scaleUp.minStepAbsolute`             | Minimum absolute increase in capacity during scale-up                           | `1Gi`      |
+| `.spec.volumePolicies[].scaleUp.cooldownDuration`            | Duration to wait before another scale-up operation for the targeted PVC objects | N/A        |
+| `.spec.volumePolicies[].scaleUp.resizeStrategy`              | The strategy to use when resizing PersistentVolumeClaims                        | `InPlace`  |
+
+**Available Resize Strategies**
+- `InPlace` - resizes the PVC directly by modifying it's size.
+- `Off` - turns off resizing and only target recommendations continue to be calculated.
 
 In order to watch the status of the autoscaler you can `kubectl describe` your
 `PersistentVolumeClaimAutoscaler` resource, where you will find information

--- a/README.md
+++ b/README.md
@@ -79,19 +79,21 @@ spec:
       stepPercent: 10
       minStepAbsolute: 1Gi
       cooldownDuration: 10m
+      resizeStrategy: InPlace
 ```
 
 The following properties must be specified when creating a new
 `PersistentVolumeClaimAutoscaler` resource.
 
-| Property                                                     | Description                                                                     | Default |
-|:-------------------------------------------------------------|:--------------------------------------------------------------------------------|:-------:|
-| `.spec.targetRef.name`                                       | Name of the controller or PVC to monitor and autoscale                          | N/A     |
-| `.spec.volumePolicies[].maxCapacity`                         | Max capacity up to which a PVC can be resized                                   | N/A     |
-| `.spec.volumePolicies[].scaleUp.utilizationThresholdPercent` | Threshold percentage for used space/inodes that triggers a resize               | `80`    |
-| `.spec.volumePolicies[].scaleUp.stepPercent`                 | Percentage by which to increase the PVC during resize                           | `10`    |
-| `.spec.volumePolicies[].scaleUp.minStepAbsolute`             | Minimum absolute increase in capacity during scale-up                           | `1Gi`   |
-| `.spec.volumePolicies[].scaleUp.cooldownDuration`            | Duration to wait before another scale-up operation for the targeted PVC objects | N/A     |
+| Property                                                     | Description                                                                                                                                                                          | Default    |
+|:-------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------:|
+| `.spec.targetRef.name`                                       | Name of the controller or PVC to monitor and autoscale                                                                                                                               | N/A        |
+| `.spec.volumePolicies[].maxCapacity`                         | Max capacity up to which a PVC can be resized                                                                                                                                        | N/A        |
+| `.spec.volumePolicies[].scaleUp.utilizationThresholdPercent` | Threshold percentage for used space/inodes that triggers a resize                                                                                                                    | `80`       |
+| `.spec.volumePolicies[].scaleUp.stepPercent`                 | Percentage by which to increase the PVC during resize                                                                                                                                | `10`       |
+| `.spec.volumePolicies[].scaleUp.minStepAbsolute`             | Minimum absolute increase in capacity during scale-up                                                                                                                                | `1Gi`      |
+| `.spec.volumePolicies[].scaleUp.cooldownDuration`            | Duration to wait before another scale-up operation for the targeted PVC objects                                                                                                      | N/A        |
+| `.spec.volumePolicies[].scaleUp.resizeStrategy`              | The strategy to use when resizing PersistentVolumeClaims. `InPlace` resizes the PVC directly; `Off` turns of resizing and only target recommendations continue to be calculated      | `InPlace`  |
 
 In order to watch the status of the autoscaler you can `kubectl describe` your
 `PersistentVolumeClaimAutoscaler` resource, where you will find information

--- a/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
+++ b/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
@@ -143,7 +143,24 @@ type ScalingRules struct {
 	// operation before another scaling operation can be triggered for the targeted PVC objects.
 	// +optional
 	CooldownDuration *metav1.Duration `json:"cooldownDuration,omitempty"`
+
+	// ResizeStrategy defines the strategy that will be used to resize the targeted PVC objects.
+	// +kubebuilder:default:=InPlace
+	// +kubebuilder:validation:Enum=InPlace;Off
+	// +optional
+	ResizeStrategy VolumeResizeStrategy `json:"resizeStrategy,omitempty"`
 }
+
+// VolumeResizeStrategy is a string enumeration type that enumerates all possible resize strategies
+// for the PVCs targeted by the PersistentVolumeClaimAutoscaler.
+type VolumeResizeStrategy string
+
+const (
+	// InPlaceVolumeResizeStrategy resizes the volume by directly modifying the corresponding PVC.
+	InPlaceVolumeResizeStrategy VolumeResizeStrategy = "InPlace"
+	// OffVolumeResizeStrategy turns off resizing.
+	OffVolumeResizeStrategy VolumeResizeStrategy = "Off"
+)
 
 // VolumeRecommendation defines the observed state of a PVC managed by the autoscaler.
 type VolumeRecommendation struct {

--- a/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_webhook_test.go
+++ b/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_webhook_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
-	Context("When creating PersistentVolumeClaimAutoscaler under Defaulting Webhook", func() {
-		It("Should fill in default values if empty", func() {
+	When("creating PersistentVolumeClaimAutoscaler under Defaulting Webhook", func() {
+		It("should fill in default values if empty", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-1",
@@ -51,8 +51,8 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 		})
 	})
 
-	Context("When creating PersistentVolumeClaimAutoscaler under Validating Webhook", func() {
-		It("Should admit if all required fields are provided", func() {
+	When("creating PersistentVolumeClaimAutoscaler under Validating Webhook", func() {
+		It("should admit if all required fields are provided", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-2",
@@ -82,7 +82,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
 		})
 
-		It("Should deny if no volume policies are specified", func() {
+		It("should deny if no volume policies are specified", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-3",
@@ -100,7 +100,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
 		})
 
-		It("Should default and admit if match criteria is not specified", func() {
+		It("should default and admit if match criteria is not specified", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-missing-match",
@@ -130,7 +130,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
 		})
 
-		It("Should deny if maxCapacity is not specified", func() {
+		It("should deny if maxCapacity is not specified", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-5",
@@ -156,7 +156,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
 		})
 
-		It("Should deny if invalid stepPercent is specified", func() {
+		It("should deny if invalid stepPercent is specified", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-6",
@@ -183,7 +183,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
 		})
 
-		It("Should deny if invalid utilizationThresholdPercent is specified", func() {
+		It("should deny if invalid utilizationThresholdPercent is specified", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-7",
@@ -210,7 +210,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
 		})
 
-		It("Should deny if minStepAbsolute is less than 1Gi", func() {
+		It("should deny if minStepAbsolute is less than 1Gi", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-8",
@@ -238,7 +238,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
 		})
 
-		It("Should deny if invalid cooldownDuration is specified", func() {
+		It("should deny if invalid cooldownDuration is specified", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-9",
@@ -267,7 +267,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
 		})
 
-		It("Should deny if match name contains unsupported characters", func() {
+		It("should deny if match name contains unsupported characters", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-match-name-invalid-characters",
@@ -299,7 +299,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
 		})
 
-		It("Should deny if targetRef kind is empty", func() {
+		It("should deny if targetRef kind is empty", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-10",
@@ -328,7 +328,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
 		})
 
-		It("Should deny if targetRef kind contains invalid characters", func() {
+		It("should deny if targetRef kind contains invalid characters", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-11",
@@ -357,7 +357,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
 		})
 
-		It("Should admit if targetRef kind is Deployment", func() {
+		It("should admit if targetRef kind is Deployment", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-12",
@@ -387,7 +387,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
 		})
 
-		It("Should admit if targetRef kind is StatefulSet", func() {
+		It("should admit if targetRef kind is StatefulSet", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-12b",
@@ -417,7 +417,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
 		})
 
-		It("Should deny if targetRef name is empty", func() {
+		It("should deny if targetRef name is empty", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-13",
@@ -446,7 +446,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
 		})
 
-		It("Should deny if targetRef name contains invalid characters", func() {
+		It("should deny if targetRef name contains invalid characters", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-14",
@@ -475,7 +475,7 @@ var _ = Describe("PersistentVolumeClaimAutoscaler Webhook", func() {
 			Expect(k8sClient.Create(ctx, obj)).NotTo(Succeed())
 		})
 
-		It("Should deny if targetRef apiVersion is empty", func() {
+		It("should deny if targetRef apiVersion is empty", func() {
 			obj := &PersistentVolumeClaimAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pvca-15",

--- a/config/crd/bases/autoscaling.gardener.cloud_persistentvolumeclaimautoscalers.yaml
+++ b/config/crd/bases/autoscaling.gardener.cloud_persistentvolumeclaimautoscalers.yaml
@@ -129,6 +129,14 @@ spec:
                             This ensures that the change in capacity is at least this amount, regardless of the percentage.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        resizeStrategy:
+                          default: InPlace
+                          description: ResizeStrategy defines the strategy that will
+                            be used to resize the targeted PVC objects.
+                          enum:
+                          - InPlace
+                          - "Off"
+                          type: string
                         stepPercent:
                           default: 10
                           description: StepPercent specifies the percentage by which

--- a/config/overlays/kind/fake-metrics/kustomization.yaml
+++ b/config/overlays/kind/fake-metrics/kustomization.yaml
@@ -27,6 +27,7 @@ configMapGenerator:
   - sts_bytes_low_1Gi.txt
   - sts_bytes_high_1Gi.txt
   - sts_bytes_low_2Gi.txt
+  - pod_off_strategy_high_1Gi.txt
 
 resources:
 - metrics-test-pod-with-pvc.yaml

--- a/config/overlays/kind/fake-metrics/pod_off_strategy_high_1Gi.txt
+++ b/config/overlays/kind/fake-metrics/pod_off_strategy_high_1Gi.txt
@@ -1,0 +1,15 @@
+# HELP kubelet_volume_stats_available_bytes Number of available bytes in the volume
+# TYPE kubelet_volume_stats_available_bytes gauge
+kubelet_volume_stats_available_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="test-pvc-5",type="fake"} 129023424
+# HELP kubelet_volume_stats_capacity_bytes Total capacity of the volume in bytes
+# TYPE kubelet_volume_stats_capacity_bytes gauge
+kubelet_volume_stats_capacity_bytes{namespace="pvc-autoscaler-system",persistentvolumeclaim="test-pvc-5",type="fake"} 1073741824
+# HELP kubelet_volume_stats_inodes_free Number of free inodes in the volume
+# TYPE kubelet_volume_stats_inodes_free gauge
+kubelet_volume_stats_inodes_free{namespace="pvc-autoscaler-system",persistentvolumeclaim="test-pvc-5",type="fake"} 65536
+# HELP kubelet_volume_stats_inodes Total number of inodes in the volume
+# TYPE kubelet_volume_stats_inodes gauge
+kubelet_volume_stats_inodes{namespace="pvc-autoscaler-system",persistentvolumeclaim="test-pvc-5",type="fake"} 65536
+# HELP fake_metrics_stage Current stage information
+# TYPE fake_metrics_stage gauge
+fake_metrics_pod_off_strategy_high_1Gi{stage="2",description="bytes_high"} 1

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -153,6 +153,14 @@ spec:
                             This ensures that the change in capacity is at least this amount, regardless of the percentage.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        resizeStrategy:
+                          default: InPlace
+                          description: ResizeStrategy defines the strategy that will
+                            be used to resize the targeted PVC objects.
+                          enum:
+                          - InPlace
+                          - "Off"
+                          type: string
                         stepPercent:
                           default: 10
                           description: StepPercent specifies the percentage by which

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -397,6 +397,61 @@ function _test_consume_space_and_resize_statefulset() {
   _cleanup_statefulset "${_sts_name}" "${_pvca_name}" "${_namespace}" "${_pvc_0}" "${_pvc_1}"
 }
 
+# Tests that the Off resize strategy produces a recommendation but never patches the PVC.
+# The PVC must remain at its original capacity even when usage crosses the threshold.
+function _test_off_resize_strategy() {
+  local _pvc_yaml="${_TEST_MANIFESTS_DIR}/pvc-5.yaml"
+  local _pvca_yaml="${_TEST_MANIFESTS_DIR}/pvca-5.yaml"
+  local _pod_yaml="${_TEST_MANIFESTS_DIR}/pod-5.yaml"
+  local _pod_name=$( yq '.metadata.name' "${_pod_yaml}" )
+  local _pvca_name=$( yq '.metadata.name' "${_pvca_yaml}" )
+  local _pvc_name=$( yq '.metadata.name' "${_pvc_yaml}" )
+  local _pod_path=$( yq '.spec.containers[0].volumeMounts[0].mountPath' "${_pod_yaml}" )
+  local _namespace=$( yq '.metadata.namespace // "default"' "${_pod_yaml}" )
+
+  _msg_info "starting test: Off resize strategy produces recommendation but no resize"
+  _msg_info "creating test pvc, pvca and pod ..."
+  _kubectl_create_with_storage_class "${_pvc_yaml}"
+  kubectl create -f "${_pvca_yaml}"
+  kubectl create -f "${_pod_yaml}"
+
+  _msg_info "waiting for test pod to be ready ..."
+  kubectl wait "pod/${_pod_name}" \
+          --for condition=Ready \
+          --namespace "${_namespace}" \
+          --timeout 10m
+
+  _msg_info "waiting for PVC Autoscaler resource to have RecommendationAvailable condition ..."
+  kubectl wait "pvca/${_pvca_name}" \
+          --for condition=RecommendationAvailable \
+          --namespace "${_namespace}" \
+          --timeout 10m
+
+  # Consume ~90% of the 1Gi PVC — this crosses the threshold on both minikube and KinD.
+  _consume bytes 9 1Gi "${_pod_name}" "${_namespace}" "${_pod_path}" pod_off_strategy
+
+  # Usage is above the threshold; the autoscaler should record a recommendation
+  # but must not resize the PVC because the strategy is Off.
+  _wait_for_event Warning UsedSpaceThresholdReached "pvc/${_pvc_name}"
+
+  # PVC must remain at 1Gi — no resize event should ever appear.
+  _ensure_pvc_capacity "${_pvc_name}" "${_namespace}" 1Gi
+
+  # Confirm no Resizing event was emitted for the PVC.
+  local _resizing_events=$( kubectl events \
+                                    -n "${_namespace}" \
+                                    --for "pvc/${_pvc_name}" \
+                                    --types Normal \
+                                    -o yaml | \
+                              yq '.items.[] | select(.reason == "Resizing") | .message' )
+  if [ -n "${_resizing_events}" ]; then
+    _msg_error "unexpected Resizing event found on pvc/${_pvc_name} with Off strategy" 1
+  fi
+  _msg_info "confirmed: no Resizing event emitted with Off strategy"
+
+  _cleanup "${_pod_name}" "${_pvc_name}" "${_pvca_name}" "${_namespace}"
+}
+
 # Cleanup helper for the StatefulSet-based test. StatefulSets do not delete
 # their PVCs, so we drop them explicitly.
 function _cleanup_statefulset() {
@@ -447,6 +502,11 @@ function _main() {
 
   if ! _test_consume_space_and_resize_statefulset; then
     _msg_error "test consume space and resize for statefulset has failed" 0
+    _has_failed="true"
+  fi
+
+  if ! _test_off_resize_strategy; then
+    _msg_error "test Off resize strategy has failed" 0
     _has_failed="true"
   fi
 

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -729,22 +729,31 @@ func (r *Runner) resizePVC(ctx context.Context, logger logr.Logger, pvc *corev1.
 				pvc,
 				corev1.EventTypeWarning,
 				"MaxCapacityReached",
-				"max capacity (%s) has been reached, will not resize",
+				"max capacity (%s) has been reached",
 				policy.MaxCapacity.String(),
 			)
 			logger.Info("max capacity reached")
-			metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
-			resizingConditions.addCondition(metav1.Condition{
-				Type:    string(v1alpha1.ConditionTypeResizing),
-				Status:  metav1.ConditionFalse,
-				Reason:  ReasonReconcile,
-				Message: fmt.Sprintf("%s: max capacity reached", pvc.Name),
-			})
+
+			if policy.ScaleUp.ResizeStrategy != v1alpha1.OffVolumeResizeStrategy {
+				metrics.MaxCapacityReachedTotal.WithLabelValues(pvc.Namespace, pvc.Name).Inc()
+				resizingConditions.addCondition(metav1.Condition{
+					Type:    string(v1alpha1.ConditionTypeResizing),
+					Status:  metav1.ConditionFalse,
+					Reason:  ReasonReconcile,
+					Message: fmt.Sprintf("%s: max capacity reached", pvc.Name),
+				})
+			}
 
 			return volumeRecommendation, nil
 		}
 		// Clamp to max capacity instead of skipping the resize entirely
 		targetSize = &policy.MaxCapacity
+	}
+
+	if policy.ScaleUp.ResizeStrategy == v1alpha1.OffVolumeResizeStrategy {
+		volumeRecommendation.Target.Size = targetSize
+
+		return volumeRecommendation, nil
 	}
 
 	if policy.ScaleUp.CooldownDuration != nil {

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -1708,6 +1708,118 @@ var _ = Describe("Periodic Runner", func() {
 			)
 		})
 
+		Describe("resize strategies", func() {
+			var (
+				strategy     v1alpha1.VolumeResizeStrategy
+				logOutput    strings.Builder
+				aggregator   *resizingConditionAggregator
+				volumePolicy *v1alpha1.VolumePolicy
+			)
+
+			BeforeEach(func() {
+				logOutput.Reset()
+				aggregator = &resizingConditionAggregator{}
+			})
+
+			JustBeforeEach(func() {
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies[0].ScaleUp.ResizeStrategy = strategy
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
+
+				var err error
+				volumePolicy, err = getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			When("using InPlace strategy", func() {
+				BeforeEach(func() {
+					strategy = v1alpha1.InPlaceVolumeResizeStrategy
+				})
+
+				It("should patch the PVC when threshold is reached", func() {
+					volumeRecommendation := v1alpha1.VolumeRecommendation{
+						Name:    pvc.Name,
+						Current: v1alpha1.CurrentVolumeStatus{UsedSpacePercent: ptr.To(95)},
+					}
+					_, err := runner.resizePVC(parentCtx, zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &logOutput))), pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(logOutput.String()).To(ContainSubstring("resizing persistent volume claim"))
+
+					var pvcObj corev1.PersistentVolumeClaim
+					Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &pvcObj)).To(Succeed())
+					Expect(pvcObj.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("2Gi")))
+					Expect(aggregator.getAggregatedCondition()).To(And(
+						HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
+						HaveField("Status", metav1.ConditionTrue),
+					))
+				})
+
+				It("should set Resizing=False condition when max capacity is reached", func() {
+					pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+					pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("1500Mi")
+					Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+					waitForPVCACacheSync(parentCtx, pvca)
+
+					volumeRecommendation := v1alpha1.VolumeRecommendation{
+						Name:    pvc.Name,
+						Current: v1alpha1.CurrentVolumeStatus{UsedSpacePercent: ptr.To(95)},
+					}
+					volumePolicy, _ = getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
+					_, err := runner.resizePVC(parentCtx, zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &logOutput))), pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(logOutput.String()).To(ContainSubstring("max capacity reached"))
+					Expect(aggregator.getAggregatedCondition()).To(And(
+						HaveField("Type", string(v1alpha1.ConditionTypeResizing)),
+						HaveField("Status", metav1.ConditionFalse),
+						HaveField("Message", ContainSubstring("max capacity reached")),
+					))
+				})
+			})
+
+			When("using Off strategy", func() {
+				BeforeEach(func() {
+					strategy = v1alpha1.OffVolumeResizeStrategy
+				})
+
+				It("should update the recommendation without patching the PVC when threshold is reached", func() {
+					volumeRecommendation := v1alpha1.VolumeRecommendation{
+						Name:    pvc.Name,
+						Current: v1alpha1.CurrentVolumeStatus{UsedSpacePercent: ptr.To(95)},
+					}
+					updatedRecommendation, err := runner.resizePVC(parentCtx, zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &logOutput))), pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+					Expect(err).NotTo(HaveOccurred())
+
+					var pvcObj corev1.PersistentVolumeClaim
+					Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvc), &pvcObj)).To(Succeed())
+					Expect(pvcObj.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
+					Expect(aggregator.getAggregatedCondition().Message).To(BeEmpty())
+					Expect(updatedRecommendation.Target.Size).NotTo(BeNil())
+					Expect(updatedRecommendation.Target.Size.String()).To(Equal("2Gi"))
+				})
+
+				It("should not set a Resizing condition when max capacity is reached", func() {
+					pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+					pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("1500Mi")
+					Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+					waitForPVCACacheSync(parentCtx, pvca)
+					volumePolicy, _ = getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
+
+					volumeRecommendation := v1alpha1.VolumeRecommendation{
+						Name:    pvc.Name,
+						Current: v1alpha1.CurrentVolumeStatus{UsedSpacePercent: ptr.To(95)},
+					}
+					_, err := runner.resizePVC(parentCtx, zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &logOutput))), pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(logOutput.String()).To(ContainSubstring("max capacity reached"))
+					Expect(aggregator.getAggregatedCondition().Message).To(BeEmpty())
+				})
+			})
+		})
+
 		Describe("#SetStatus", func() {
 			It("should persist the recommendations condition with the aggregated message", func() {
 				recAgg := &recommendationsConditionAggregator{}

--- a/test/manifests/pod-5.yaml
+++ b/test/manifests/pod-5.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-5
+  namespace: pvc-autoscaler-system
+spec:
+  volumes:
+    - name: app-vol
+      persistentVolumeClaim:
+        claimName: test-pvc-5
+  containers:
+    - name: test-pod-5
+      image: alpine:3.23.3
+      command:
+        - sleep
+        - infinity
+      volumeMounts:
+        - mountPath: /app
+          name: app-vol

--- a/test/manifests/pvc-5.yaml
+++ b/test/manifests/pvc-5.yaml
@@ -1,0 +1,14 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: test-pvc-5
+  namespace: pvc-autoscaler-system
+spec:
+  storageClassName: standard
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/test/manifests/pvca-5.yaml
+++ b/test/manifests/pvca-5.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: autoscaling.gardener.cloud/v1alpha1
+kind: PersistentVolumeClaimAutoscaler
+metadata:
+  name: test-pvca-5
+  namespace: pvc-autoscaler-system
+spec:
+  targetRef:
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: test-pvc-5
+  volumePolicies:
+  - maxCapacity: 3Gi
+    scaleUp:
+      resizeStrategy: "Off"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR adds a field that allows to select the `resizeStrategy` when scaling up as described in https://github.com/gardener/enhancements/tree/main/geps/0038-autoscaling-persistentvolumeclaims

Currently only `InPlace` - direct modification of PVCs and `Off` - turning of resizing are allowed. 

**Which issue(s) this PR fixes**:
Fixes #161 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Volume policies now support a `resizeStrategy` field under `scaleUp`. The default value `InPlace` preserves existing behaviour - when the utilisation threshold is crossed, the PVC is patched with the new size. The new `Off` value disables the resize: the autoscaler still evaluates the policy, records a target size in the PVCA status, but it never patches the PVC. 
```
