### PR TITLE
Clear `volumeRecommendations` that no longer match any `volumePolicies`

### DIFF
--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -342,11 +342,18 @@ func (r *Runner) reconcilePVCA(
 
 	volumeRecommendations := make([]v1alpha1.VolumeRecommendation, 0, len(pvcs))
 	for _, volumeRecommendation := range pvca.Status.VolumeRecommendations {
-		if slices.ContainsFunc(pvcs, func(pvc *corev1.PersistentVolumeClaim) bool {
+		if !slices.ContainsFunc(pvcs, func(pvc *corev1.PersistentVolumeClaim) bool {
 			return pvc.Name == volumeRecommendation.Name
 		}) {
-			volumeRecommendations = append(volumeRecommendations, volumeRecommendation)
+			continue
 		}
+
+		policy, err := getVolumePolicy(volumeRecommendation.Name, pvca.Spec.VolumePolicies)
+		if err != nil || policy == nil {
+			continue
+		}
+
+		volumeRecommendations = append(volumeRecommendations, volumeRecommendation)
 	}
 
 	for _, pvc := range pvcs {
@@ -393,12 +400,6 @@ func (r *Runner) reconcilePVCA(
 
 		if policy == nil {
 			logger.Info("skipping persistentvolumeclaim", "reason", "no matching volume policy")
-			recommendationConditions.addCondition(metav1.Condition{
-				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
-				Status:  metav1.ConditionFalse,
-				Reason:  ReasonRecommendationError,
-				Message: fmt.Sprintf("%s: no matching volume policy", pvcObjKey.Name),
-			})
 
 			continue
 		}

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -855,50 +855,31 @@ var _ = Describe("Periodic Runner", func() {
 				)))
 			})
 
-			It("should set RecommendationAvailable condition to false when no matching volume policy exists", func() {
-				By("Creating a PVC that has no volumePolicy match")
-				noMatchPVC := createPVC(parentCtx, "no-match-pvc", ptr.To(testutils.StorageClassName), nil)
-				DeferCleanup(func() {
-					By("Deleting no-match PVC")
-					Expect(testutils.CleanupObject(parentCtx, k8sClient, noMatchPVC)).To(Succeed())
-					Eventually(func() error {
-						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(noMatchPVC), noMatchPVC)
-					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
-				})
+			It("should drop a stale volume recommendation when its PVC no longer matches a policy", func() {
+				By("Seeding the PVCA status with a recommendation for the PVC")
+				patch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Status.VolumeRecommendations = []v1alpha1.VolumeRecommendation{{Name: pvc.Name}}
+				Expect(k8sClient.Status().Patch(parentCtx, pvca, patch)).To(Succeed())
 
-				By("Creating a PVCA with only a named policy that doesn't match the PVC")
-				noMatchTargetRef := autoscalingv1.CrossVersionObjectReference{
-					APIVersion: "v1",
-					Kind:       "PersistentVolumeClaim",
-					Name:       noMatchPVC.Name,
-				}
-				noMatchPVCA := createPVCA(parentCtx, "pvca-no-match", "", noMatchTargetRef, []v1alpha1.VolumePolicy{
+				By("Changing the volume policy so it no longer matches the PVC")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies = []v1alpha1.VolumePolicy{
 					{
-						Match: v1alpha1.Match{
-							Name: "non-matching-pvc-name",
-						},
-						MaxCapacity: resource.MustParse("10Gi"),
+						Match:       v1alpha1.Match{Name: "does-not-match-*"},
+						MaxCapacity: resource.MustParse("3Gi"),
 					},
-				})
-				DeferCleanup(func() {
-					By("Deleting no-match PVCA")
-					Expect(testutils.CleanupObject(parentCtx, k8sClient, noMatchPVCA)).To(Succeed())
-					Eventually(func() error {
-						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(noMatchPVCA), noMatchPVCA)
-					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
-				})
+				}
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
 
 				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
 
-				By("Verifying the RecommendationAvailable condition indicates no matching policy")
+				By("Verifying the stale recommendation was pruned from the status")
 				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
-				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(noMatchPVCA), updatedPVCA)).To(Succeed())
-				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
-					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
-					HaveField("Status", metav1.ConditionFalse),
-					HaveField("Reason", ReasonRecommendationError),
-					HaveField("Message", ContainSubstring("no matching volume policy")),
-				)))
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.VolumeRecommendations).NotTo(ContainElement(
+					HaveField("Name", pvc.Name),
+				))
 			})
 
 			It("should set Resizing to Unknown on PVC fetch failure when it was previously set", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area auto-scaling
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR makes it so that entries in the `status.volumeRecommendations[]` array are removed, if they do not match any of the `spec.volumePolicies[].match.name`s. 
Additionally, the `RecommendationAvailable` condition is no longer set to `False` if a PVC does not match any `spec.volumePolicies[].match.name`. This was done because operators might intentionally want to skip resizing or generating recommendations for a particular voluem - e.g. if a workload has a data and a WAL volume, they might want to only resize the data volume. It would be weird then to report a `False` status for the `RecommendationAvailable` for a PVC that is never intended to be managed by the `pvc-autoscaler`

**Which issue(s) this PR fixes**:
Part of #295 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Volume recommendations listed in the PersistentVolumeClaimAutoscaler's `status.volumeRecommendations` array are now removed if they are no-longer matched by any of the entries in the `spec.volumePolicies[].match.name`
Additionally, if a PVC is not matched by any of the volume policies, the `RecommendationAvailable` condition is no longer set to `False`.
```
