### PR TITLE
Add `PreferInPlace` resize strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ The following properties can be specified when creating a new
   in-place resize (a `ControllerResizeError` on the PVC, e.g. on infrastructures that cannot
   resize a volume while it is attached to a running Pod) by evicting the Pods using the PVC so
   the volume can be detached and resized offline. Re-created Pods are held unscheduled via a
-  scheduling gate until the resize is ready to be finalized.
+  scheduling gate until the resize is ready to be finalized. To avoid unexpected downtime, make
+  sure to configure appropriate `PodDisruptionBudged`s for the Pods under the `PersistentVolumeClaimAutoscaler`
+  and run your workload with multiple replicas.
 - `InPlace` - resizes the PVC directly by modifying it's size, without any offline-resize recovery.
 - `Off` - turns off resizing and only target recommendations continue to be calculated.
 

--- a/README.md
+++ b/README.md
@@ -93,10 +93,15 @@ The following properties can be specified when creating a new
 | `.spec.volumePolicies[].scaleUp.stepPercent`                 | Percentage by which to increase the PVC during resize                           | `10`       |
 | `.spec.volumePolicies[].scaleUp.minStepAbsolute`             | Minimum absolute increase in capacity during scale-up                           | `1Gi`      |
 | `.spec.volumePolicies[].scaleUp.cooldownDuration`            | Duration to wait before another scale-up operation for the targeted PVC objects | N/A        |
-| `.spec.volumePolicies[].scaleUp.resizeStrategy`              | The strategy to use when resizing PersistentVolumeClaims                        | `InPlace`  |
+| `.spec.volumePolicies[].scaleUp.resizeStrategy`              | The strategy to use when resizing PersistentVolumeClaims                        | `PreferInPlace` |
 
 **Available Resize Strategies**
-- `InPlace` - resizes the PVC directly by modifying it's size.
+- `PreferInPlace` (default) - resizes the PVC in place, and additionally recovers from a failed
+  in-place resize (a `ControllerResizeError` on the PVC, e.g. on infrastructures that cannot
+  resize a volume while it is attached to a running Pod) by evicting the Pods using the PVC so
+  the volume can be detached and resized offline. Re-created Pods are held unscheduled via a
+  scheduling gate until the resize is ready to be finalized.
+- `InPlace` - resizes the PVC directly by modifying it's size, without any offline-resize recovery.
 - `Off` - turns off resizing and only target recommendations continue to be calculated.
 
 In order to watch the status of the autoscaler you can `kubectl describe` your

--- a/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
+++ b/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
@@ -145,8 +145,10 @@ type ScalingRules struct {
 	CooldownDuration *metav1.Duration `json:"cooldownDuration,omitempty"`
 
 	// ResizeStrategy defines the strategy that will be used to resize the targeted PVC objects.
-	// +kubebuilder:default:=InPlace
-	// +kubebuilder:validation:Enum=InPlace;Off
+	// With PreferInPlace (the default) the autoscaler additionally recovers PVCs whose in-place
+	// resize failed by evicting the Pods using them so the volume can be resized offline.
+	// +kubebuilder:default:=PreferInPlace
+	// +kubebuilder:validation:Enum=InPlace;Off;PreferInPlace
 	// +optional
 	ResizeStrategy VolumeResizeStrategy `json:"resizeStrategy,omitempty"`
 }
@@ -156,6 +158,10 @@ type ScalingRules struct {
 type VolumeResizeStrategy string
 
 const (
+	// PreferInPlaceVolumeResizeStrategy resizes the volume in place, and additionally recovers
+	// from a failed in-place resize by evicting the Pods using the PVC so  the volume can be
+	// detached and resized offline.
+	PreferInPlaceVolumeResizeStrategy VolumeResizeStrategy = "PreferInPlace"
 	// InPlaceVolumeResizeStrategy resizes the volume by directly modifying the corresponding PVC.
 	InPlaceVolumeResizeStrategy VolumeResizeStrategy = "InPlace"
 	// OffVolumeResizeStrategy turns off resizing.

--- a/config/crd/bases/autoscaling.gardener.cloud_persistentvolumeclaimautoscalers.yaml
+++ b/config/crd/bases/autoscaling.gardener.cloud_persistentvolumeclaimautoscalers.yaml
@@ -130,12 +130,15 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizeStrategy:
-                          default: InPlace
-                          description: ResizeStrategy defines the strategy that will
-                            be used to resize the targeted PVC objects.
+                          default: PreferInPlace
+                          description: |-
+                            ResizeStrategy defines the strategy that will be used to resize the targeted PVC objects.
+                            With PreferInPlace (the default) the autoscaler additionally recovers PVCs whose in-place
+                            resize failed by evicting the Pods using them so the volume can be resized offline.
                           enum:
                           - InPlace
                           - "Off"
+                          - PreferInPlace
                           type: string
                         stepPercent:
                           default: 10

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -154,12 +154,15 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizeStrategy:
-                          default: InPlace
-                          description: ResizeStrategy defines the strategy that will
-                            be used to resize the targeted PVC objects.
+                          default: PreferInPlace
+                          description: |-
+                            ResizeStrategy defines the strategy that will be used to resize the targeted PVC objects.
+                            With PreferInPlace (the default) the autoscaler additionally recovers PVCs whose in-place
+                            resize failed by evicting the Pods using them so the volume can be resized offline.
                           enum:
                           - InPlace
                           - "Off"
+                          - PreferInPlace
                           type: string
                         stepPercent:
                           default: 10


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR adds the `PreferInPlace` resize strategy and sets it as the new default. This strategy will be used by a new reconciler and webhook that will detect if a PVC is stuck in resize error due to lack of online volume resize support and evict the pods so that the resize can finish.

**Which issue(s) this PR fixes**:
Part of #295 

**Special notes for your reviewer**:
Draft as it depends on #329 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Added the `PreferInPlace` resize strategy which is set by default. When this resize strategy is used the pvc-autoscaler will attempt to recover from volume expansion failures of `PersistentVolumeClaim`s by evicting pods that use them, so that the resize could finish in "offline" mode. 
```
