### PR TITLE
Add Pod mutating webhook to gate Pods pending offline volume resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,15 @@ The following properties can be specified when creating a new
 | `.spec.volumePolicies[].scaleUp.stepPercent`                 | Percentage by which to increase the PVC during resize                           | `10`       |
 | `.spec.volumePolicies[].scaleUp.minStepAbsolute`             | Minimum absolute increase in capacity during scale-up                           | `1Gi`      |
 | `.spec.volumePolicies[].scaleUp.cooldownDuration`            | Duration to wait before another scale-up operation for the targeted PVC objects | N/A        |
-| `.spec.volumePolicies[].scaleUp.resizeStrategy`              | The strategy to use when resizing PersistentVolumeClaims                        | `InPlace`  |
+| `.spec.volumePolicies[].scaleUp.resizeStrategy`              | The strategy to use when resizing PersistentVolumeClaims                        | `PreferInPlace` |
 
 **Available Resize Strategies**
-- `InPlace` - resizes the PVC directly by modifying it's size.
+- `PreferInPlace` (default) - resizes the PVC in place, and additionally recovers from a failed
+  in-place resize (a `ControllerResizeError` on the PVC, e.g. on infrastructures that cannot
+  resize a volume while it is attached to a running Pod) by evicting the Pods using the PVC so
+  the volume can be detached and resized offline. Re-created Pods are held unscheduled via a
+  scheduling gate until the resize is ready to be finalized.
+- `InPlace` - resizes the PVC directly by modifying it's size, without any offline-resize recovery.
 - `Off` - turns off resizing and only target recommendations continue to be calculated.
 
 In order to watch the status of the autoscaler you can `kubectl describe` your

--- a/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
+++ b/api/autoscaling/v1alpha1/persistentvolumeclaimautoscaler_types.go
@@ -145,8 +145,10 @@ type ScalingRules struct {
 	CooldownDuration *metav1.Duration `json:"cooldownDuration,omitempty"`
 
 	// ResizeStrategy defines the strategy that will be used to resize the targeted PVC objects.
-	// +kubebuilder:default:=InPlace
-	// +kubebuilder:validation:Enum=InPlace;Off
+	// With PreferInPlace (the default) the autoscaler additionally recovers PVCs whose in-place
+	// resize failed by evicting the Pods using them so the volume can be resized offline.
+	// +kubebuilder:default:=PreferInPlace
+	// +kubebuilder:validation:Enum=InPlace;Off;PreferInPlace
 	// +optional
 	ResizeStrategy VolumeResizeStrategy `json:"resizeStrategy,omitempty"`
 }
@@ -156,6 +158,10 @@ type ScalingRules struct {
 type VolumeResizeStrategy string
 
 const (
+	// PreferInPlaceVolumeResizeStrategy resizes the volume in place, and additionally recovers
+	// from a failed in-place resize by evicting the Pods using the PVC so  the volume can be
+	// detached and resized offline.
+	PreferInPlaceVolumeResizeStrategy VolumeResizeStrategy = "PreferInPlace"
 	// InPlaceVolumeResizeStrategy resizes the volume by directly modifying the corresponding PVC.
 	InPlaceVolumeResizeStrategy VolumeResizeStrategy = "InPlace"
 	// OffVolumeResizeStrategy turns off resizing.

--- a/cmd/pvc-autoscaler/main.go
+++ b/cmd/pvc-autoscaler/main.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 	"github.com/gardener/pvc-autoscaler/internal/common"
@@ -38,6 +39,7 @@ import (
 	"github.com/gardener/pvc-autoscaler/internal/periodic"
 	"github.com/gardener/pvc-autoscaler/internal/target/pvcfetcher"
 	"github.com/gardener/pvc-autoscaler/internal/target/selectorfetcher"
+	podwebhook "github.com/gardener/pvc-autoscaler/internal/webhook/pod"
 )
 
 var (
@@ -212,6 +214,12 @@ func main() {
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&v1alpha1.PersistentVolumeClaimAutoscaler{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "controller", common.ControllerName)
+			os.Exit(1)
+		}
+
+		podMutator := podwebhook.NewMutator(mgr.GetClient(), admission.NewDecoder(mgr.GetScheme()), autoscalerName)
+		if err = podMutator.SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "pod")
 			os.Exit(1)
 		}
 	}

--- a/cmd/pvc-autoscaler/main.go
+++ b/cmd/pvc-autoscaler/main.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 	"github.com/gardener/pvc-autoscaler/internal/common"
+	"github.com/gardener/pvc-autoscaler/internal/controller/offlineresize"
 	"github.com/gardener/pvc-autoscaler/internal/healthcheck"
 	_ "github.com/gardener/pvc-autoscaler/internal/metrics"
 	"github.com/gardener/pvc-autoscaler/internal/metrics/source"
@@ -189,6 +190,22 @@ func main() {
 
 	if err := mgr.Add(runner); err != nil {
 		setupLog.Error(err, "unable to add periodic runner to manager", "controller", common.ControllerName)
+		os.Exit(1)
+	}
+
+	// Add the offline-resize recovery controller
+	offlineResizeReconciler, err := offlineresize.New(
+		offlineresize.WithClient(mgr.GetClient()),
+		offlineresize.WithEventRecorder(mgr.GetEventRecorderFor(offlineresize.ControllerName)),
+		offlineresize.WithAutoscalerName(autoscalerName),
+	)
+	if err != nil {
+		setupLog.Error(err, "unable to create offline-resize reconciler", "controller", offlineresize.ControllerName)
+		os.Exit(1)
+	}
+
+	if err := offlineResizeReconciler.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to set up offline-resize reconciler with manager", "controller", offlineresize.ControllerName)
 		os.Exit(1)
 	}
 

--- a/config/crd/bases/autoscaling.gardener.cloud_persistentvolumeclaimautoscalers.yaml
+++ b/config/crd/bases/autoscaling.gardener.cloud_persistentvolumeclaimautoscalers.yaml
@@ -130,12 +130,15 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizeStrategy:
-                          default: InPlace
-                          description: ResizeStrategy defines the strategy that will
-                            be used to resize the targeted PVC objects.
+                          default: PreferInPlace
+                          description: |-
+                            ResizeStrategy defines the strategy that will be used to resize the targeted PVC objects.
+                            With PreferInPlace (the default) the autoscaler additionally recovers PVCs whose in-place
+                            resize failed by evicting the Pods using them so the volume can be resized offline.
                           enum:
                           - InPlace
                           - "Off"
+                          - PreferInPlace
                           type: string
                         stepPercent:
                           default: 10

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,5 +1,30 @@
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate--v1-pod
+  failurePolicy: Ignore
+  name: mpod.autoscaling.gardener.cloud
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -833,6 +833,31 @@ spec:
   - Ingress
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: pvc-autoscaler-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: pvc-autoscaler-webhook-service
+      namespace: pvc-autoscaler-system
+      path: /mutate--v1-pod
+  failurePolicy: Ignore
+  name: mpod.autoscaling.gardener.cloud
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -154,12 +154,15 @@ spec:
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         resizeStrategy:
-                          default: InPlace
-                          description: ResizeStrategy defines the strategy that will
-                            be used to resize the targeted PVC objects.
+                          default: PreferInPlace
+                          description: |-
+                            ResizeStrategy defines the strategy that will be used to resize the targeted PVC objects.
+                            With PreferInPlace (the default) the autoscaler additionally recovers PVCs whose in-place
+                            resize failed by evicting the Pods using them so the volume can be resized offline.
                           enum:
                           - InPlace
                           - "Off"
+                          - PreferInPlace
                           type: string
                         stepPercent:
                           default: 10

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -59,4 +59,12 @@ const (
 	// cleared after a successful resize, to indicate that the autoscaler has done
 	// work on this PVC.
 	AnnotationPreviousSize = "pvc.autoscaling.gardener.cloud/prev-size"
+
+	// SchedulingGateOfflineResize is the name of the scheduling gate that the
+	// pvc-autoscaler adds to Pods whose PVC failed to resize online (while the Pod
+	// is still running). The gate holds the Pod unscheduled so that
+	// the VolumeAttachment can be deleted and the volume detached and resized
+	// offline. It is removed once the PVC gets the FileSystemResizePending condition,
+	// allowing the Pod to be scheduled, re-mount the volume and finish the resize.
+	SchedulingGateOfflineResize = "pvc.autoscaling.gardener.cloud/offline-resize"
 )

--- a/internal/controller/offlineresize/offlineresize_suite_test.go
+++ b/internal/controller/offlineresize/offlineresize_suite_test.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package offlineresize_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
+	testutils "github.com/gardener/pvc-autoscaler/test/utils"
+)
+
+var (
+	cfg           *rest.Config
+	k8sClient     client.Client
+	mgrClient     client.Client
+	testEnv       *envtest.Environment
+	eventRecorder = record.NewFakeRecorder(1024)
+	parentCtx     context.Context
+	cancelFunc    context.CancelFunc
+)
+
+func TestOfflineResize(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Offline Resize Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s",
+			fmt.Sprintf("1.31.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+	}
+
+	parentCtx, cancelFunc = context.WithCancel(context.Background())
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	Expect(corev1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(appsv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(v1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:  scheme.Scheme,
+		Metrics: metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(v1alpha1.AddAutoscalerNameFieldIndexer(context.Background(), mgr.GetFieldIndexer())).To(Succeed())
+
+	mgrClient = mgr.GetClient()
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(parentCtx)).To(Succeed())
+	}()
+
+	Expect(mgr.GetCache().WaitForCacheSync(parentCtx)).To(BeTrue())
+
+	Expect(k8sClient.Create(context.Background(), &testutils.StorageClass)).To(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancelFunc()
+	Expect(testEnv.Stop()).To(Succeed())
+})

--- a/internal/controller/offlineresize/reconciler.go
+++ b/internal/controller/offlineresize/reconciler.go
@@ -1,0 +1,304 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package offlineresize
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/gardener/pvc-autoscaler/internal/common"
+	"github.com/gardener/pvc-autoscaler/internal/utils"
+)
+
+// ControllerName is the name of the offline-resize recovery controller.
+const ControllerName = "offline-resize"
+
+// Event reasons emitted by the controller.
+const (
+	// ReasonEvicting indicates that the controller is evicting a Pod so its volume
+	// can be detached and resized offline.
+	ReasonEvicting = "EvictingForOfflineResize"
+	// ReasonEvictionBlocked indicates that a Pod eviction was blocked, e.g. by a
+	// PodDisruptionBudget, and will be retried.
+	ReasonEvictionBlocked = "EvictionBlocked"
+	// ReasonGateRemoved indicates that the offline-resize scheduling gate was removed
+	// from a Pod so it can be scheduled again.
+	ReasonGateRemoved = "OfflineResizeGateRemoved"
+)
+
+// ErrNoClient is returned when the [Reconciler] is configured without a client.
+var ErrNoClient = errors.New("no client provided")
+
+// Reconciler recovers PersistentVolumeClaims from failed online volume resizes.
+type Reconciler struct {
+	client         client.Client
+	eventRecorder  record.EventRecorder
+	autoscalerName string
+}
+
+var _ reconcile.Reconciler = (*Reconciler)(nil)
+
+// Option is a function which configures the [Reconciler].
+type Option func(*Reconciler)
+
+// New creates a new [Reconciler] with the given options.
+func New(opts ...Option) (*Reconciler, error) {
+	r := &Reconciler{}
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	if r.client == nil {
+		return nil, ErrNoClient
+	}
+
+	if r.eventRecorder == nil {
+		return nil, common.ErrNoEventRecorder
+	}
+
+	return r, nil
+}
+
+// WithClient configures the [Reconciler] with the given client.
+func WithClient(c client.Client) Option {
+	return func(r *Reconciler) {
+		r.client = c
+	}
+}
+
+// WithEventRecorder configures the [Reconciler] with the given event recorder.
+func WithEventRecorder(recorder record.EventRecorder) Option {
+	return func(r *Reconciler) {
+		r.eventRecorder = recorder
+	}
+}
+
+// WithAutoscalerName configures the [Reconciler] to act only on PersistentVolumeClaims
+// managed by a [v1alpha1.PersistentVolumeClaimAutoscaler] whose spec.autoscalerName
+// matches the given value. An empty string (the default) matches PVCAs with an empty
+// autoscalerName.
+func WithAutoscalerName(name string) Option {
+	return func(r *Reconciler) {
+		r.autoscalerName = name
+	}
+}
+
+// SetupWithManager wires the [Reconciler] into the given manager. It watches
+// PersistentVolumeClaims and filters, via a predicate, to those which are managed by
+// the pvc-autoscaler (carry the previous-size annotation) and have one of the
+// conditions relevant to offline-resize recovery.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(ControllerName).
+		For(&corev1.PersistentVolumeClaim{}, builder.WithPredicates(managedPVCPredicate())).
+		Complete(r)
+}
+
+// managedPVCPredicate limits reconciliation to PersistentVolumeClaims that the
+// pvc-autoscaler has resized (they carry the previous-size annotation) and which
+// have either the ControllerResizeError or FileSystemResizePending condition.
+func managedPVCPredicate() predicate.Predicate {
+	relevant := func(obj client.Object) bool {
+		pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+		if !ok {
+			return false
+		}
+
+		if _, ok := pvc.Annotations[common.AnnotationPreviousSize]; !ok {
+			return false
+		}
+
+		return utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimControllerResizeError) ||
+			utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimFileSystemResizePending)
+	}
+
+	return predicate.NewPredicateFuncs(relevant)
+}
+
+// Reconcile drives offline-resize recovery for a single PersistentVolumeClaim.
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	logger := log.FromContext(ctx, "controller", ControllerName, "pvc", req.NamespacedName)
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := r.client.Get(ctx, req.NamespacedName, pvc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+
+		return reconcile.Result{}, fmt.Errorf("failed to get PersistentVolumeClaim: %w", err)
+	}
+
+	// Gate removal is intentionally unconditional: it is not gated on ownership or
+	// the PreferInPlace strategy. A gate could only ever have been added while the
+	// PVC was owned and the strategy was PreferInPlace, so if the PVC is no longer
+	// owned (e.g. the PVCA was deleted) or the strategy was flipped away since then,
+	// we must still remove the gate so the Pod is not stranded unschedulable forever.
+	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimFileSystemResizePending) {
+		return reconcile.Result{}, r.removeSchedulingGates(ctx, logger, pvc)
+	}
+
+	// Eviction is opt-in: only act on PVCs managed by a PVCA that belongs to this
+	// autoscaler instance and whose effective policy enables offline-resize recovery.
+	owner, policy, err := utils.FindOwningPVCAAndPolicy(ctx, r.client, r.autoscalerName, pvc)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to determine ownership of PersistentVolumeClaim: %w", err)
+	}
+	if owner == nil || policy == nil {
+		logger.Info("persistentvolumeclaim is not managed by this autoscaler instance, skipping")
+
+		return reconcile.Result{}, nil
+	}
+
+	if !utils.IsOfflineResizeEnabled(owner, policy) {
+		logger.Info("offline-resize recovery is not enabled for this persistentvolumeclaim, skipping")
+
+		return reconcile.Result{}, nil
+	}
+
+	if utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimControllerResizeError) {
+		return reconcile.Result{}, r.evictPodsUsingPVC(ctx, logger, pvc)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// evictPodsUsingPVC evicts all Pods that use the given PVC so that the volume can
+// be detached and resized offline. Eviction is used so PodDisruptionBudgets are
+// respected. Pods that are already terminating, not running, or not owned by a
+// workload controller are skipped.
+func (r *Reconciler) evictPodsUsingPVC(ctx context.Context, logger logr.Logger, pvc *corev1.PersistentVolumeClaim) error {
+	pods, err := r.podsUsingPVC(ctx, pvc)
+	if err != nil {
+		return err
+	}
+
+	var blocked bool
+	for i := range pods {
+		pod := &pods[i]
+
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+
+		if pod.Status.Phase != corev1.PodRunning {
+			logger.Info("pod is not running, skipping eviction", "pod", client.ObjectKeyFromObject(pod), "phase", pod.Status.Phase)
+
+			continue
+		}
+
+		logger.Info("evicting pod for offline resize", "pod", client.ObjectKeyFromObject(pod))
+		if err := r.evict(ctx, pod); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+
+			// A blocked eviction (e.g. PodDisruptionBudget) is not a hard error -
+			// record it and requeue so it is retried later. The k8s API returns 429 (too many requests) when
+			// eviction would violate the PodDisruptionBudget.
+			if apierrors.IsTooManyRequests(err) {
+				blocked = true
+				r.eventRecorder.Eventf(pod, corev1.EventTypeWarning, ReasonEvictionBlocked,
+					"eviction of pod %s for offline resize of PersistentVolumeClaim %s was blocked, will retry: %s",
+					client.ObjectKeyFromObject(pod), pvc.Name, err.Error())
+				logger.Info("eviction blocked, will retry", "pod", client.ObjectKeyFromObject(pod), "reason", err.Error())
+
+				continue
+			}
+
+			return fmt.Errorf("failed to evict pod %s: %w", client.ObjectKeyFromObject(pod), err)
+		}
+
+		r.eventRecorder.Eventf(pod, corev1.EventTypeNormal, ReasonEvicting,
+			"evicted pod %s so PersistentVolumeClaim %s can be resized offline",
+			client.ObjectKeyFromObject(pod), pvc.Name)
+	}
+
+	if blocked {
+		// Requeue via a returned error so at least one eviction is retried.
+		return fmt.Errorf("one or more pod evictions for offline resize of PersistentVolumeClaim %s were blocked", pvc.Name)
+	}
+
+	return nil
+}
+
+// evict evicts the given Pod via the pods/eviction subresource so that
+// PodDisruptionBudgets are respected. The API server returns a TooManyRequests
+// error when the eviction is blocked by a PodDisruptionBudget, which the caller
+// treats as retryable rather than fatal.
+func (r *Reconciler) evict(ctx context.Context, pod *corev1.Pod) error {
+	return r.client.SubResource("eviction").Create(ctx, pod, &policyv1.Eviction{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
+	})
+}
+
+// removeSchedulingGates removes the offline-resize scheduling gate from all Pods
+// that use the given PVC, allowing them to be scheduled so that, once they mount
+// the volume, the kubelet can complete the filesystem resize.
+func (r *Reconciler) removeSchedulingGates(ctx context.Context, logger logr.Logger, pvc *corev1.PersistentVolumeClaim) error {
+	pods, err := r.podsUsingPVC(ctx, pvc)
+	if err != nil {
+		return err
+	}
+
+	for i := range pods {
+		pod := &pods[i]
+
+		if !utils.HasSchedulingGate(pod, common.SchedulingGateOfflineResize) {
+			continue
+		}
+
+		patch := client.MergeFrom(pod.DeepCopy())
+		utils.RemoveSchedulingGate(pod, common.SchedulingGateOfflineResize)
+		if err := r.client.Patch(ctx, pod, patch); err != nil {
+			return fmt.Errorf("failed to remove scheduling gate from pod %s: %w", client.ObjectKeyFromObject(pod), err)
+		}
+
+		logger.Info("removed offline-resize scheduling gate from pod", "pod", client.ObjectKeyFromObject(pod))
+		r.eventRecorder.Eventf(pod, corev1.EventTypeNormal, ReasonGateRemoved,
+			"removed offline-resize scheduling gate from pod %s, PersistentVolumeClaim %s is ready for filesystem resize",
+			client.ObjectKeyFromObject(pod), pvc.Name)
+	}
+
+	return nil
+}
+
+// podsUsingPVC returns all Pods in the PVC's namespace that reference it via a
+// PersistentVolumeClaim volume.
+func (r *Reconciler) podsUsingPVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim) ([]corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	if err := r.client.List(ctx, podList, client.InNamespace(pvc.Namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list Pods: %w", err)
+	}
+
+	pods := make([]corev1.Pod, 0)
+	for i := range podList.Items {
+		for _, volume := range podList.Items[i].Spec.Volumes {
+			if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvc.Name {
+				pods = append(pods, podList.Items[i])
+
+				break
+			}
+		}
+	}
+
+	return pods, nil
+}

--- a/internal/controller/offlineresize/reconciler_test.go
+++ b/internal/controller/offlineresize/reconciler_test.go
@@ -1,0 +1,397 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package offlineresize_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
+	"github.com/gardener/pvc-autoscaler/internal/common"
+	"github.com/gardener/pvc-autoscaler/internal/controller/offlineresize"
+	testutils "github.com/gardener/pvc-autoscaler/test/utils"
+)
+
+var _ = Describe("Offline Resize Reconciler", func() {
+	var (
+		ctx        context.Context
+		reconciler *offlineresize.Reconciler
+
+		pvc  *corev1.PersistentVolumeClaim
+		pod  *corev1.Pod
+		pvca *v1alpha1.PersistentVolumeClaimAutoscaler
+	)
+
+	setPVCConditions := func(conditions ...corev1.PersistentVolumeClaimConditionType) {
+		GinkgoHelper()
+		patch := client.MergeFrom(pvc.DeepCopy())
+		pvc.Status.Phase = corev1.ClaimBound
+		for _, condType := range conditions {
+			pvc.Status.Conditions = append(pvc.Status.Conditions, corev1.PersistentVolumeClaimCondition{
+				Type:   condType,
+				Status: corev1.ConditionTrue,
+			})
+		}
+		Expect(k8sClient.Status().Patch(ctx, pvc, patch)).To(Succeed())
+		Eventually(func(g Gomega) {
+			observed := &corev1.PersistentVolumeClaim{}
+			g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(pvc), observed)).To(Succeed())
+			g.Expect(observed.Status.Conditions).To(HaveLen(len(conditions)))
+		}).Should(Succeed())
+	}
+
+	setPodPhase := func(phase corev1.PodPhase) {
+		GinkgoHelper()
+		patch := client.MergeFrom(pod.DeepCopy())
+		pod.Status.Phase = phase
+		Expect(k8sClient.Status().Patch(ctx, pod, patch)).To(Succeed())
+		Eventually(func(g Gomega) {
+			observed := &corev1.Pod{}
+			g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(pod), observed)).To(Succeed())
+			g.Expect(observed.Status.Phase).To(Equal(phase))
+		}).Should(Succeed())
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		var err error
+		reconciler, err = offlineresize.New(
+			offlineresize.WithClient(mgrClient),
+			offlineresize.WithEventRecorder(eventRecorder),
+			offlineresize.WithAutoscalerName(""),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		pvc = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+				Annotations: map[string]string{
+					common.AnnotationPreviousSize: "10Gi",
+				},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: ptr.To(testutils.StorageClassName),
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				VolumeMode:       ptr.To(corev1.PersistentVolumeFilesystem),
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+				},
+			},
+		}
+
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c", Image: "nginx"}},
+				Volumes: []corev1.Volume{{
+					Name: "data",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvc.Name},
+					},
+				}},
+			},
+		}
+
+		pvca = &v1alpha1.PersistentVolumeClaimAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pvca", Namespace: "default"},
+			Spec: v1alpha1.PersistentVolumeClaimAutoscalerSpec{
+				TargetRef: autoscalingv1.CrossVersionObjectReference{
+					Kind:       "StatefulSet",
+					Name:       "test-sts",
+					APIVersion: "apps/v1",
+				},
+				VolumePolicies: []v1alpha1.VolumePolicy{{
+					Match:       v1alpha1.Match{Name: "*"},
+					MaxCapacity: resource.MustParse("100Gi"),
+					ScaleUp:     &v1alpha1.ScalingRules{ResizeStrategy: v1alpha1.PreferInPlaceVolumeResizeStrategy},
+				}},
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, pvc)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(testutils.CleanupObject(ctx, k8sClient, pvc)).To(Succeed())
+		})
+
+		Eventually(func() error {
+			return mgrClient.Get(ctx, client.ObjectKeyFromObject(pvc), &corev1.PersistentVolumeClaim{})
+		}).Should(Succeed())
+	})
+
+	JustBeforeEach(func() {
+		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(testutils.CleanupObject(ctx, k8sClient, pod)).To(Succeed())
+		})
+
+		Eventually(func() error {
+			return mgrClient.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{})
+		}).Should(Succeed())
+
+		setPodPhase(corev1.PodRunning)
+	})
+
+	Context("PVC managed by this autoscaler instance", func() {
+		BeforeEach(func() {
+			Expect(k8sClient.Create(ctx, pvca)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(testutils.CleanupObject(ctx, k8sClient, pvca)).To(Succeed())
+			})
+
+			patch := client.MergeFrom(pvca.DeepCopy())
+			pvca.Status.VolumeRecommendations = []v1alpha1.VolumeRecommendation{{Name: pvc.Name}}
+			Expect(k8sClient.Status().Patch(ctx, pvca, patch)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				observed := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+				g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(pvca), observed)).To(Succeed())
+				g.Expect(observed.Status.VolumeRecommendations).To(HaveLen(1))
+			}).Should(Succeed())
+		})
+
+		When("the PVC has the ControllerResizeError condition", func() {
+			BeforeEach(func() {
+				setPVCConditions(corev1.PersistentVolumeClaimControllerResizeError)
+			})
+
+			It("should evict the pod using the PVC", func() {
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pvc)})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				Eventually(func() bool {
+					return apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{}))
+				}).Should(BeTrue())
+			})
+
+			When("the pod is not running", func() {
+				JustBeforeEach(func() {
+					setPodPhase(corev1.PodPending)
+				})
+
+				It("should not evict the pod", func() {
+					result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pvc)})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(reconcile.Result{}))
+
+					Consistently(func() error {
+						return k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{})
+					}).Should(Succeed())
+				})
+			})
+
+			When("the resize strategy is not PreferInPlace", func() {
+				setStrategy := func(strategy v1alpha1.VolumeResizeStrategy) {
+					GinkgoHelper()
+					patch := client.MergeFrom(pvca.DeepCopy())
+					pvca.Spec.VolumePolicies[0].ScaleUp.ResizeStrategy = strategy
+					Expect(k8sClient.Patch(ctx, pvca, patch)).To(Succeed())
+					Eventually(func(g Gomega) {
+						observed := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+						g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(pvca), observed)).To(Succeed())
+						g.Expect(observed.Spec.VolumePolicies[0].ScaleUp.ResizeStrategy).To(Equal(strategy))
+					}).Should(Succeed())
+				}
+
+				When("the strategy is InPlace", func() {
+					BeforeEach(func() {
+						setStrategy(v1alpha1.InPlaceVolumeResizeStrategy)
+					})
+
+					It("should not evict the pod", func() {
+						result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pvc)})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(result).To(Equal(reconcile.Result{}))
+
+						Consistently(func() error {
+							return k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{})
+						}).Should(Succeed())
+					})
+				})
+
+				When("the strategy is Off", func() {
+					BeforeEach(func() {
+						setStrategy(v1alpha1.OffVolumeResizeStrategy)
+					})
+
+					It("should not evict the pod", func() {
+						result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pvc)})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(result).To(Equal(reconcile.Result{}))
+
+						Consistently(func() error {
+							return k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{})
+						}).Should(Succeed())
+					})
+				})
+			})
+
+			When("the PVCA targets a PersistentVolumeClaim directly", func() {
+				BeforeEach(func() {
+					patch := client.MergeFrom(pvca.DeepCopy())
+					pvca.Spec.TargetRef = autoscalingv1.CrossVersionObjectReference{
+						Kind:       "PersistentVolumeClaim",
+						Name:       pvc.Name,
+						APIVersion: "v1",
+					}
+					Expect(k8sClient.Patch(ctx, pvca, patch)).To(Succeed())
+					Eventually(func(g Gomega) {
+						observed := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+						g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(pvca), observed)).To(Succeed())
+						g.Expect(observed.Spec.TargetRef.Kind).To(Equal("PersistentVolumeClaim"))
+					}).Should(Succeed())
+				})
+
+				It("should not evict the pod", func() {
+					result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pvc)})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(reconcile.Result{}))
+
+					Consistently(func() error {
+						return k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{})
+					}).Should(Succeed())
+				})
+			})
+
+		})
+
+		When("the PVC has no ControllerResizeError condition", func() {
+			It("should not evict the pod", func() {
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pvc)})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				Consistently(func() error {
+					return k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{})
+				}).Should(Succeed())
+			})
+		})
+
+		When("the PVC has the FileSystemResizePending condition", func() {
+			BeforeEach(func() {
+				setPVCConditions(corev1.PersistentVolumeClaimFileSystemResizePending)
+			})
+
+			When("the pod carries the offline-resize scheduling gate", func() {
+				BeforeEach(func() {
+					pod.Spec.SchedulingGates = []corev1.PodSchedulingGate{{Name: common.SchedulingGateOfflineResize}}
+				})
+
+				It("should remove the offline-resize scheduling gate", func() {
+					result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pvc)})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(reconcile.Result{}))
+
+					Eventually(func(g Gomega) {
+						updated := &corev1.Pod{}
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), updated)).To(Succeed())
+						g.Expect(updated.Spec.SchedulingGates).To(BeEmpty())
+					}).Should(Succeed())
+				})
+
+				When("the resize strategy has since been flipped to InPlace", func() {
+					BeforeEach(func() {
+						patch := client.MergeFrom(pvca.DeepCopy())
+						pvca.Spec.VolumePolicies[0].ScaleUp.ResizeStrategy = v1alpha1.InPlaceVolumeResizeStrategy
+						Expect(k8sClient.Patch(ctx, pvca, patch)).To(Succeed())
+						Eventually(func(g Gomega) {
+							observed := &v1alpha1.PersistentVolumeClaimAutoscaler{}
+							g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(pvca), observed)).To(Succeed())
+							g.Expect(observed.Spec.VolumePolicies[0].ScaleUp.ResizeStrategy).To(Equal(v1alpha1.InPlaceVolumeResizeStrategy))
+						}).Should(Succeed())
+					})
+
+					It("should remove the offline-resize scheduling gate", func() {
+						result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pvc)})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(result).To(Equal(reconcile.Result{}))
+
+						Eventually(func(g Gomega) {
+							updated := &corev1.Pod{}
+							g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), updated)).To(Succeed())
+							g.Expect(updated.Spec.SchedulingGates).To(BeEmpty())
+						}).Should(Succeed())
+					})
+				})
+			})
+
+			When("the pod has no scheduling gate", func() {
+				It("should leave the pod untouched", func() {
+					result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pvc)})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(reconcile.Result{}))
+
+					updated := &corev1.Pod{}
+					Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), updated)).To(Succeed())
+					Expect(updated.Spec.SchedulingGates).To(BeEmpty())
+				})
+			})
+		})
+
+		When("the PVC has both ControllerResizeError and FileSystemResizePending", func() {
+			BeforeEach(func() {
+				pod.Spec.SchedulingGates = []corev1.PodSchedulingGate{{Name: common.SchedulingGateOfflineResize}}
+
+				setPVCConditions(
+					corev1.PersistentVolumeClaimControllerResizeError,
+					corev1.PersistentVolumeClaimFileSystemResizePending,
+				)
+			})
+
+			It("should remove the gate and not evict the pod", func() {
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pvc)})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				Eventually(func(g Gomega) {
+					updated := &corev1.Pod{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), updated)).To(Succeed())
+					g.Expect(updated.Spec.SchedulingGates).To(BeEmpty())
+					g.Expect(updated.DeletionTimestamp).To(BeNil())
+				}).Should(Succeed())
+			})
+		})
+	})
+
+	Context("PVC not managed by any PVCA of this instance", func() {
+		When("the PVC has the ControllerResizeError condition", func() {
+			BeforeEach(func() {
+				setPVCConditions(corev1.PersistentVolumeClaimControllerResizeError)
+			})
+
+			It("should not evict the pod", func() {
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pvc)})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				Consistently(func() error {
+					return k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{})
+				}).Should(Succeed())
+			})
+		})
+	})
+
+	Context("PVC no longer exists", func() {
+		It("should do nothing", func() {
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: client.ObjectKey{Namespace: "default", Name: "does-not-exist"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+		})
+	})
+})

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -342,11 +342,18 @@ func (r *Runner) reconcilePVCA(
 
 	volumeRecommendations := make([]v1alpha1.VolumeRecommendation, 0, len(pvcs))
 	for _, volumeRecommendation := range pvca.Status.VolumeRecommendations {
-		if slices.ContainsFunc(pvcs, func(pvc *corev1.PersistentVolumeClaim) bool {
+		if !slices.ContainsFunc(pvcs, func(pvc *corev1.PersistentVolumeClaim) bool {
 			return pvc.Name == volumeRecommendation.Name
 		}) {
-			volumeRecommendations = append(volumeRecommendations, volumeRecommendation)
+			continue
 		}
+
+		policy, err := getVolumePolicy(volumeRecommendation.Name, pvca.Spec.VolumePolicies)
+		if err != nil || policy == nil {
+			continue
+		}
+
+		volumeRecommendations = append(volumeRecommendations, volumeRecommendation)
 	}
 
 	for _, pvc := range pvcs {
@@ -393,12 +400,6 @@ func (r *Runner) reconcilePVCA(
 
 		if policy == nil {
 			logger.Info("skipping persistentvolumeclaim", "reason", "no matching volume policy")
-			recommendationConditions.addCondition(metav1.Condition{
-				Type:    string(v1alpha1.ConditionTypeRecommendationAvailable),
-				Status:  metav1.ConditionFalse,
-				Reason:  ReasonRecommendationError,
-				Message: fmt.Sprintf("%s: no matching volume policy", pvcObjKey.Name),
-			})
 
 			continue
 		}

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"path"
 	"slices"
 	"strings"
 	"time"
@@ -348,7 +347,7 @@ func (r *Runner) reconcilePVCA(
 			continue
 		}
 
-		policy, err := getVolumePolicy(volumeRecommendation.Name, pvca.Spec.VolumePolicies)
+		policy, err := utils.GetVolumePolicy(volumeRecommendation.Name, pvca.Spec.VolumePolicies)
 		if err != nil || policy == nil {
 			continue
 		}
@@ -385,7 +384,7 @@ func (r *Runner) reconcilePVCA(
 			continue
 		}
 
-		policy, err := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
+		policy, err := utils.GetVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
 		if err != nil {
 			logger.Info("skipping persistentvolumeclaim", "reason", err.Error())
 			recommendationConditions.addCondition(metav1.Condition{
@@ -493,24 +492,6 @@ func (r *Runner) updateVolumeRecommendationForPVC(volumeRecommendations []v1alph
 	}
 
 	return volumeRecommendation, nil
-}
-
-// getVolumePolicy returns the VolumePolicy for a given [corev1.PersistentVolumeClaim] name.
-// It returns nil if there is no policy specified for the [corev1.PersistentVolumeClaim].
-// Policies are evaluated in the order they appear in the list, and the first
-// matching policy is returned.
-func getVolumePolicy(pvcName string, volumePolicies []v1alpha1.VolumePolicy) (*v1alpha1.VolumePolicy, error) {
-	for _, volumePolicy := range volumePolicies {
-		matched, err := path.Match(volumePolicy.Match.Name, pvcName)
-		if err != nil {
-			return nil, fmt.Errorf("invalid volume policy name %q: %w", volumePolicy.Match.Name, err)
-		}
-		if matched {
-			return &volumePolicy, nil
-		}
-	}
-
-	return nil, nil
 }
 
 // getOrCreateVolumeRecommendationForPVC returns the [v1alpha1.VolumeRecommendation] for

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -855,50 +855,31 @@ var _ = Describe("Periodic Runner", func() {
 				)))
 			})
 
-			It("should set RecommendationAvailable condition to false when no matching volume policy exists", func() {
-				By("Creating a PVC that has no volumePolicy match")
-				noMatchPVC := createPVC(parentCtx, "no-match-pvc", ptr.To(testutils.StorageClassName), nil)
-				DeferCleanup(func() {
-					By("Deleting no-match PVC")
-					Expect(testutils.CleanupObject(parentCtx, k8sClient, noMatchPVC)).To(Succeed())
-					Eventually(func() error {
-						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(noMatchPVC), noMatchPVC)
-					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
-				})
+			It("should drop a stale volume recommendation when its PVC no longer matches a policy", func() {
+				By("Seeding the PVCA status with a recommendation for the PVC")
+				patch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Status.VolumeRecommendations = []v1alpha1.VolumeRecommendation{{Name: pvc.Name}}
+				Expect(k8sClient.Status().Patch(parentCtx, pvca, patch)).To(Succeed())
 
-				By("Creating a PVCA with only a named policy that doesn't match the PVC")
-				noMatchTargetRef := autoscalingv1.CrossVersionObjectReference{
-					APIVersion: "v1",
-					Kind:       "PersistentVolumeClaim",
-					Name:       noMatchPVC.Name,
-				}
-				noMatchPVCA := createPVCA(parentCtx, "pvca-no-match", "", noMatchTargetRef, []v1alpha1.VolumePolicy{
+				By("Changing the volume policy so it no longer matches the PVC")
+				pvcaPatch := client.MergeFrom(pvca.DeepCopy())
+				pvca.Spec.VolumePolicies = []v1alpha1.VolumePolicy{
 					{
-						Match: v1alpha1.Match{
-							Name: "non-matching-pvc-name",
-						},
-						MaxCapacity: resource.MustParse("10Gi"),
+						Match:       v1alpha1.Match{Name: "does-not-match-*"},
+						MaxCapacity: resource.MustParse("3Gi"),
 					},
-				})
-				DeferCleanup(func() {
-					By("Deleting no-match PVCA")
-					Expect(testutils.CleanupObject(parentCtx, k8sClient, noMatchPVCA)).To(Succeed())
-					Eventually(func() error {
-						return k8sClient.Get(parentCtx, client.ObjectKeyFromObject(noMatchPVCA), noMatchPVCA)
-					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
-				})
+				}
+				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
+				waitForPVCACacheSync(parentCtx, pvca)
 
 				Expect(runner.reconcileAll(parentCtx)).To(Succeed())
 
-				By("Verifying the RecommendationAvailable condition indicates no matching policy")
+				By("Verifying the stale recommendation was pruned from the status")
 				updatedPVCA := &v1alpha1.PersistentVolumeClaimAutoscaler{}
-				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(noMatchPVCA), updatedPVCA)).To(Succeed())
-				Expect(updatedPVCA.Status.Conditions).To(ContainElement(And(
-					HaveField("Type", string(v1alpha1.ConditionTypeRecommendationAvailable)),
-					HaveField("Status", metav1.ConditionFalse),
-					HaveField("Reason", ReasonRecommendationError),
-					HaveField("Message", ContainSubstring("no matching volume policy")),
-				)))
+				Expect(k8sClient.Get(parentCtx, client.ObjectKeyFromObject(pvca), updatedPVCA)).To(Succeed())
+				Expect(updatedPVCA.Status.VolumeRecommendations).NotTo(ContainElement(
+					HaveField("Name", pvc.Name),
+				))
 			})
 
 			It("should set Resizing to Unknown on PVC fetch failure when it was previously set", func() {

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -185,139 +185,6 @@ var _ = Describe("Periodic Runner", func() {
 		})
 	})
 
-	Context("getVolumePolicy", func() {
-		It("should return error on invalid glob pattern", func() {
-			volumePolicies := []v1alpha1.VolumePolicy{
-				{
-					Match: v1alpha1.Match{
-						Name: "[",
-					},
-					MaxCapacity: resource.MustParse("10Gi"),
-				},
-			}
-
-			policy, err := getVolumePolicy("data-pvc", volumePolicies)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("invalid volume policy name \"[\""))
-			Expect(policy).To(BeNil())
-		})
-
-		It("should return nil when no policy matches", func() {
-			volumePolicies := []v1alpha1.VolumePolicy{
-				{
-					Match: v1alpha1.Match{
-						Name: "other-pvc",
-					},
-					MaxCapacity: resource.MustParse("10Gi"),
-				},
-			}
-
-			policy, err := getVolumePolicy("data-pvc", volumePolicies)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(policy).To(BeNil())
-		})
-
-		It("should match exact name", func() {
-			volumePolicies := []v1alpha1.VolumePolicy{
-				{
-					Match: v1alpha1.Match{
-						Name: "data-pvc",
-					},
-					MaxCapacity: resource.MustParse("10Gi"),
-				},
-			}
-
-			policy, err := getVolumePolicy("data-pvc", volumePolicies)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(policy).NotTo(BeNil())
-			Expect(policy.Match.Name).To(Equal("data-pvc"))
-		})
-
-		It("should match glob pattern", func() {
-			volumePolicies := []v1alpha1.VolumePolicy{
-				{
-					Match: v1alpha1.Match{
-						Name: "*-logs",
-					},
-					MaxCapacity: resource.MustParse("15Gi"),
-				},
-			}
-
-			policy, err := getVolumePolicy("app-logs", volumePolicies)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(policy).NotTo(BeNil())
-			Expect(policy.Match.Name).To(Equal("*-logs"))
-		})
-
-		It("should match default policy", func() {
-			volumePolicies := []v1alpha1.VolumePolicy{
-				{
-					Match: v1alpha1.Match{
-						Name: "*",
-					},
-					MaxCapacity: resource.MustParse("5Gi"),
-				},
-			}
-
-			policy, err := getVolumePolicy("data-pvc", volumePolicies)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(policy).NotTo(BeNil())
-			Expect(policy.Match.Name).To(Equal("*"))
-		})
-
-		It("should fall back to default policy when no other policy matches", func() {
-			volumePolicies := []v1alpha1.VolumePolicy{
-				{
-					Match: v1alpha1.Match{
-						Name: "other-pvc",
-					},
-					MaxCapacity: resource.MustParse("20Gi"),
-				},
-				{
-					Match: v1alpha1.Match{
-						Name: "*",
-					},
-					MaxCapacity: resource.MustParse("5Gi"),
-				},
-			}
-
-			policy, err := getVolumePolicy("data-pvc", volumePolicies)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(policy).NotTo(BeNil())
-			Expect(policy.Match.Name).To(Equal("*"))
-			Expect(policy.MaxCapacity).To(Equal(resource.MustParse("5Gi")))
-		})
-
-		It("should return first seen matching policy", func() {
-			volumePolicies := []v1alpha1.VolumePolicy{
-				{
-					Match: v1alpha1.Match{
-						Name: "data-*",
-					},
-					MaxCapacity: resource.MustParse("10Gi"),
-				},
-				{
-					Match: v1alpha1.Match{
-						Name: "data-pvc",
-					},
-					MaxCapacity: resource.MustParse("20Gi"),
-				},
-				{
-					Match: v1alpha1.Match{
-						Name: "*",
-					},
-					MaxCapacity: resource.MustParse("5Gi"),
-				},
-			}
-
-			policy, err := getVolumePolicy("data-pvc", volumePolicies)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(policy).NotTo(BeNil())
-			Expect(policy.Match.Name).To(Equal("data-*"))
-			Expect(policy.MaxCapacity).To(Equal(resource.MustParse("10Gi")))
-		})
-	})
-
 	Context("With runner instance", func() {
 		var (
 			runner                *Runner
@@ -499,10 +366,7 @@ var _ = Describe("Periodic Runner", func() {
 					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 				})
 
-				volumePolicy, err := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(volumePolicy).NotTo(BeNil())
-				err = runner.validatePVC(parentCtx, pvc, *volumePolicy)
+				err := runner.validatePVC(parentCtx, pvc, pvca.Spec.VolumePolicies[0])
 				Expect(err).To(MatchError(ErrStorageClassNotFound))
 			})
 
@@ -552,10 +416,7 @@ var _ = Describe("Periodic Runner", func() {
 					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 				})
 
-				volumePolicy, err := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(volumePolicy).NotTo(BeNil())
-				err = runner.validatePVC(parentCtx, pvc, *volumePolicy)
+				err := runner.validatePVC(parentCtx, pvc, pvca.Spec.VolumePolicies[0])
 				Expect(err).To(MatchError(ErrStorageClassDoesNotSupportExpansion))
 			})
 
@@ -586,10 +447,7 @@ var _ = Describe("Periodic Runner", func() {
 					}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 				})
 
-				volumePolicy, err := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(volumePolicy).NotTo(BeNil())
-				err = runner.validatePVC(parentCtx, pvc, *volumePolicy)
+				err := runner.validatePVC(parentCtx, pvc, pvca.Spec.VolumePolicies[0])
 				Expect(err).To(MatchError(ErrVolumeModeIsNotFilesystem))
 			})
 
@@ -599,10 +457,7 @@ var _ = Describe("Periodic Runner", func() {
 				pvc.Status.Phase = corev1.ClaimLost
 				Expect(k8sClient.Status().Patch(parentCtx, pvc, patch)).To(Succeed())
 
-				volumePolicy, err := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(volumePolicy).NotTo(BeNil())
-				err = runner.validatePVC(parentCtx, pvc, *volumePolicy)
+				err := runner.validatePVC(parentCtx, pvc, pvca.Spec.VolumePolicies[0])
 				Expect(err).To(MatchError(ErrPVCNotBound))
 			})
 		})
@@ -617,11 +472,7 @@ var _ = Describe("Periodic Runner", func() {
 					},
 				}
 
-				volumePolicy, err := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(volumePolicy).NotTo(BeNil())
-
-				ok, reason := runner.shouldResizePVC(pvc, *volumePolicy, volumeRecommendation)
+				ok, reason := runner.shouldResizePVC(pvc, pvca.Spec.VolumePolicies[0], volumeRecommendation)
 				Expect(ok).To(BeFalse())
 				Expect(reason).To(BeEmpty())
 			})
@@ -650,11 +501,7 @@ var _ = Describe("Periodic Runner", func() {
 						},
 					}
 
-					volumePolicy, err := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(volumePolicy).NotTo(BeNil())
-
-					ok, reason := testRunner.shouldResizePVC(pvc, *volumePolicy, volumeRecommendation)
+					ok, reason := testRunner.shouldResizePVC(pvc, pvca.Spec.VolumePolicies[0], volumeRecommendation)
 					Expect(ok).To(BeTrue())
 					Expect(reason).To(Equal("passing storage threshold"))
 
@@ -672,11 +519,7 @@ var _ = Describe("Periodic Runner", func() {
 						},
 					}
 
-					volumePolicy, err := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(volumePolicy).NotTo(BeNil())
-
-					ok, reason := testRunner.shouldResizePVC(pvc, *volumePolicy, volumeRecommendation)
+					ok, reason := testRunner.shouldResizePVC(pvc, pvca.Spec.VolumePolicies[0], volumeRecommendation)
 					Expect(ok).To(BeTrue())
 					Expect(reason).To(Equal("passing inodes threshold"))
 
@@ -1542,9 +1385,7 @@ var _ = Describe("Periodic Runner", func() {
 					logger := zap.New(zap.WriteTo(w))
 
 					aggregator := &resizingConditionAggregator{}
-					volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
-					Expect(errPolicy).NotTo(HaveOccurred())
-					updatedRecommendation, err := runner.resizePVC(parentCtx, logger, pvc, *volumePolicy, reason, volumeRecommendation, aggregator)
+					updatedRecommendation, err := runner.resizePVC(parentCtx, logger, pvc, pvca.Spec.VolumePolicies[0], reason, volumeRecommendation, aggregator)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(buf.String()).To(ContainSubstring(expectedLogSubstring))
 
@@ -1596,9 +1437,7 @@ var _ = Describe("Periodic Runner", func() {
 
 				By("Performing first resize")
 				aggregator := &resizingConditionAggregator{}
-				volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
-				Expect(errPolicy).NotTo(HaveOccurred())
-				volumeRecommendation, err := runner.resizePVC(parentCtx, logger, pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+				volumeRecommendation, err := runner.resizePVC(parentCtx, logger, pvc, pvca.Spec.VolumePolicies[0], "passing storage threshold", volumeRecommendation, aggregator)
 				Expect(err).NotTo(HaveOccurred())
 
 				wantLog := `"resizing persistent volume claim","pvc":"test-pvc","from":"1Gi","to":"2Gi"}`
@@ -1617,9 +1456,7 @@ var _ = Describe("Periodic Runner", func() {
 
 				By("Performing second resize")
 				aggregator = &resizingConditionAggregator{}
-				volumePolicy, errPolicy = getVolumePolicy(resizedPvc.Name, pvca.Spec.VolumePolicies)
-				Expect(errPolicy).NotTo(HaveOccurred())
-				volumeRecommendation, err = runner.resizePVC(parentCtx, logger, &resizedPvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+				volumeRecommendation, err = runner.resizePVC(parentCtx, logger, &resizedPvc, pvca.Spec.VolumePolicies[0], "passing storage threshold", volumeRecommendation, aggregator)
 				Expect(err).NotTo(HaveOccurred())
 
 				wantLog = `"resizing persistent volume claim","pvc":"test-pvc","from":"2Gi","to":"3Gi"}`
@@ -1637,9 +1474,7 @@ var _ = Describe("Periodic Runner", func() {
 
 				By("Expecting third attempt to fail with max capacity reached (already at max)")
 				aggregator = &resizingConditionAggregator{}
-				volumePolicy, errPolicy = getVolumePolicy(resizedPvc.Name, pvca.Spec.VolumePolicies)
-				Expect(errPolicy).NotTo(HaveOccurred())
-				_, err = runner.resizePVC(parentCtx, logger, &resizedPvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+				_, err = runner.resizePVC(parentCtx, logger, &resizedPvc, pvca.Spec.VolumePolicies[0], "passing storage threshold", volumeRecommendation, aggregator)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(buf.String()).To(ContainSubstring("max capacity reached"))
 
@@ -1669,9 +1504,7 @@ var _ = Describe("Periodic Runner", func() {
 					Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
 
 					aggregator := &resizingConditionAggregator{}
-					volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
-					Expect(errPolicy).NotTo(HaveOccurred())
-					_, err := runner.resizePVC(parentCtx, logger, pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+					_, err := runner.resizePVC(parentCtx, logger, pvc, pvca.Spec.VolumePolicies[0], "passing storage threshold", volumeRecommendation, aggregator)
 					Expect(err).NotTo(HaveOccurred())
 
 					var updatedPvc corev1.PersistentVolumeClaim
@@ -1719,9 +1552,7 @@ var _ = Describe("Periodic Runner", func() {
 
 					beforeResize := time.Now()
 					aggregator := &resizingConditionAggregator{}
-					volumePolicy, errPolicy := getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
-					Expect(errPolicy).NotTo(HaveOccurred())
-					updatedRecommendation, err := runner.resizePVC(parentCtx, logger, pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+					updatedRecommendation, err := runner.resizePVC(parentCtx, logger, pvc, pvca.Spec.VolumePolicies[0], "passing storage threshold", volumeRecommendation, aggregator)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(buf.String()).To(ContainSubstring(expectedLog))
 
@@ -1751,10 +1582,9 @@ var _ = Describe("Periodic Runner", func() {
 
 		Describe("resize strategies", func() {
 			var (
-				strategy     v1alpha1.VolumeResizeStrategy
-				logOutput    strings.Builder
-				aggregator   *resizingConditionAggregator
-				volumePolicy *v1alpha1.VolumePolicy
+				strategy   v1alpha1.VolumeResizeStrategy
+				logOutput  strings.Builder
+				aggregator *resizingConditionAggregator
 			)
 
 			BeforeEach(func() {
@@ -1767,10 +1597,6 @@ var _ = Describe("Periodic Runner", func() {
 				pvca.Spec.VolumePolicies[0].ScaleUp.ResizeStrategy = strategy
 				Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
 				waitForPVCACacheSync(parentCtx, pvca)
-
-				var err error
-				volumePolicy, err = getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
-				Expect(err).NotTo(HaveOccurred())
 			})
 
 			When("using InPlace strategy", func() {
@@ -1783,7 +1609,7 @@ var _ = Describe("Periodic Runner", func() {
 						Name:    pvc.Name,
 						Current: v1alpha1.CurrentVolumeStatus{UsedSpacePercent: ptr.To(95)},
 					}
-					_, err := runner.resizePVC(parentCtx, zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &logOutput))), pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+					_, err := runner.resizePVC(parentCtx, zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &logOutput))), pvc, pvca.Spec.VolumePolicies[0], "passing storage threshold", volumeRecommendation, aggregator)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(logOutput.String()).To(ContainSubstring("resizing persistent volume claim"))
@@ -1807,8 +1633,7 @@ var _ = Describe("Periodic Runner", func() {
 						Name:    pvc.Name,
 						Current: v1alpha1.CurrentVolumeStatus{UsedSpacePercent: ptr.To(95)},
 					}
-					volumePolicy, _ = getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
-					_, err := runner.resizePVC(parentCtx, zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &logOutput))), pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+					_, err := runner.resizePVC(parentCtx, zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &logOutput))), pvc, pvca.Spec.VolumePolicies[0], "passing storage threshold", volumeRecommendation, aggregator)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(logOutput.String()).To(ContainSubstring("max capacity reached"))
@@ -1830,7 +1655,7 @@ var _ = Describe("Periodic Runner", func() {
 						Name:    pvc.Name,
 						Current: v1alpha1.CurrentVolumeStatus{UsedSpacePercent: ptr.To(95)},
 					}
-					updatedRecommendation, err := runner.resizePVC(parentCtx, zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &logOutput))), pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+					updatedRecommendation, err := runner.resizePVC(parentCtx, zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &logOutput))), pvc, pvca.Spec.VolumePolicies[0], "passing storage threshold", volumeRecommendation, aggregator)
 					Expect(err).NotTo(HaveOccurred())
 
 					var pvcObj corev1.PersistentVolumeClaim
@@ -1846,13 +1671,12 @@ var _ = Describe("Periodic Runner", func() {
 					pvca.Spec.VolumePolicies[0].MaxCapacity = resource.MustParse("1500Mi")
 					Expect(k8sClient.Patch(parentCtx, pvca, pvcaPatch)).To(Succeed())
 					waitForPVCACacheSync(parentCtx, pvca)
-					volumePolicy, _ = getVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
 
 					volumeRecommendation := v1alpha1.VolumeRecommendation{
 						Name:    pvc.Name,
 						Current: v1alpha1.CurrentVolumeStatus{UsedSpacePercent: ptr.To(95)},
 					}
-					_, err := runner.resizePVC(parentCtx, zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &logOutput))), pvc, *volumePolicy, "passing storage threshold", volumeRecommendation, aggregator)
+					_, err := runner.resizePVC(parentCtx, zap.New(zap.WriteTo(io.MultiWriter(GinkgoWriter, &logOutput))), pvc, pvca.Spec.VolumePolicies[0], "passing storage threshold", volumeRecommendation, aggregator)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(logOutput.String()).To(ContainSubstring("max capacity reached"))

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -5,12 +5,18 @@
 package utils
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"path"
 	"slices"
 	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 )
 
 // ErrBadPercentageValue is an error which is returned when attempting to parse
@@ -79,4 +85,61 @@ func RemoveSchedulingGate(pod *corev1.Pod, name string) {
 	pod.Spec.SchedulingGates = slices.DeleteFunc(pod.Spec.SchedulingGates, func(gate corev1.PodSchedulingGate) bool {
 		return gate.Name == name
 	})
+}
+
+// FindOwningPVCAAndPolicy returns the PersistentVolumeClaimAutoscaler that manages the
+// given PersistentVolumeClaim and whose spec.autoscalerName matches the given
+// autoscalerName, together with the VolumePolicy that applies to the PVC, or
+// (nil, nil) if the PVC is not managed by any such PVCA.
+func FindOwningPVCAAndPolicy(ctx context.Context, c client.Client, autoscalerName string, pvc *corev1.PersistentVolumeClaim) (*v1alpha1.PersistentVolumeClaimAutoscaler, *v1alpha1.VolumePolicy, error) {
+	pvcaList := &v1alpha1.PersistentVolumeClaimAutoscalerList{}
+	if err := c.List(ctx, pvcaList, client.InNamespace(pvc.Namespace), client.MatchingFields{v1alpha1.AutoscalerNameIndexKey: autoscalerName}); err != nil {
+		return nil, nil, fmt.Errorf("failed to list PersistentVolumeClaimAutoscalers: %w", err)
+	}
+
+	for i := range pvcaList.Items {
+		pvca := &pvcaList.Items[i]
+
+		if slices.ContainsFunc(pvca.Status.VolumeRecommendations, func(vr v1alpha1.VolumeRecommendation) bool {
+			return vr.Name == pvc.Name
+		}) {
+			policy, err := GetVolumePolicy(pvc.Name, pvca.Spec.VolumePolicies)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			return pvca, policy, nil
+		}
+	}
+
+	return nil, nil, nil
+}
+
+// GetVolumePolicy returns the VolumePolicy for the given PersistentVolumeClaim
+// name. Policies are evaluated in list order and the first policy whose match
+// glob matches the name is returned. It returns nil if no policy matches.
+func GetVolumePolicy(pvcName string, volumePolicies []v1alpha1.VolumePolicy) (*v1alpha1.VolumePolicy, error) {
+	for i := range volumePolicies {
+		matched, err := path.Match(volumePolicies[i].Match.Name, pvcName)
+		if err != nil {
+			return nil, fmt.Errorf("invalid volume policy name %q: %w", volumePolicies[i].Match.Name, err)
+		}
+		if matched {
+			return &volumePolicies[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+// IsOfflineResizeEnabled reports whether the given PersistentVolumeClaimAutoscaler
+// and the VolumePolicy that applies to a PVC it manages opt into offline-resize
+// recovery. This requires that both both the policy's scaleUp.resizeStrategy is PreferInPlace,
+// and the PVCA targets a workload controller rather than a PersistentVolumeClaim directly.
+func IsOfflineResizeEnabled(pvca *v1alpha1.PersistentVolumeClaimAutoscaler, policy *v1alpha1.VolumePolicy) bool {
+	return pvca != nil &&
+		pvca.Spec.TargetRef.Kind != "PersistentVolumeClaim" &&
+		policy != nil &&
+		policy.ScaleUp != nil &&
+		policy.ScaleUp.ResizeStrategy == v1alpha1.PreferInPlaceVolumeResizeStrategy
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"errors"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -52,4 +53,30 @@ func IsPersistentVolumeClaimConditionPresentAndEqual(obj *corev1.PersistentVolum
 	}
 
 	return false
+}
+
+// HasSchedulingGate returns whether the given Pod already has a scheduling gate
+// with the given name in its spec.
+func HasSchedulingGate(pod *corev1.Pod, name string) bool {
+	return slices.ContainsFunc(pod.Spec.SchedulingGates, func(gate corev1.PodSchedulingGate) bool {
+		return gate.Name == name
+	})
+}
+
+// AddSchedulingGate adds a scheduling gate with the given name to the Pod's spec,
+// if it is not already present.
+func AddSchedulingGate(pod *corev1.Pod, name string) {
+	if HasSchedulingGate(pod, name) {
+		return
+	}
+
+	pod.Spec.SchedulingGates = append(pod.Spec.SchedulingGates, corev1.PodSchedulingGate{Name: name})
+}
+
+// RemoveSchedulingGate removes the scheduling gate with the given name from the
+// Pod's spec if it is present.
+func RemoveSchedulingGate(pod *corev1.Pod, name string) {
+	pod.Spec.SchedulingGates = slices.DeleteFunc(pod.Spec.SchedulingGates, func(gate corev1.PodSchedulingGate) bool {
+		return gate.Name == name
+	})
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var _ = Describe("Utils", func() {
-	Context("# ParsePercentage", func() {
+	Describe("#ParsePercentage", func() {
 		It("should succeed", func() {
 			tests := []struct {
 				val  string
@@ -37,7 +37,7 @@ var _ = Describe("Utils", func() {
 		})
 	})
 
-	Context("# IsPersistentVolumeClaimConditionPresentAndEqual", func() {
+	Describe("#IsPersistentVolumeClaimConditionPresentAndEqual", func() {
 		pvc := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "sample-pvc",
@@ -61,21 +61,80 @@ var _ = Describe("Utils", func() {
 			},
 		}
 
-		It("is present and true", func() {
+		It("should be present and true", func() {
 			Expect(utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimFileSystemResizePending)).To(BeTrue())
 		})
 
-		It("is present and equal", func() {
+		It("should be present and equal", func() {
 			Expect(utils.IsPersistentVolumeClaimConditionPresentAndEqual(pvc, corev1.PersistentVolumeClaimFileSystemResizePending, corev1.ConditionTrue)).To(BeTrue())
 			Expect(utils.IsPersistentVolumeClaimConditionPresentAndEqual(pvc, corev1.PersistentVolumeClaimResizing, corev1.ConditionFalse)).To(BeTrue())
 			Expect(utils.IsPersistentVolumeClaimConditionPresentAndEqual(pvc, corev1.PersistentVolumeClaimVolumeModifyingVolume, corev1.ConditionUnknown)).To(BeTrue())
 		})
 
-		It("is present and false", func() {
+		It("should be present and false", func() {
 			Expect(utils.IsPersistentVolumeClaimConditionPresentAndEqual(pvc, corev1.PersistentVolumeClaimFileSystemResizePending, corev1.ConditionFalse)).To(BeFalse())
 			Expect(utils.IsPersistentVolumeClaimConditionPresentAndEqual(pvc, corev1.PersistentVolumeClaimResizing, corev1.ConditionTrue)).To(BeFalse())
 			Expect(utils.IsPersistentVolumeClaimConditionPresentAndEqual(pvc, corev1.PersistentVolumeClaimResizing, corev1.ConditionTrue)).To(BeFalse())
 			Expect(utils.IsPersistentVolumeClaimConditionPresentAndEqual(pvc, corev1.PersistentVolumeClaimVolumeModifyVolumeError, corev1.ConditionTrue)).To(BeFalse())
+		})
+	})
+
+	Context("scheduling gates", func() {
+		const gate = "pvc.autoscaling.gardener.cloud/offline-resize"
+
+		var newPod = func(gates ...string) *corev1.Pod {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "sample-pod", Namespace: "default"},
+			}
+			for _, gate := range gates {
+				pod.Spec.SchedulingGates = append(pod.Spec.SchedulingGates, corev1.PodSchedulingGate{Name: gate})
+			}
+			return pod
+		}
+
+		Describe("#HasSchedulingGate", func() {
+			It("should return true when the gate is present", func() {
+				Expect(utils.HasSchedulingGate(newPod("other", gate), gate)).To(BeTrue())
+			})
+
+			It("should return false when the gate is absent", func() {
+				Expect(utils.HasSchedulingGate(newPod("other"), gate)).To(BeFalse())
+			})
+		})
+
+		Describe("#AddSchedulingGate", func() {
+			It("should add the gate and report modification", func() {
+				pod := newPod("other")
+				utils.AddSchedulingGate(pod, gate)
+
+				Expect(pod.Spec.SchedulingGates).To(HaveLen(2))
+				Expect(pod.Spec.SchedulingGates).To(ContainElement(HaveField("Name", gate)))
+			})
+
+			It("should be idempotent when the gate is already present", func() {
+				pod := newPod(gate)
+				utils.AddSchedulingGate(pod, gate)
+
+				Expect(pod.Spec.SchedulingGates).To(HaveLen(1))
+			})
+		})
+
+		Describe("#RemoveSchedulingGate", func() {
+			It("should remove the gate and report modification", func() {
+				pod := newPod("other", gate)
+				utils.RemoveSchedulingGate(pod, gate)
+
+				Expect(pod.Spec.SchedulingGates).To(HaveLen(1))
+				Expect(pod.Spec.SchedulingGates).To(ConsistOf(HaveField("Name", "other")))
+			})
+
+			It("should be a no-op when the gate is absent", func() {
+				pod := newPod("other")
+				utils.RemoveSchedulingGate(pod, gate)
+
+				Expect(pod.Spec.SchedulingGates).To(HaveLen(1))
+				Expect(pod.Spec.SchedulingGates).To(ConsistOf(HaveField("Name", "other")))
+			})
 		})
 	})
 })

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -5,11 +5,19 @@
 package utils_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
 	"github.com/gardener/pvc-autoscaler/internal/utils"
 )
 
@@ -136,5 +144,268 @@ var _ = Describe("Utils", func() {
 				Expect(pod.Spec.SchedulingGates).To(ConsistOf(HaveField("Name", "other")))
 			})
 		})
+	})
+
+	Describe("#GetVolumePolicy", func() {
+		It("should return error on invalid glob pattern", func() {
+			volumePolicies := []v1alpha1.VolumePolicy{
+				{
+					Match: v1alpha1.Match{
+						Name: "[",
+					},
+					MaxCapacity: resource.MustParse("10Gi"),
+				},
+			}
+
+			policy, err := utils.GetVolumePolicy("data-pvc", volumePolicies)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid volume policy name \"[\""))
+			Expect(policy).To(BeNil())
+		})
+
+		It("should return nil when no policy matches", func() {
+			volumePolicies := []v1alpha1.VolumePolicy{
+				{
+					Match: v1alpha1.Match{
+						Name: "other-pvc",
+					},
+					MaxCapacity: resource.MustParse("10Gi"),
+				},
+			}
+
+			policy, err := utils.GetVolumePolicy("data-pvc", volumePolicies)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(policy).To(BeNil())
+		})
+
+		It("should match exact name", func() {
+			volumePolicies := []v1alpha1.VolumePolicy{
+				{
+					Match: v1alpha1.Match{
+						Name: "data-pvc",
+					},
+					MaxCapacity: resource.MustParse("10Gi"),
+				},
+			}
+
+			policy, err := utils.GetVolumePolicy("data-pvc", volumePolicies)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(policy).NotTo(BeNil())
+			Expect(policy.Match.Name).To(Equal("data-pvc"))
+		})
+
+		It("should match glob pattern", func() {
+			volumePolicies := []v1alpha1.VolumePolicy{
+				{
+					Match: v1alpha1.Match{
+						Name: "*-logs",
+					},
+					MaxCapacity: resource.MustParse("15Gi"),
+				},
+			}
+
+			policy, err := utils.GetVolumePolicy("app-logs", volumePolicies)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(policy).NotTo(BeNil())
+			Expect(policy.Match.Name).To(Equal("*-logs"))
+		})
+
+		It("should match default policy", func() {
+			volumePolicies := []v1alpha1.VolumePolicy{
+				{
+					Match: v1alpha1.Match{
+						Name: "*",
+					},
+					MaxCapacity: resource.MustParse("5Gi"),
+				},
+			}
+
+			policy, err := utils.GetVolumePolicy("data-pvc", volumePolicies)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(policy).NotTo(BeNil())
+			Expect(policy.Match.Name).To(Equal("*"))
+		})
+
+		It("should fall back to default policy when no other policy matches", func() {
+			volumePolicies := []v1alpha1.VolumePolicy{
+				{
+					Match: v1alpha1.Match{
+						Name: "other-pvc",
+					},
+					MaxCapacity: resource.MustParse("20Gi"),
+				},
+				{
+					Match: v1alpha1.Match{
+						Name: "*",
+					},
+					MaxCapacity: resource.MustParse("5Gi"),
+				},
+			}
+
+			policy, err := utils.GetVolumePolicy("data-pvc", volumePolicies)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(policy).NotTo(BeNil())
+			Expect(policy.Match.Name).To(Equal("*"))
+			Expect(policy.MaxCapacity).To(Equal(resource.MustParse("5Gi")))
+		})
+
+		It("should return first seen matching policy", func() {
+			volumePolicies := []v1alpha1.VolumePolicy{
+				{
+					Match: v1alpha1.Match{
+						Name: "data-*",
+					},
+					MaxCapacity: resource.MustParse("10Gi"),
+				},
+				{
+					Match: v1alpha1.Match{
+						Name: "data-pvc",
+					},
+					MaxCapacity: resource.MustParse("20Gi"),
+				},
+				{
+					Match: v1alpha1.Match{
+						Name: "*",
+					},
+					MaxCapacity: resource.MustParse("5Gi"),
+				},
+			}
+
+			policy, err := utils.GetVolumePolicy("data-pvc", volumePolicies)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(policy).NotTo(BeNil())
+			Expect(policy.Match.Name).To(Equal("data-*"))
+			Expect(policy.MaxCapacity).To(Equal(resource.MustParse("10Gi")))
+		})
+	})
+
+	Describe("#FindOwningPVCAAndPolicy", func() {
+		const (
+			namespace      = "default"
+			autoscalerName = "instance-a"
+		)
+
+		var (
+			ctx  context.Context
+			pvc  *corev1.PersistentVolumeClaim
+			pvca *v1alpha1.PersistentVolumeClaimAutoscaler
+
+			testScheme *runtime.Scheme
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			testScheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(testScheme)).To(Succeed())
+			Expect(v1alpha1.AddToScheme(testScheme)).To(Succeed())
+
+			pvc = &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: namespace},
+			}
+
+			pvca = &v1alpha1.PersistentVolumeClaimAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pvca", Namespace: namespace},
+				Spec: v1alpha1.PersistentVolumeClaimAutoscalerSpec{
+					AutoscalerName: autoscalerName,
+					TargetRef: autoscalingv1.CrossVersionObjectReference{
+						Kind:       "PersistentVolumeClaim",
+						Name:       "test",
+						APIVersion: "v1",
+					},
+					VolumePolicies: []v1alpha1.VolumePolicy{{Match: v1alpha1.Match{Name: "*"}, MaxCapacity: resource.MustParse("100Gi")}},
+				},
+				Status: v1alpha1.PersistentVolumeClaimAutoscalerStatus{
+					VolumeRecommendations: []v1alpha1.VolumeRecommendation{{Name: "test"}},
+				},
+			}
+		})
+
+		DescribeTable("should resolve PVC ownership",
+			func(mutate func(*v1alpha1.PersistentVolumeClaimAutoscaler), seedPVCA, wantOwner bool) {
+				mutate(pvca)
+
+				objs := []client.Object{pvc}
+				if seedPVCA {
+					objs = append(objs, pvca)
+				}
+
+				c := fake.NewClientBuilder().
+					WithScheme(testScheme).
+					WithObjects(objs...).
+					WithIndex(&v1alpha1.PersistentVolumeClaimAutoscaler{}, v1alpha1.AutoscalerNameIndexKey, func(obj client.Object) []string {
+						return []string{obj.(*v1alpha1.PersistentVolumeClaimAutoscaler).Spec.AutoscalerName}
+					}).
+					Build()
+
+				owner, policy, err := utils.FindOwningPVCAAndPolicy(ctx, c, autoscalerName, pvc)
+				Expect(err).NotTo(HaveOccurred())
+
+				if wantOwner {
+					Expect(owner).NotTo(BeNil())
+					Expect(owner.Name).To(Equal(pvca.Name))
+					// The seeded policy matches all PVCs, so an owned PVC always
+					// resolves to a matching policy.
+					Expect(policy).NotTo(BeNil())
+				} else {
+					Expect(owner).To(BeNil())
+					Expect(policy).To(BeNil())
+				}
+			},
+			Entry("when the PVCA status lists the PVC", func(*v1alpha1.PersistentVolumeClaimAutoscaler) {}, true, true),
+			Entry("when no PVCA exists", func(*v1alpha1.PersistentVolumeClaimAutoscaler) {}, false, false),
+			Entry("when the managing PVCA has a different autoscalerName", func(p *v1alpha1.PersistentVolumeClaimAutoscaler) { p.Spec.AutoscalerName = "other" }, true, false),
+			Entry("when the PVCA status does not list the PVC", func(p *v1alpha1.PersistentVolumeClaimAutoscaler) {
+				p.Status.VolumeRecommendations = []v1alpha1.VolumeRecommendation{{Name: "other-pvc"}}
+			}, true, false),
+			Entry("when the PVCA is in a different namespace", func(p *v1alpha1.PersistentVolumeClaimAutoscaler) { p.Namespace = "other-namespace" }, true, false),
+		)
+	})
+
+	Context("#IsOfflineResizeEnabled", func() {
+		var (
+			workloadPVCA *v1alpha1.PersistentVolumeClaimAutoscaler
+			preferPolicy *v1alpha1.VolumePolicy
+		)
+
+		BeforeEach(func() {
+			workloadPVCA = &v1alpha1.PersistentVolumeClaimAutoscaler{
+				Spec: v1alpha1.PersistentVolumeClaimAutoscalerSpec{
+					TargetRef: autoscalingv1.CrossVersionObjectReference{Kind: "StatefulSet"},
+				},
+			}
+			preferPolicy = &v1alpha1.VolumePolicy{ScaleUp: &v1alpha1.ScalingRules{ResizeStrategy: v1alpha1.PreferInPlaceVolumeResizeStrategy}}
+		})
+
+		DescribeTable("should report whether offline-resize recovery is enabled",
+			func(mutate func(*v1alpha1.PersistentVolumeClaimAutoscaler, *v1alpha1.VolumePolicy), want bool) {
+				mutate(workloadPVCA, preferPolicy)
+				Expect(utils.IsOfflineResizeEnabled(workloadPVCA, preferPolicy)).To(Equal(want))
+			},
+			Entry("when the PVCA targets a workload and the strategy is PreferInPlace",
+				func(*v1alpha1.PersistentVolumeClaimAutoscaler, *v1alpha1.VolumePolicy) {}, true),
+			Entry("when the PVCA is nil",
+				func(_ *v1alpha1.PersistentVolumeClaimAutoscaler, _ *v1alpha1.VolumePolicy) { workloadPVCA = nil }, false),
+			Entry("when the PVCA targets a PersistentVolumeClaim directly",
+				func(p *v1alpha1.PersistentVolumeClaimAutoscaler, _ *v1alpha1.VolumePolicy) {
+					p.Spec.TargetRef.Kind = "PersistentVolumeClaim"
+				}, false),
+			Entry("when the policy is nil",
+				func(_ *v1alpha1.PersistentVolumeClaimAutoscaler, _ *v1alpha1.VolumePolicy) { preferPolicy = nil }, false),
+			Entry("when scaleUp is nil",
+				func(_ *v1alpha1.PersistentVolumeClaimAutoscaler, p *v1alpha1.VolumePolicy) { p.ScaleUp = nil }, false),
+			Entry("when the strategy is unset",
+				func(_ *v1alpha1.PersistentVolumeClaimAutoscaler, p *v1alpha1.VolumePolicy) {
+					p.ScaleUp.ResizeStrategy = ""
+				}, false),
+			Entry("when the strategy is InPlace",
+				func(_ *v1alpha1.PersistentVolumeClaimAutoscaler, p *v1alpha1.VolumePolicy) {
+					p.ScaleUp.ResizeStrategy = v1alpha1.InPlaceVolumeResizeStrategy
+				}, false),
+			Entry("when the strategy is Off",
+				func(_ *v1alpha1.PersistentVolumeClaimAutoscaler, p *v1alpha1.VolumePolicy) {
+					p.ScaleUp.ResizeStrategy = v1alpha1.OffVolumeResizeStrategy
+				}, false),
+		)
 	})
 })

--- a/internal/webhook/pod/mutator.go
+++ b/internal/webhook/pod/mutator.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pod
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/gardener/pvc-autoscaler/internal/common"
+	"github.com/gardener/pvc-autoscaler/internal/utils"
+)
+
+// WebhookPath is the path the Pod mutating webhook is served on.
+const WebhookPath = "/mutate--v1-pod"
+
+// +kubebuilder:webhook:path=/mutate--v1-pod,mutating=true,failurePolicy=ignore,sideEffects=None,groups="",resources=pods,verbs=create,versions=v1,name=mpod.autoscaling.gardener.cloud,admissionReviewVersions=v1
+
+// Mutator is an admission webhook handler which adds the offline-resize
+// scheduling gate to Pods whose PersistentVolumeClaim failed to resize online.
+type Mutator struct {
+	client         client.Client
+	decoder        admission.Decoder
+	autoscalerName string
+}
+
+var _ admission.Handler = (*Mutator)(nil)
+
+// NewMutator returns a new Pod [Mutator]. It resolves PVC ownership scoped to
+// PersistentVolumeClaimAutoscalers whose spec.autoscalerName matches
+// autoscalerName, so it gates exactly the Pods whose PVCs the offline-resize
+// recovery controller of this instance manages.
+func NewMutator(c client.Client, decoder admission.Decoder, autoscalerName string) *Mutator {
+	return &Mutator{
+		client:         c,
+		decoder:        decoder,
+		autoscalerName: autoscalerName,
+	}
+}
+
+// SetupWebhookWithManager registers the Pod mutating webhook with the manager's
+// webhook server under [WebhookPath].
+func (m *Mutator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	mgr.GetWebhookServer().Register(WebhookPath, &admission.Webhook{Handler: m})
+	return nil
+}
+
+// Handle implements [admission.Handler].
+func (m *Mutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	logger := log.FromContext(ctx)
+
+	pod := &corev1.Pod{}
+	if err := m.decoder.Decode(req, pod); err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	namespace := pod.Namespace
+
+	if m.shouldGate(ctx, logger, namespace, pod) {
+		utils.AddSchedulingGate(pod, common.SchedulingGateOfflineResize)
+		logger.Info("adding offline-resize scheduling gate to pod", "namespace", namespace, "generateName", pod.GenerateName)
+	}
+
+	marshaled, err := json.Marshal(pod)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaled)
+}
+
+// shouldGate reports whether the given Pod should receive the offline-resize
+// scheduling gate.
+func (m *Mutator) shouldGate(ctx context.Context, logger logr.Logger, namespace string, pod *corev1.Pod) bool {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.PersistentVolumeClaim == nil {
+			continue
+		}
+
+		pvc := &corev1.PersistentVolumeClaim{}
+		key := client.ObjectKey{Namespace: namespace, Name: volume.PersistentVolumeClaim.ClaimName}
+		if err := m.client.Get(ctx, key, pvc); err != nil {
+			if apierrors.IsNotFound(err) {
+				// The PVC does not exist yet - nothing to gate on.
+				continue
+			}
+
+			logger.Error(err, "failed to get PersistentVolumeClaim referenced by pod, not gating", "pvc", key)
+
+			continue
+		}
+
+		if !utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimControllerResizeError) || utils.IsPersistentVolumeClaimConditionTrue(pvc, corev1.PersistentVolumeClaimFileSystemResizePending) {
+			continue
+		}
+
+		owner, policy, err := utils.FindOwningPVCAAndPolicy(ctx, m.client, m.autoscalerName, pvc)
+		if err != nil {
+			// Do not block Pod creation because of a transient lookup error.
+			logger.Error(err, "failed to determine ownership of PersistentVolumeClaim referenced by pod, not gating", "pvc", key)
+
+			continue
+		}
+
+		if owner != nil && utils.IsOfflineResizeEnabled(owner, policy) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/webhook/pod/mutator_test.go
+++ b/internal/webhook/pod/mutator_test.go
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pod_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/gardener/pvc-autoscaler/api/autoscaling/v1alpha1"
+	"github.com/gardener/pvc-autoscaler/internal/common"
+	podwebhook "github.com/gardener/pvc-autoscaler/internal/webhook/pod"
+)
+
+func TestPodWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	Expect(v1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+	RunSpecs(t, "Pod Webhook Suite")
+}
+
+var _ = Describe("Pod Mutator", func() {
+	const (
+		namespace      = "default"
+		autoscalerName = ""
+	)
+
+	var (
+		ctx     context.Context
+		decoder admission.Decoder
+
+		pod  *corev1.Pod
+		pvcs []*corev1.PersistentVolumeClaim
+		pvca *v1alpha1.PersistentVolumeClaimAutoscaler
+
+		mutated *corev1.Pod
+
+		offlineResizeGate = corev1.PodSchedulingGate{Name: common.SchedulingGateOfflineResize}
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		decoder = admission.NewDecoder(scheme.Scheme)
+
+		pvcs = []*corev1.PersistentVolumeClaim{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: namespace,
+			},
+			Status: corev1.PersistentVolumeClaimStatus{
+				Conditions: []corev1.PersistentVolumeClaimCondition{{
+					Type:   corev1.PersistentVolumeClaimControllerResizeError,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		}}
+
+		pvca = &v1alpha1.PersistentVolumeClaimAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pvca", Namespace: namespace},
+			Spec: v1alpha1.PersistentVolumeClaimAutoscalerSpec{
+				AutoscalerName: autoscalerName,
+				TargetRef: autoscalingv1.CrossVersionObjectReference{
+					Kind:       "StatefulSet",
+					Name:       "test-sts",
+					APIVersion: "apps/v1",
+				},
+				VolumePolicies: []v1alpha1.VolumePolicy{{
+					Match:       v1alpha1.Match{Name: "*"},
+					MaxCapacity: resource.MustParse("100Gi"),
+					ScaleUp:     &v1alpha1.ScalingRules{ResizeStrategy: v1alpha1.PreferInPlaceVolumeResizeStrategy},
+				}},
+			},
+			Status: v1alpha1.PersistentVolumeClaimAutoscalerStatus{
+				VolumeRecommendations: []v1alpha1.VolumeRecommendation{{Name: "test"}},
+			},
+		}
+
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-", Namespace: namespace},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c", Image: "nginx"}},
+				Volumes: []corev1.Volume{{
+					Name: "data",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test"},
+					},
+				}},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		objs := make([]client.Object, 0, len(pvcs)+1)
+		for _, p := range pvcs {
+			objs = append(objs, p)
+		}
+		if pvca != nil {
+			objs = append(objs, pvca)
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithObjects(objs...).
+			WithIndex(&v1alpha1.PersistentVolumeClaimAutoscaler{}, v1alpha1.AutoscalerNameIndexKey, func(obj client.Object) []string {
+				return []string{obj.(*v1alpha1.PersistentVolumeClaimAutoscaler).Spec.AutoscalerName}
+			}).
+			Build()
+
+		raw, err := json.Marshal(pod)
+		Expect(err).NotTo(HaveOccurred())
+
+		mutator := podwebhook.NewMutator(c, decoder, autoscalerName)
+		response := mutator.Handle(ctx, admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Namespace: namespace,
+				Object:    runtime.RawExtension{Raw: raw},
+			},
+		})
+		Expect(response.Allowed).To(BeTrue())
+
+		mutated = pod.DeepCopy()
+		if len(response.Patches) > 0 {
+			patchJSON, err := json.Marshal(response.Patches)
+			Expect(err).NotTo(HaveOccurred())
+			patch, err := jsonpatch.DecodePatch(patchJSON)
+			Expect(err).NotTo(HaveOccurred())
+			modified, err := patch.Apply(raw)
+			Expect(err).NotTo(HaveOccurred())
+			mutated = &corev1.Pod{}
+			Expect(json.Unmarshal(modified, mutated)).To(Succeed())
+		}
+	})
+
+	When("a referenced PVC is managed and has ControllerResizeError", func() {
+		It("should add the offline-resize scheduling gate", func() {
+			Expect(mutated.Spec.SchedulingGates).To(ConsistOf(offlineResizeGate))
+		})
+
+		When("the pod already carries the gate", func() {
+			BeforeEach(func() {
+				pod.Spec.SchedulingGates = []corev1.PodSchedulingGate{{Name: common.SchedulingGateOfflineResize}}
+			})
+
+			It("should not duplicate the gate", func() {
+				Expect(mutated.Spec.SchedulingGates).To(ConsistOf(offlineResizeGate))
+			})
+		})
+
+		When("another referenced PVC is healthy", func() {
+			BeforeEach(func() {
+				pvcs = append(pvcs, &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "healthy",
+						Namespace: namespace,
+					},
+				})
+				pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+					Name: "data-healthy",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "healthy"},
+					},
+				})
+			})
+
+			It("should still add the gate because one PVC is stuck", func() {
+				Expect(mutated.Spec.SchedulingGates).To(ConsistOf(offlineResizeGate))
+			})
+		})
+
+		When("the managing PVCA uses the InPlace resize strategy", func() {
+			BeforeEach(func() {
+				pvca.Spec.VolumePolicies[0].ScaleUp.ResizeStrategy = v1alpha1.InPlaceVolumeResizeStrategy
+			})
+
+			It("should not add the gate", func() {
+				Expect(mutated.Spec.SchedulingGates).NotTo(ContainElement(offlineResizeGate))
+			})
+		})
+
+		When("the managing PVCA uses the Off resize strategy", func() {
+			BeforeEach(func() {
+				pvca.Spec.VolumePolicies[0].ScaleUp.ResizeStrategy = v1alpha1.OffVolumeResizeStrategy
+			})
+
+			It("should not add the gate", func() {
+				Expect(mutated.Spec.SchedulingGates).NotTo(ContainElement(offlineResizeGate))
+			})
+		})
+
+		When("the managing PVCA has no scaleUp rules", func() {
+			BeforeEach(func() {
+				pvca.Spec.VolumePolicies[0].ScaleUp = nil
+			})
+
+			It("should not add the gate", func() {
+				Expect(mutated.Spec.SchedulingGates).NotTo(ContainElement(offlineResizeGate))
+			})
+		})
+	})
+
+	When("the referenced PVC is not managed by any PVCA of this instance", func() {
+		BeforeEach(func() {
+			pvca = nil
+		})
+
+		It("should not add the gate", func() {
+			Expect(mutated.Spec.SchedulingGates).NotTo(ContainElement(offlineResizeGate))
+		})
+	})
+
+	When("the referenced PVC is managed by a PVCA of another instance", func() {
+		BeforeEach(func() {
+			pvca.Spec.AutoscalerName = "other"
+		})
+
+		It("should not add the gate", func() {
+			Expect(mutated.Spec.SchedulingGates).NotTo(ContainElement(offlineResizeGate))
+		})
+	})
+
+	When("the referenced PVC already has FileSystemResizePending", func() {
+		BeforeEach(func() {
+			pvcs[0].Status.Conditions = append(pvcs[0].Status.Conditions, corev1.PersistentVolumeClaimCondition{
+				Type:   corev1.PersistentVolumeClaimFileSystemResizePending,
+				Status: corev1.ConditionTrue,
+			})
+		})
+
+		It("should not add the gate", func() {
+			Expect(mutated.Spec.SchedulingGates).NotTo(ContainElement(offlineResizeGate))
+		})
+	})
+
+	When("the referenced PVC has no relevant condition", func() {
+		BeforeEach(func() {
+			pvcs[0].Status.Conditions = nil
+		})
+
+		It("should not add the gate", func() {
+			Expect(mutated.Spec.SchedulingGates).NotTo(ContainElement(offlineResizeGate))
+		})
+	})
+
+	When("the referenced PVC does not exist", func() {
+		BeforeEach(func() {
+			pvcs = nil
+		})
+
+		It("should not add the gate", func() {
+			Expect(mutated.Spec.SchedulingGates).NotTo(ContainElement(offlineResizeGate))
+		})
+	})
+})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR adds a Pod mutating webhook that adds the `pvc.autoscaling.gardener.cloud/offline-resize` scheduling gate to the pod. The scheduling gate is only added to pods that mount PVCs which are stuck in resize due a `ControllerResizeError`, there is a `PersistentVolumeClaimAutoscaler` that matches the PVC, there is a matching volume policy and the resize strategy is `PreferInPlace`.

The webhook is only enabled when `ENABLE_WEBHOOKS` env variable is set to true for the pvc-autoscaler controller manager pod. 

**Which issue(s) this PR fixes**:
Part of #295

**Special notes for your reviewer**:
Draft as it depends on https://github.com/gardener/pvc-autoscaler/pull/331

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Introduced a Pod mutating webhook which adds the `pvc.autoscaling.gardener.cloud/offline-resize` scheduling gate to Pods that mount `PersistentVolumeClaims` managed by a `PersistentVolumeClaimAutoscaler`, if the `PersistentVolumeClaim` is being resized and is stuck due to a `ControllerResizeError`.
The scheduling gate is only added, if there is a matching volume policy and it specifies the `PreferInPlace` resize strategy.
```
